### PR TITLE
Update mlir-python-bindings version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "lighthouse"
 dynamic = ["version"]
 requires-python = ">=3.10,<3.13"  # Bounds are due to torch-mlir's packaging
 dependencies = [
-    "mlir-python-bindings==20251118+99630eb1b"
+    "mlir-python-bindings==20251209+cdb525d2e"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Bump llvm version to use latest xegpu dialect updates in xegpu matmul example.