### PR TITLE
Making importing torch and dependent funcs optional

### DIFF
--- a/lighthouse/utils/__init__.py
+++ b/lighthouse/utils/__init__.py
@@ -4,9 +4,6 @@ from .runtime_args import (
     get_packed_arg,
     memref_to_ctype,
     memrefs_to_packed_args,
-    torch_to_memref,
-    torch_to_packed_args,
-    mlir_type_to_torch_dtype,
 )
 
 __all__ = [
@@ -17,3 +14,20 @@ __all__ = [
     "torch_to_memref",
     "torch_to_packed_args",
 ]
+
+try:
+    from .runtime_args import (
+        mlir_type_to_torch_dtype,
+        torch_to_memref,
+        torch_to_packed_args,
+    )
+
+    __all__.extend(
+        [
+            "mlir_type_to_torch_dtype",
+            "torch_to_memref",
+            "torch_to_packed_args",
+        ]
+    )
+except:
+    pass

--- a/lighthouse/utils/runtime_args.py
+++ b/lighthouse/utils/runtime_args.py
@@ -1,5 +1,8 @@
 import ctypes
-import torch
+try:
+    import torch
+except ImportError:
+    torch = None
 
 from mlir.runtime.np_to_memref import (
     get_ranked_memref_descriptor,
@@ -42,56 +45,57 @@ def memrefs_to_packed_args(memref_descs) -> list[ctypes.c_void_p]:
     return get_packed_arg(ctype_args)
 
 
-def torch_to_memref(input: torch.Tensor) -> ctypes.Structure:
-    """
-    Convert a PyTorch tensor into a memref descriptor.
+if torch is not None:
+    def torch_to_memref(input: torch.Tensor) -> ctypes.Structure:
+        """
+        Convert a PyTorch tensor into a memref descriptor.
 
-    Args:
-        input: PyTorch tensor.
-    """
-    return get_ranked_memref_descriptor(input.numpy())
-
-
-def torch_to_packed_args(inputs: list[torch.Tensor]) -> list[ctypes.c_void_p]:
-    """
-    Convert a list of PyTorch tensors into packed ctype arguments.
-
-    Args:
-        inputs: A list of PyTorch tensors.
-    """
-    memrefs = [torch_to_memref(input) for input in inputs]
-    return memrefs_to_packed_args(memrefs)
+        Args:
+            input: PyTorch tensor.
+        """
+        return get_ranked_memref_descriptor(input.numpy())
 
 
-def mlir_type_to_torch_dtype(mlir_type: ir.Type):
-    """
-    Convert an MLIR type to a PyTorch dtype.
-    Args:
-        mlir_type: An MLIR type (e.g., ir.F32Type, ir.F64Type)
-    Returns:
-        Corresponding PyTorch dtype
-    """
-    import torch
+    def torch_to_packed_args(inputs: list[torch.Tensor]) -> list[ctypes.c_void_p]:
+        """
+        Convert a list of PyTorch tensors into packed ctype arguments.
 
-    if isinstance(mlir_type, ir.F32Type):
-        return torch.float32
-    elif isinstance(mlir_type, ir.F64Type):
-        return torch.float64
-    elif isinstance(mlir_type, ir.F16Type):
-        return torch.float16
-    elif isinstance(mlir_type, ir.BF16Type):
-        return torch.bfloat16
-    elif isinstance(mlir_type, ir.IntegerType):
-        width = mlir_type.width
-        if width == 64:
-            return torch.int64
-        elif width == 32:
-            return torch.int32
-        elif width == 16:
-            return torch.int16
-        elif width == 8:
-            return torch.int8
-        elif width == 1:
-            return torch.bool
+        Args:
+            inputs: A list of PyTorch tensors.
+        """
+        memrefs = [torch_to_memref(input) for input in inputs]
+        return memrefs_to_packed_args(memrefs)
 
-    raise ValueError(f"Unsupported MLIR type: {mlir_type}")
+
+    def mlir_type_to_torch_dtype(mlir_type: ir.Type):
+        """
+        Convert an MLIR type to a PyTorch dtype.
+        Args:
+            mlir_type: An MLIR type (e.g., ir.F32Type, ir.F64Type)
+        Returns:
+            Corresponding PyTorch dtype
+        """
+        import torch
+
+        if isinstance(mlir_type, ir.F32Type):
+            return torch.float32
+        elif isinstance(mlir_type, ir.F64Type):
+            return torch.float64
+        elif isinstance(mlir_type, ir.F16Type):
+            return torch.float16
+        elif isinstance(mlir_type, ir.BF16Type):
+            return torch.bfloat16
+        elif isinstance(mlir_type, ir.IntegerType):
+            width = mlir_type.width
+            if width == 64:
+                return torch.int64
+            elif width == 32:
+                return torch.int32
+            elif width == 16:
+                return torch.int16
+            elif width == 8:
+                return torch.int8
+            elif width == 1:
+                return torch.bool
+
+        raise ValueError(f"Unsupported MLIR type: {mlir_type}")


### PR DESCRIPTION
Allows simple examples with no torch dependences use utils that also do not depend on torch.