### PR TITLE
[infra] Search for FileCheck if available

### DIFF
--- a/lit.cfg.py
+++ b/lit.cfg.py
@@ -18,7 +18,7 @@ def find_filecheck() -> str:
     # If FileCheck is available in path, use it.
     path = shutil.which("FileCheck")
     if path:
-        return "FileCheck" # Avoid full path when none is needed
+        return "FileCheck"  # Avoid full path when none is needed
     # Otherwise, search for FileCheck in the system and return the newest one.
     for version in range(21, 0, -1):
         path = shutil.which("FileCheck-{}".format(version))


### PR DESCRIPTION
To avoid having to remember to set the environment flag. If FileCheck isn't one of the standard ones, symbolic links from user's home bin work too, or even the environment variable still works.