### PR TITLE
[Tune] Constraint extraction, model finding, and schedule rewriting

### DIFF
--- a/examples/xegpu_matmul/matmul.py
+++ b/examples/xegpu_matmul/matmul.py
@@ -387,7 +387,7 @@ if __name__ == "__main__":
                 stop_at_stage=args.dump_payload, parameters=params
             )
             print(schedule_module)
-        elif args.dump_kernel:
+        elif args.dump_payload:
             wload.lower_payload(
                 dump_payload=args.dump_payload,
                 dump_schedule=args.dump_schedule,

--- a/lighthouse/tune/__init__.py
+++ b/lighthouse/tune/__init__.py
@@ -1,0 +1,21 @@
+__all__ = ["smt", "rewrite"]
+
+import sys
+import importlib
+
+
+def __getattr__(name):
+    """Enable lazy loading of submodules.
+
+    Enables `import lighthouse.tune as lh_tune; lh_tune.<submodule>` with
+    loading of (the submodule's heavy) depenendencies only upon being needed.
+    """
+
+    if name in __all__:
+        # Import the submodule and cache it on the current module. That is,
+        # upon the next access __getattr__ will not be called.
+        submodule = importlib.import_module("lighthouse.tune." + name)
+        lighthouse_tune_mod = sys.modules[__name__]
+        setattr(lighthouse_tune_mod, name, submodule)
+        return submodule
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/lighthouse/tune/__init__.py
+++ b/lighthouse/tune/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ["smt", "rewrite"]
+__all__ = ["rewrite", "smt"]
 
 import sys
 import importlib

--- a/lighthouse/tune/__main__.py
+++ b/lighthouse/tune/__main__.py
@@ -1,0 +1,71 @@
+import sys
+import argparse
+from pprint import pprint
+from typing import Mapping
+
+import z3
+
+from mlir import ir
+import lighthouse.tune as lh_tune
+from lighthouse.utils.types import LazyChainMap
+
+HEADER = "//" * 40 + "\n// {}\n" + "//" * 40
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file", type=str, help="Path to the MLIR file to process")
+    parser.add_argument(
+        "-n", type=int, help="Number of determinized schedules to find", default=1
+    )
+    parser.add_argument(
+        "--print-smtlib", action="store_true", help="Print the constraints in SMT-LIB format"
+    )
+    parser.add_argument(
+        "--print-model", action="store_true", help="Print the model from the SMT solver"
+    )
+    parser.add_argument(
+        "--print-knobs-set", action="store_true", help="Print the schedule with knobs set"
+    )
+    args = parser.parse_args()
+
+    file = sys.stdin if args.file == "-" else open(args.file, "r")
+    with ir.Context() as ctx, ir.Location.unknown():
+        module = ir.Module.parse(file.read())
+
+        z3_constraints, values_to_z3_vars = (
+            lh_tune.smt.z3.transform_tune_and_smt_ops_to_z3_constraints(
+                module.operation
+            )
+        )
+
+        solver = z3.Solver()
+        solver.add(z3_constraints)
+
+        if args.print_smtlib:
+            print(HEADER.format("SMT-LIB constraints"))
+            print(solver.sexpr())
+
+        all_models = lh_tune.smt.z3.all_smt(solver, values_to_z3_vars.values())
+        for i in range(args.n):
+            model = next(all_models)
+            if args.print_model:
+                print(HEADER.format(f"SMT Model #{i+1}"))
+                pprint(model)
+
+            env: Mapping[ir.Value | ir.Operation, ir.Attribute] = LazyChainMap(
+                values_to_z3_vars, lambda var: lh_tune.smt.z3.model_to_mlir(model[var])
+            )
+
+            mod_op = lh_tune.rewrite.set_selected(module.operation, env)
+
+            mod_op, undo = lh_tune.rewrite.constraint_results_to_constants(mod_op, env)
+
+            if args.print_knobs_set:
+                print(HEADER.format(f"Schedule #{i+1} with knobs set"))
+                print(mod_op)
+
+            print(HEADER.format(f"Determinized schedule #{i+1}"))
+            print(lh_tune.rewrite.nondet_to_det(mod_op.clone()))
+
+            undo() # Undo the introduction of constants for the results of constraints.

--- a/lighthouse/tune/__main__.py
+++ b/lighthouse/tune/__main__.py
@@ -19,13 +19,17 @@ if __name__ == "__main__":
         "-n", type=int, help="Number of determinized schedules to find", default=1
     )
     parser.add_argument(
-        "--print-smtlib", action="store_true", help="Print the constraints in SMT-LIB format"
+        "--print-smtlib",
+        action="store_true",
+        help="Print the constraints in SMT-LIB format",
     )
     parser.add_argument(
         "--print-model", action="store_true", help="Print the model from the SMT solver"
     )
     parser.add_argument(
-        "--print-knobs-set", action="store_true", help="Print the schedule with knobs set"
+        "--print-knobs-set",
+        action="store_true",
+        help="Print the schedule with knobs set",
     )
     args = parser.parse_args()
 
