### PR TITLE
[utils][torch] PyTorch to memref - enable bf16 conversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dev = [
 
 [project.optional-dependencies]
 ingress_torch_mlir = [
-    "torch-mlir==20260125.703"
+    "torch-mlir==20260125.703",
+    "ml_dtypes",
 ]
 # Additional "targets" which pull in optional dependencies -- use `uv sync --extra TARGET`
 ingress_torch_cpu = [


### PR DESCRIPTION
Adds a special case for bfloat16 torch.Tensor to memref conversion.