### PR TITLE
[examples] Remove obsolete kernel dump levels from XeGPU matmul example

### DIFF
--- a/examples/xegpu_matmul/matmul.py
+++ b/examples/xegpu_matmul/matmul.py
@@ -324,8 +324,6 @@ def parse_cli():
             "bufferized",
             "xegpu-initial",
             "xegpu-wg",
-            "xegpu-sg",
-            "xegpu-inst",
             "final",
         ],
         help="Dump kernel IR at different stages of lowering.",

--- a/examples/xegpu_matmul/schedule.py
+++ b/examples/xegpu_matmul/schedule.py
@@ -381,12 +381,7 @@ def bundle_xepu_matmul_schedule(
 
 def bundle_xegpu_to_binary(mod, stop_at_stage: str = "") -> ir.Module:
     """Schedule for lowering xegpu wg level to binary."""
-    # This schedule corresponds to upstream MLIR XeVM lowering pipeline
-    # and is payload independent.
-
-    # This pipeline causes performance regression with the existing
-    # xegpu transform ops.
-    # FIXME Use anchor layouts in transform ops.
+    # upstream xegpu/xevm pipeline is payload independent.
     mod = apply_registered_pass(
         mod, "gpu-lower-to-xevm-pipeline", options={"xegpu-op-level": "workgroup"}
     )


### PR DESCRIPTION
We are now using the monolithic `gpu-lower-to-xevm-pipeline` pass to lower below the xegpu workgroup level, so the lowering cannot be stopped on subgroup/instruction/etc levels anymore.

While having such diagnostics is useful for debugging, to support it we'd need to replicate the xevm lowering pipeline in lighthouse as a schedule implying some sync/maintenance burden.