@@ -50,7 +54,7 @@ if __name__ == "__main__":
         for i in range(args.n):
             model = next(all_models)
             if args.print_model:
-                print(HEADER.format(f"SMT Model #{i+1}"))
+                print(HEADER.format(f"SMT Model #{i + 1}"))
                 pprint(model)
 
             env: Mapping[ir.Value | ir.Operation, ir.Attribute] = LazyChainMap(
@@ -62,10 +66,10 @@ if __name__ == "__main__":
             mod_op, undo = lh_tune.rewrite.constraint_results_to_constants(mod_op, env)
 
             if args.print_knobs_set:
-                print(HEADER.format(f"Schedule #{i+1} with knobs set"))
+                print(HEADER.format(f"Schedule #{i + 1} with knobs set"))
                 print(mod_op)
 
-            print(HEADER.format(f"Determinized schedule #{i+1}"))
+            print(HEADER.format(f"Determinized schedule #{i + 1}"))
             print(lh_tune.rewrite.nondet_to_det(mod_op.clone()))
 
-            undo() # Undo the introduction of constants for the results of constraints.
+            undo()  # Undo the introduction of constants for the results of constraints.

--- a/lighthouse/tune/annotate.py
+++ b/lighthouse/tune/annotate.py
@@ -1,0 +1,90 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Callable, get_args
+from functools import wraps
+
+from mlir import ir
+
+NonDet = object()  # Sentinel value for non-determinized parameters.
+
+
+def check_annotated_constraints(f: Callable):
+    """Wrapper that runs __metadata__ constraints from Annotated types on function arguments."""
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        sig = inspect.signature(f)
+        bound_args = sig.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+
+        for name, value in bound_args.arguments.items():
+            if value is NonDet:
+                continue
+
+            param = sig.parameters[name]
+
+            if param.kind != param.KEYWORD_ONLY or not hasattr(
+                param.annotation, "__metadata__"
+            ):
+                continue
+
+            wrapped_type, constraint = get_args(param.annotation)
+
+            if not isinstance(value, wrapped_type):
+                raise TypeError(
+                    f"Argument {name} must be of type {param.annotation}, got {type(value)}"
+                )
+
+            if not constraint(value):
+                raise ValueError(
+                    f"Constraint {constraint} not satisfied for argument {name} with value {value}"
+                )
+
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
+@dataclass
+class ConstraintCollector:
+    """Used on annotated constraint functions to reify the constraints as data."""
+
+    children: list[Any] = field(default_factory=list)
+    lb: int | None = None
+    ub: int | None = None
+
+    def __mod__(self, other):
+        self.children.append(mod := ModConstraintCollector(modulus=other))
+        return mod
+
+    def __le__(self, other):
+        self.ub = other
+        return self
+
+    def __ge__(self, other):
+        self.lb = other
+        return self
+
+    def to_mlir(self) -> ir.Attribute:
+        dict_attrs = {}
+        i64 = ir.IntegerType.get_signless(64)
+        if self.lb is not None:
+            dict_attrs["lb"] = ir.IntegerAttr.get(i64, self.lb)
+        if self.ub is not None:
+            dict_attrs["ub"] = ir.IntegerAttr.get(i64, self.ub)
+        if self.children:
+            assert len(self.children) == 1 and isinstance(
+                self.children[0], ModConstraintCollector
+            )
+            dict_attrs["step"] = ir.IntegerAttr.get(i64, self.children[0].modulus)
+        return ir.DictAttr.get(dict_attrs)
+
+
+@dataclass
+class ModConstraintCollector:
+    modulus: int
+    remainder: int | None = None
+
+    def __eq__(self, other):
+        assert other == 0, "Only equality with zero is currently supported"
+        return self

--- a/lighthouse/tune/rewrite.py
+++ b/lighthouse/tune/rewrite.py
@@ -1,0 +1,120 @@
+from collections import OrderedDict
+
+from mlir import ir
+from mlir.dialects import transform
+from mlir.dialects.transform import smt as transform_smt, tune as transform_tune
+
+
+def set_selected(op: ir.Operation, env: dict[ir.Value | ir.Operation, object]):
+    def recurse(op: ir.Operation):
+        for region in op.regions:
+            for block in region.blocks:
+                for child in block:
+                    set_selected(child, env)
+
+    match type(op):
+        case transform_tune.KnobOp:
+            op.attributes["selected"] = env[op.result]
+        case transform_tune.AlternativesOp:
+            op.attributes["selected_region"] = env[op]
+            recurse(op)
+        case _:
+            recurse(op)
+    return op
+
+
+# This is a hack >;(
+def constraint_results_to_constants(
+    op: ir.Operation | ir.Module,
+    env: dict[ir.Value | ir.Operation, object],
+    undo_actions=None,
+):
+    undo_actions = undo_actions if undo_actions is not None else []
+
+    def undo():
+        for action in reversed(undo_actions):
+            action()
+
+    match type(op):
+        case transform_smt.ConstrainParamsOp:
+            with ir.InsertionPoint.after(op):
+                orig_results_and_uses = OrderedDict(
+                    (res, list((use.owner, use.operand_number) for use in res.uses))
+                    for res in op.results
+                )
+
+                for result in op.results:
+                    val = transform.param_constant(result.type, env[result])
+
+                    for use in result.uses:
+                        use.owner.operands[use.operand_number] = val
+
+                def undo_rewrite():
+                    for orig_res, orig_uses in orig_results_and_uses.items():
+                        for orig_owner, orig_operand_number in orig_uses:
+                            param = orig_owner.operands[orig_operand_number].owner
+                            assert isinstance(param, transform.ParamConstantOp)
+                            orig_owner.operands[orig_operand_number] = orig_res
+                        param.erase()
+
+                undo_actions.append(undo_rewrite)
+        case _:
+            for region in op.regions:
+                for block in region.blocks:
+                    for child in block:
+                        constraint_results_to_constants(child, env, undo_actions)
+
+    return op, undo
+
+
+def nondet_to_det(op: ir.Operation, env: dict[ir.Value, ir.Value] = None):
+    env = env if env is not None else {}  # TODO: nested scopes
+
+    i64 = ir.IntegerType.get_signless(64)
+    transform_param_i64 = transform.ParamType.get(i64)
+
+    match type(op):
+        case transform_tune.KnobOp:
+            assert "selected" in op.attributes
+            with ir.InsertionPoint.after(op):
+                subst = transform.param_constant(
+                    transform_param_i64, op.attributes["selected"]
+                )
+
+            for use in op.result.uses:
+                use.owner.operands[use.operand_number] = subst
+
+            op.erase()
+
+        case transform_tune.AlternativesOp:
+            assert "selected_region" in op.attributes
+            region_idx = op.attributes["selected_region"].value
+            with ir.InsertionPoint.after(op):
+                for child in op.regions[region_idx].blocks[0]:
+                    new_yield = cloned_child = child.clone()
+                    for result, new_result in zip(child.results, cloned_child.results):
+                        env[result] = new_result
+                    for idx, operand in enumerate(cloned_child.operands):
+                        if operand in env:
+                            cloned_child.operands[idx] = env[operand]
+                    nondet_to_det(cloned_child, env)
+                for yield_operand, result in zip(new_yield.operands, op.results):
+                    for res_use in result.uses:
+                        res_use.owner.operands[res_use.operand_number] = yield_operand
+                new_yield.erase()
+
+            op.erase()
+
+        case transform_smt.ConstrainParamsOp:
+            for res in op.results:
+                assert next(res.uses, None) is None
+
+            op.erase()
+
+        case _:
+            for region in op.regions:
+                for block in region.blocks:
+                    for child in block:
+                        nondet_to_det(child, env)
+
+            return op

--- a/lighthouse/tune/smt/__init__.py
+++ b/lighthouse/tune/smt/__init__.py
@@ -1,0 +1,21 @@
+__all__ = ["z3"]
+
+import sys
+import importlib
+
+
+def __getattr__(name):
+    """Enable lazy loading of submodules.
+
+    Enables `import lighthouse.tune as lh_tune; lh_tune.smt.<submodule>` with
+    loading of (the submodule's heavy) depenendencies only upon being needed.
+    """
+
+    if name in __all__:
+        # Import the submodule and cache it on the current module. That is,
+        # upon the next access __getattr__ will not be called.
+        submodule = importlib.import_module("lighthouse.tune.smt." + name)
+        lighthouse_mod = sys.modules[__name__]
+        setattr(lighthouse_mod, name, submodule)
+        return submodule
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/lighthouse/tune/smt/z3.py
+++ b/lighthouse/tune/smt/z3.py
@@ -1,0 +1,187 @@
+import operator
+
+from functools import reduce
+
+from mlir import ir
+from mlir.dialects import transform, smt
+from mlir.dialects.transform import smt as transform_smt, tune as transform_tune
+
+import z3
+
+
+# From: http://theory.stanford.edu/%7Enikolaj/programmingz3.html#sec-blocking-evaluations
+def all_smt(s, initial_terms):
+    def block_term(s, m, t):
+        s.add(t != m.eval(t))
+
+    def fix_term(s, m, t):
+        s.add(t == m.eval(t))
+
+    def all_smt_rec(terms):
+        if z3.sat == s.check():
+            m = s.model()
+            yield m
+            for i in range(len(terms)):
+                s.push()
+                block_term(s, m, terms[i])
+                for j in range(i):
+                    fix_term(s, m, terms[j])
+                yield from all_smt_rec(terms[i:])
+                s.pop()
+
+    yield from all_smt_rec(list(initial_terms))
+
+
+def model_to_mlir(x):
+    return ir.IntegerAttr.get(ir.IntegerType.get_signless(64), x.py_value())
+
+
+name_counter = 0
+
+
+def fresh_name(prefix="fresh"):
+    global name_counter
+    name_counter += 1
+    return f"{prefix}{name_counter}"
+
+
+def transform_tune_and_smt_ops_to_z3_constraints(
+    op: ir.Operation | ir.OpView, env=None, path=None, constraints=None
+):
+    env = env if env is not None else {}  # TODO: nested scopes
+    path = path if path is not None else []
+    constraints = constraints if constraints is not None else []
+
+    match type(op):
+        case transform.ParamConstantOp:
+            name = fresh_name("cst")
+            var = env[op.result] = z3.Int(name)
+            C = op.value.value
+            constraints += [z3.Implies(z3.And(*path), var == C)]
+
+        case transform.MatchParamCmpIOp:
+            lvar = env[op.operands[0]]
+            rvar = env[op.operands[1]]
+            predicate_to_operator = {
+                transform.MatchCmpIPredicate.eq: operator.eq,
+                transform.MatchCmpIPredicate.le: operator.le,
+                transform.MatchCmpIPredicate.lt: operator.lt,
+                transform.MatchCmpIPredicate.ge: operator.ge,
+                transform.MatchCmpIPredicate.gt: operator.gt,
+                transform.MatchCmpIPredicate.ne: operator.ne,
+            }
+            constraints += [
+                z3.Implies(
+                    z3.And(*path),
+                    predicate_to_operator[
+                        transform.MatchCmpIPredicate(op.predicate.value)
+                    ](lvar, rvar),
+                )
+            ]
+
+        case transform_tune.KnobOp:
+            var = env[op.result] = z3.Int(op.name.value)
+            if isinstance(op.options, ir.ArrayAttr):
+                constraints += [
+                    z3.Implies(
+                        z3.And(*path), z3.Or(*[var == opt.value for opt in op.options])
+                    )
+                ]
+            elif isinstance(op.options, ir.DictAttr):
+                assert "lb" in op.options and "ub" in op.options
+                atoms = [op.options["lb"].value <= var, var <= op.options["ub"].value]
+                if "step" in op.options:
+                    atoms += [var % op.options["step"].value == 0]
+
+                constraints += [z3.Implies(z3.And(*path), z3.And(atoms))]
+            else:
+                assert False, "Unknown options attribute type"
+
+        case transform_tune.AlternativesOp:
+            var = env[op] = z3.Int(op.name.value)
+            constraints += [
+                z3.Implies(z3.And(path), z3.And(0 <= var, var < len(op.regions)))
+            ]
+            for idx, region in enumerate(op.regions):
+                for child in region.blocks[0]:
+                    transform_tune_and_smt_ops_to_z3_constraints(
+                        child, env, path + [var == idx], constraints
+                    )
+                for yield_operand, result in zip(
+                    region.blocks[0].operations[-1].operands, op.results
+                ):
+                    if isinstance(yield_operand.type, transform.ParamType):
+                        env[result] = z3.Int(fresh_name("alt_res"))
+                        constraints += [
+                            z3.Implies(
+                                z3.And(*(path + [var == idx])),
+                                env[result] == env[yield_operand],
+                            )
+                        ]
+
+        case transform_smt.ConstrainParamsOp:
+            mapping_constraints = []
+            for operand, block_arg in zip(op.operands, op.body.arguments):
+                var = env[block_arg] = z3.Int(fresh_name("cp_bbarg"))
+                mapping_constraints += [var == env[operand]]
+            constraints += [z3.Implies(z3.And(*path), z3.And(*mapping_constraints))]
+            for idx in range(len(op.body.operations) - 1):
+                transform_tune_and_smt_ops_to_z3_constraints(
+                    op.body.operations[idx], env, path, constraints
+                )
+            assert isinstance(op.body.operations[-1], smt.YieldOp)
+            mapping_constraints = []
+            for result, yield_arg in zip(op.results, op.body.operations[-1].operands):
+                var = env[result] = z3.Int(fresh_name("cp_bbres"))
+                mapping_constraints += [var == env[yield_arg]]
+            constraints += [z3.Implies(z3.And(*path), z3.And(*mapping_constraints))]
+
+        case smt.IntAddOp:
+            var = env[op.result] = z3.Int(fresh_name("add"))
+            constraints += [
+                z3.Implies(
+                    z3.And(*path), var == sum(env[value] for value in op.operands)
+                )
+            ]
+
+        case smt.IntMulOp:
+            var = env[op.result] = z3.Int(fresh_name("mul"))
+            constraints += [
+                z3.Implies(
+                    z3.And(*path),
+                    var == reduce(operator.mul, (env[value] for value in op.operands)),
+                )
+            ]
+
+        case smt.IntConstantOp:
+            var = env[op.result] = z3.Int(fresh_name("cst"))
+            constraints += [z3.Implies(z3.And(*path), var == op.value.value)]
+
+        case smt.EqOp:
+            assert len(op.operands) == 2
+            lhs, rhs = env[op.operands[0]], env[op.operands[1]]
+            var = env[op.result] = z3.Bool(fresh_name("eq"))
+            constraints += [z3.Implies(z3.And(*path), var == (lhs == rhs))]
+
+        case smt.IntModOp:
+            lhs, rhs = env[op.lhs], env[op.rhs]
+            var = env[op.result] = z3.Int(fresh_name("int.mod"))
+            constraints += [z3.Implies(z3.And(*path), var == (lhs % rhs))]
+
+        case smt.IntDivOp:
+            lhs, rhs = env[op.lhs], env[op.rhs]
+            var = env[op.result] = z3.Int(fresh_name("int.div"))
+            constraints += [z3.Implies(z3.And(*path), var == (lhs / rhs))]
+
+        case smt.AssertOp:
+            constraints += [z3.Implies(z3.And(*path), env[op.input])]
+
+        case _:
+            for region in op.regions:
+                for block in region.blocks:
+                    for child in block:
+                        transform_tune_and_smt_ops_to_z3_constraints(
+                            child, env, path, constraints
+                        )
+
+    return [z3.simplify(c) for c in constraints], env

--- a/lighthouse/utils/types.py
+++ b/lighthouse/utils/types.py
@@ -6,6 +6,7 @@ K = TypeVar("K")
 V = TypeVar("V")
 W = TypeVar("V")
 
+
 class LazyChainMap(Mapping, Generic[K, V, W]):
     def __init__(self, data: dict[K, V], func: Callable[V, W]):
         self._data = data

--- a/lighthouse/utils/types.py
+++ b/lighthouse/utils/types.py
@@ -1,0 +1,23 @@
+from typing import TypeVar, Generic, Callable
+
+from collections.abc import Mapping
+
+K = TypeVar("K")
+V = TypeVar("V")
+W = TypeVar("V")
+
+class LazyChainMap(Mapping, Generic[K, V, W]):
+    def __init__(self, data: dict[K, V], func: Callable[V, W]):
+        self._data = data
+        self._func = func
+
+    def __getitem__(self, key):
+        # Access the underlying data and apply the transformation
+        value = self._data[key]
+        return self._func(value)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ ingress_torch_xpu = [
     "pytorch_triton_xpu",  # Transitive dependency listed explicitly so that we can state which package repository it is supposed to come from
     "lighthouse[ingress_torch_mlir]"
 ]
+tune_smt_z3 = [
+    "z3-solver"
+]
 
 [tool.uv]
 # Declare that the following "targets" are mutually exclusive of one another


### PR DESCRIPTION
For a non-trivial example, run `python examples/xegpu_matmul/matmul.py --dump-schedule --non-det` for
```mlir
module attributes {transform.with_named_sequence} {                                                                                                                                  
  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {                                                                                        
    %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op                                                                           
    %1 = transform.get_parent_op %0 {deduplicate, op_name = "builtin.module"} : (!transform.any_op) -> !transform.any_op                                                             
    %2 = transform.tune.knob<"wg_d0"> options = {lb = 128 : i64, step = 32 : i64, ub = 256 : i64} -> !transform.any_param                                                            
    %3 = transform.tune.knob<"wg_d1"> options = {lb = 128 : i64, step = 32 : i64, ub = 256 : i64} -> !transform.any_param                                                            
    %4 = transform.tune.knob<"sg_d0"> options = {lb = 16 : i64, step = 8 : i64, ub = 32 : i64} -> !transform.any_param                                                               
    %5 = transform.tune.knob<"sg_d1"> options = {lb = 16 : i64, step = 8 : i64, ub = 32 : i64} -> !transform.any_param                                                               
    %6:3 = transform.smt.constrain_params(%2, %3, %4, %5) : (!transform.any_param, !transform.any_param, !transform.any_param, !transform.any_param) -> (!transform.any_param, !trans
form.any_param, !transform.any_param) {                                                                                                                                              
    ^bb0(%arg1: !smt.int, %arg2: !smt.int, %arg3: !smt.int, %arg4: !smt.int):                                                                                                        
      %c0 = smt.int.constant 0                                                                                                                                                       
      %58 = smt.int.mod %arg1, %arg3
...
```
then feed that to `... | python -m lighthouse.tune - --print-smtlib -n 100`:
```mlir
////////////////////////////////////////////////////////////////////////////////                                                                                                     
// SMT-LIB constraints                                                                                                                                                               
////////////////////////////////////////////////////////////////////////////////                                                                                                     
(declare-fun wg_d0 () Int)                                                                                                                                                           
(declare-fun wg_d1 () Int)                                                                                                                                                           
(declare-fun sg_d0 () Int)                                                                                                                                                           
(declare-fun sg_d1 () Int)                                                                                                                                                           
(declare-fun cp_bbarg4 () Int)
...
(assert (and (>= wg_d0 128) (<= wg_d0 256) (= (mod wg_d0 32) 0)))
(assert (and (>= wg_d1 128) (<= wg_d1 256) (= (mod wg_d1 32) 0)))
(assert (and (>= sg_d0 16) (<= sg_d0 32) (= (mod sg_d0 8) 0)))
(assert (and (>= sg_d1 16) (<= sg_d1 32) (= (mod sg_d1 8) 0)))
(assert (and (= cp_bbarg1 wg_d0)
     (= cp_bbarg2 wg_d1)
     (= cp_bbarg3 sg_d0)
     (= cp_bbarg4 sg_d1)))
...
////////////////////////////////////////////////////////////////////////////////
// Determinized schedule #1
////////////////////////////////////////////////////////////////////////////////
module attributes {transform.with_named_sequence} {
  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
    %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op
    %1 = transform.get_parent_op %0 {deduplicate, op_name = "builtin.module"} : (!transform.any_op) -> !transform.any_op
    %2 = transform.param.constant 160 : i64 -> !transform.param<i64>
    %3 = transform.param.constant 192 : i64 -> !transform.param<i64>
    %4 = transform.param.constant 16 : i64 -> !transform.param<i64>
    %5 = transform.param.constant 24 : i64 -> !transform.param<i64>
...
////////////////////////////////////////////////////////////////////////////////                                                                                                     
// Determinized schedule #100                                                                                                                                                        
////////////////////////////////////////////////////////////////////////////////                                                                                                     
module attributes {transform.with_named_sequence} {                                                                                                                                  
  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {                                                                                        
    %0 = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.any_op                                                                           
    %1 = transform.get_parent_op %0 {deduplicate, op_name = "builtin.module"} : (!transform.any_op) -> !transform.any_op                                                             
    %2 = transform.param.constant 256 : i64 -> !transform.param<i64>                                                                                                                 
    %3 = transform.param.constant 256 : i64 -> !transform.param<i64>                                                                                                                 
    %4 = transform.param.constant 16 : i64 -> !transform.param<i64>                                                                                                                  
    %5 = transform.param.constant 32 : i64 -> !transform.param<i64>
...
```
Co-authored-by: Tuomas Kärnä <tuomas.karna@intel.com>