### PR TITLE
[Pipeline] Refactor Driver, Stages and Descriptor

### DIFF
--- a/examples/ingress/torch/compile_model.py
+++ b/examples/ingress/torch/compile_model.py
@@ -8,7 +8,7 @@ from mlir import ir
 from mlir.passmanager import PassManager
 
 from lighthouse.ingress.torch import cpu_backend, TargetDialect
-from lighthouse.pipeline.opt import PassBundles, add_bundle
+from lighthouse.pipeline.stage import PassBundles, add_bundle
 
 
 def lower_to_llvm(module: ir.Module) -> ir.Module:

--- a/examples/workload/example.py
+++ b/examples/workload/example.py
@@ -20,7 +20,7 @@ from mlir.execution_engine import ExecutionEngine
 
 from lighthouse import dialects as lh_dialects
 from lighthouse.pipeline.helper import match
-from lighthouse.pipeline.opt import PassBundles, apply_bundle
+from lighthouse.pipeline.stage import PassBundles, apply_bundle
 from lighthouse.workload import Workload, execute, benchmark, get_bench_wrapper_schedule
 
 

--- a/lighthouse/pipeline/descriptor.py
+++ b/lighthouse/pipeline/descriptor.py
@@ -1,6 +1,8 @@
 import yaml
 import os
 
+from lighthouse.pipeline.helper import remove_args_and_opts, update_filename
+
 
 class PipelineDescriptor:
     """
@@ -8,9 +10,14 @@ class PipelineDescriptor:
     This class is responsible for parsing the pipeline description from a YAML file,
     and keeping a list of stages for comsumption by the Driver.
 
+    The format here is just text. The main job of this class is to handle includes,
+    to verify that the files for the stages exist, normalize their paths, etc.
+    The actual validation of the stages is left to the Driver and the stages themselves.
+
     Format is:
     Pipeline:
       - pass: PassName
+      - transform: TransformFile.py[gen=generator_name,seq=sequence_name]{opt1=val1 opt2=val2}
       - transform: TransformFile.mlir
       - include: OtherPipeline.yaml
       - bundle: BundleName
@@ -29,8 +36,26 @@ class PipelineDescriptor:
             )
 
     def _normalize_include_path(self, filename) -> str:
-        """Uses the path of the includer to determine the path of the included."""
-        return os.path.normpath(os.path.join(os.path.dirname(self.filename), filename))
+        """
+        Finds the file in some standard locations, in order:
+            * The path of the descriptor file that includes it. This allows for relative includes.
+            * The path of the Lighthouse schedule module, where all the standard pipelines are located.
+        """
+        filename = remove_args_and_opts(filename)
+        descriptor_path = os.path.normpath(os.path.dirname(self.filename))
+        schedule_module_path = os.path.normpath(
+            os.path.join(os.path.dirname(__file__), "../schedule")
+        )
+
+        file = os.path.join(descriptor_path, filename)
+        if not os.path.exists(file):
+            file = os.path.join(schedule_module_path, filename)
+            if not os.path.exists(file):
+                raise ValueError(
+                    f"Included pipeline descriptor file does not exist: {filename} \
+                        (searched in {descriptor_path} and {schedule_module_path})"
+                )
+        return file
 
     def _parse_stages(self) -> None:
         """
@@ -50,11 +75,11 @@ class PipelineDescriptor:
             elif "transform" in stage:
                 # Transforms need to be MLIR files, and need to exist.
                 filename = self._normalize_include_path(stage["transform"])
-                if not os.path.exists(filename):
-                    raise ValueError(f"Transform file does not exist: {filename}")
-                elif not filename.endswith(".mlir"):
-                    raise ValueError(f"Transform file must be an MLIR file: {filename}")
-                self.stages.append(filename)
+                if not filename.endswith(".mlir") and not filename.endswith(".py"):
+                    raise ValueError(
+                        f"Transform file must be an MLIR or Python file: {filename}"
+                    )
+                self.stages.append(update_filename(stage["transform"], filename))
 
             elif "pass" in stage:
                 # Passes are just strings, let the pass manager validate.
@@ -74,13 +99,8 @@ class PipelineDescriptor:
     def _include_pipeline(self, filename: str) -> None:
         """
         Helper function to include another pipeline descriptor file.
-        Include path is RELATIVE to the file including.
         """
         filename = self._normalize_include_path(filename)
-        if not os.path.exists(filename):
-            raise ValueError(
-                f"Included pipeline descriptor file does not exist: {filename}"
-            )
         included_pipeline = PipelineDescriptor(filename)
         self.stages.extend(included_pipeline.get_stages())
 

--- a/lighthouse/pipeline/driver.py
+++ b/lighthouse/pipeline/driver.py
@@ -1,0 +1,100 @@
+import os
+
+from mlir import ir
+import lighthouse.pipeline.stage as lhs
+from lighthouse.pipeline.helper import import_mlir_module, remove_args_and_opts
+from lighthouse.pipeline.descriptor import PipelineDescriptor
+
+
+class Driver:
+    """
+    A simple driver that runs the optimization pipeline on a given workload.
+    This is a high-level interface that abstracts away the details of the optimization pipeline,
+    and provides a simple interface for running the pipeline on a given workload.
+
+    The pipeline is flexible until the first time it is run, at which point it becomes fixed and cannot be modified until reset is called.
+    This is to allow running the same pipeline on different modules, without accidentally modifying the pipeline after it has been run.
+
+    Calling reset() will clear the pipeline and the module, allowing for a new pipeline to be constructed and run on a new module.
+    """
+
+    def __init__(self, filename: str, stages: list[str] = []):
+        # The context is shared across the entire pipeline, and is used to create the PassManager and Transform Schedules.
+        # The module is owned by the Driver to encapsulate its use through the pipeline.
+        # It is returned at the end of run() after being transformed by the stages in the pipeline.
+        self.context = ir.Context()
+        self.module = None
+        if filename:
+            self.import_payload(filename)
+        self.pipeline: list[lhs.Stage] = []
+        self.pipeline_fixed = False
+        self.bundles = lhs.PassBundles
+        if stages:
+            self.add_stages(stages)
+
+    def import_payload(self, path: str) -> None:
+        """Import the payload module and set it as the current module in the pipeline."""
+        if self.module is not None:
+            raise ValueError("Module already imported. Reset to start again.")
+        self.module = import_mlir_module(path, self.context)
+
+    def add_stage(self, stage_name: str) -> None:
+        if self.pipeline_fixed:
+            raise ValueError("Pipeline is fixed. Reset to start again.")
+
+        # Stages can contain arguments and options, clean up for os checks
+        filename = remove_args_and_opts(stage_name)
+
+        if stage_name in self.bundles:
+            # Pass Bundle
+            self.pipeline.append(lhs.PassStage(self.bundles[stage_name], self.context))
+
+        elif os.path.exists(filename):
+            # Transform or YAML
+            if filename.endswith(".mlir") or filename.endswith(".py"):
+                self.pipeline.append(
+                    lhs.TransformStage(lhs.Transform(stage_name), self.context)
+                )
+            elif filename.endswith(".yaml"):
+                desc = PipelineDescriptor(stage_name)
+                for s in desc.get_stages():
+                    self.add_stage(s)
+            else:
+                _, ext = os.path.splitext(filename)
+                raise ValueError(f"Unknown file type '{ext}' for stage '{stage_name}'.")
+
+        else:
+            # Assume random strings represent a single pass
+            # Will crash later if the pass name is not registered.
+            self.pipeline.append(lhs.PassStage([lhs.Pass(stage_name)], self.context))
+
+    def add_stages(self, stages: list[str]) -> None:
+        for s in stages:
+            self.add_stage(s)
+
+    def reset(self) -> None:
+        """Reset the pipeline to an empty state, allowing for new stages to be added."""
+        self.pipeline = list[lhs.Stage]()
+        self.module = None
+        self.pipeline_fixed = False
+
+    def run(self) -> ir.Module:
+        if self.module is None:
+            raise ValueError("Module must not be empty.")
+        if len(self.pipeline) == 0:
+            raise ValueError("Pipeline must have at least one stage.")
+        for stage in self.pipeline:
+            self.module = stage.apply(self.module)
+
+        # The pipeline is now fixed and cannot be modified until reset is called.
+        # This is to prevent accidental modifications to the pipeline after it has been run,
+        # and to ensure that different pipelines are not run on different modules.
+        self.pipeline_fixed = True
+
+        # We don't want to run the pipeline twice on the same module,
+        # so we clear the module from the driver after running the pipeline,
+        # and return it to the caller.
+        # To use the pipeline again, the caller must import a new module into the driver.
+        module = self.module
+        self.module = None
+        return module

--- a/lighthouse/pipeline/helper.py
+++ b/lighthouse/pipeline/helper.py
@@ -1,8 +1,71 @@
 import os
+import re
 
 from mlir import ir
 from mlir.dialects import transform
 from mlir.dialects.transform import structured
+
+
+def convert_string(value: str) -> str | int | float | bool:
+    if value == "True":
+        return True
+    elif value == "False":
+        return False
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+
+
+def parse_csv(line: str, separator: str = ",") -> dict:
+    result = {}
+    arg_tuples = line.split(separator)
+    for arg in arg_tuples:
+        if not arg:
+            continue
+        if "=" in arg:
+            key, value = arg.split("=")
+            result[key] = convert_string(value)
+        else:
+            result[arg] = True
+    return result
+
+
+def remove_args_and_opts(line: str) -> str:
+    if m := re.search(r"^([^[{]*)", line):
+        line = m.group(1)
+    return line
+
+
+def update_filename(line: str, filename: str) -> str:
+    print(f"Updating stage name '{line}' with filename '{filename}'...")
+    if m := re.search(r"^([^[{]+)(.*)$", line):
+        line = filename + m.group(2)
+    print(f"Resulting in '{line}'")
+    return line
+
+
+def parse_args_and_opts(line: str) -> tuple[str, dict, dict]:
+    args = {}
+    options = {}
+
+    # Args: [arg1=val1,args2]
+    if m := re.search(r"\[([^]]*)\]", line):
+        args_str = m.group(1)
+        args = parse_csv(args_str, ",")
+
+    # Opts: {arg1=val1 args2}
+    if m := re.search(r"\{([^}]+)\}", line):
+        opts_str = m.group(1)
+        options = parse_csv(opts_str, " ")
+
+    # Cleanup the original string
+    line = remove_args_and_opts(line)
+
+    return [line, args, options]
 
 
 def import_mlir_module(path: str, context: ir.Context) -> ir.Module:

--- a/lighthouse/pipeline/stage.py
+++ b/lighthouse/pipeline/stage.py
@@ -3,67 +3,11 @@ import importlib
 from enum import Enum
 from pathlib import Path
 import os
-import re
 
 from mlir import ir
 from mlir.passmanager import PassManager
 from mlir.dialects import transform
-from lighthouse.pipeline.helper import import_mlir_module
-from lighthouse.pipeline.descriptor import PipelineDescriptor
-
-
-def convert_string(value: str) -> str | int | float | bool:
-    if value == "True":
-        return True
-    elif value == "False":
-        return False
-    try:
-        return int(value)
-    except ValueError:
-        try:
-            return float(value)
-        except ValueError:
-            return value
-
-
-def parse_csv(line: str, separator: str = ",") -> dict:
-    result = {}
-    arg_tuples = line.split(separator)
-    for arg in arg_tuples:
-        if not arg:
-            continue
-        if "=" in arg:
-            key, value = arg.split("=")
-            result[key] = convert_string(value)
-        else:
-            result[arg] = True
-    return result
-
-
-def remove_args_and_opts(line: str) -> str:
-    if m := re.search(r"^([^[{]*)", line):
-        line = m.group(0)
-    return line
-
-
-def parse_args_and_opts(line: str) -> tuple[str, dict, dict]:
-    args = {}
-    options = {}
-
-    # Args: [arg1=val1,args2]
-    if m := re.search(r"\[([^]]*)\]", line):
-        args_str = m.group(1)
-        args = parse_csv(args_str, ",")
-
-    # Opts: {arg1=val1 args2}
-    if m := re.search(r"\{([^}]+)\}", line):
-        opts_str = m.group(1)
-        options = parse_csv(opts_str, " ")
-
-    # Cleanup the original string
-    line = remove_args_and_opts(line)
-
-    return [line, args, options]
+from lighthouse.pipeline.helper import import_mlir_module, parse_args_and_opts
 
 
 class Pass:
@@ -89,6 +33,7 @@ class Pass:
 # These are not exhaustive and can be extended as needed.
 # The idea is to group together passes that are commonly used together in a pipeline,
 # so that they can be easily added to a PassManager or Transform Schedule with a single function call.
+# FIXME: Deprecate bundles in favor of YAML pipeline descriptors.
 PassBundles = {
     # All in one bufferization bundle.
     # This is self consistent and should be used together.
@@ -269,98 +214,4 @@ class TransformStage(Stage):
         if module is None:
             raise ValueError("Missing module to apply transformations to.")
         self.schedule.apply(module.operation)
-        return module
-
-
-class Driver:
-    """
-    A simple driver that runs the optimization pipeline on a given workload.
-    This is a high-level interface that abstracts away the details of the optimization pipeline,
-    and provides a simple interface for running the pipeline on a given workload.
-
-    The pipeline is flexible until the first time it is run, at which point it becomes fixed and cannot be modified until reset is called.
-    This is to allow running the same pipeline on different modules, without accidentally modifying the pipeline after it has been run.
-
-    Calling reset() will clear the pipeline and the module, allowing for a new pipeline to be constructed and run on a new module.
-    """
-
-    def __init__(self, filename: str, stages: list[str] = []):
-        # The context is shared across the entire pipeline, and is used to create the PassManager and Transform Schedules.
-        # The module is owned by the Driver to encapsulate its use through the pipeline.
-        # It is returned at the end of run() after being transformed by the stages in the pipeline.
-        self.context = ir.Context()
-        self.module = None
-        if filename:
-            self.import_payload(filename)
-        self.pipeline: list[Stage] = []
-        self.pipeline_fixed = False
-        self.bundles = PassBundles
-        if stages:
-            self.add_stages(stages)
-
-    def import_payload(self, path: str) -> None:
-        """Import the payload module and set it as the current module in the pipeline."""
-        if self.module is not None:
-            raise ValueError("Module already imported. Reset to start again.")
-        self.module = import_mlir_module(path, self.context)
-
-    def add_stage(self, stage_name: str) -> None:
-        if self.pipeline_fixed:
-            raise ValueError("Pipeline is fixed. Reset to start again.")
-
-        # Stages can contain arguments and options, clean up for os checks
-        filename = remove_args_and_opts(stage_name)
-
-        if stage_name in self.bundles:
-            # Pass Bundle
-            self.pipeline.append(PassStage(self.bundles[stage_name], self.context))
-
-        elif os.path.exists(filename):
-            # Transform or YAML
-            if filename.endswith(".mlir") or filename.endswith(".py"):
-                self.pipeline.append(
-                    TransformStage(Transform(stage_name), self.context)
-                )
-            elif filename.endswith(".yaml"):
-                desc = PipelineDescriptor(stage_name)
-                for s in desc.get_stages():
-                    self.add_stage(s)
-            else:
-                _, ext = os.path.splitext(filename)
-                raise ValueError(f"Unknown file type '{ext}' for stage '{stage_name}'.")
-
-        else:
-            # Assume random strings represent a single pass
-            # Will crash later if the pass name is not registered.
-            self.pipeline.append(PassStage([Pass(stage_name)], self.context))
-
-    def add_stages(self, stages: list[str]) -> None:
-        for s in stages:
-            self.add_stage(s)
-
-    def reset(self) -> None:
-        """Reset the pipeline to an empty state, allowing for new stages to be added."""
-        self.pipeline = list[Stage]()
-        self.module = None
-        self.pipeline_fixed = False
-
-    def run(self) -> ir.Module:
-        if self.module is None:
-            raise ValueError("Module must not be empty.")
-        if len(self.pipeline) == 0:
-            raise ValueError("Pipeline must have at least one stage.")
-        for stage in self.pipeline:
-            self.module = stage.apply(self.module)
-
-        # The pipeline is now fixed and cannot be modified until reset is called.
-        # This is to prevent accidental modifications to the pipeline after it has been run,
-        # and to ensure that different pipelines are not run on different modules.
-        self.pipeline_fixed = True
-
-        # We don't want to run the pipeline twice on the same module,
-        # so we clear the module from the driver after running the pipeline,
-        # and return it to the caller.
-        # To use the pipeline again, the caller must import a new module into the driver.
-        module = self.module
-        self.module = None
         return module

--- a/lighthouse/schedule/linalg.py
+++ b/lighthouse/schedule/linalg.py
@@ -2,11 +2,11 @@ from mlir import ir
 from mlir.dialects import transform
 from mlir.dialects.transform import structured
 
-from .builders import schedule_boilerplate
+from lighthouse.schedule.builders import schedule_boilerplate
 import lighthouse.transform as lh_transform
 
 
-def linalg_contract_fold_unit_dims() -> ir.Module:
+def linalg_contract_fold_unit_dims(options: dict = {}) -> ir.Module:
     """
     Fold unit dims of linalg contract.
 

--- a/lighthouse/schedule/x86/tile_and_vector_matmul.py
+++ b/lighthouse/schedule/x86/tile_and_vector_matmul.py
@@ -8,6 +8,7 @@ import lighthouse.transform as lh_transform
 
 
 def create_schedule(
+    options: dict = {},
     tile_sizes: tuple[int, int] = [32, 32],
     register_tile: tuple[int, int, int] = [8, 32, 1],
     matmul_op: str = "linalg.matmul",

--- a/test/opt/stages/pipeline-check.yaml
+++ b/test/opt/stages/pipeline-check.yaml
@@ -1,7 +1,9 @@
 Pipeline:
   - include: bufferization.yaml
   - include: cleanup.yaml
+  - transform: linalg.py[gen=linalg_contract_fold_unit_dims]
   - bundle: MLIRLoweringBundle
   - bundle: CleanupBundle
+  - transform: x86/tile_and_vector_matmul.py
   - bundle: LLVMLoweringBundle
   - pass: canonicalize

--- a/test/opt/transforms/pipeline-check.py
+++ b/test/opt/transforms/pipeline-check.py
@@ -1,7 +1,7 @@
 from mlir import ir
 from mlir.dialects import transform
 from lighthouse.pipeline.helper import match
-from lighthouse.pipeline.opt import PassBundles, apply_bundle
+from lighthouse.pipeline.stage import PassBundles, apply_bundle
 
 
 def create_schedule(options: dict = {}) -> ir.Module:

--- a/tools/lh-opt/lh-opt
+++ b/tools/lh-opt/lh-opt
@@ -2,7 +2,7 @@
 
 import argparse
 
-from lighthouse.pipeline.opt import Driver
+from lighthouse.pipeline.driver import Driver
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR reorganizes the key pipeline classes to avoid cross dependencies. It consolidates the Descriptor class as string parsing and shallow validation, while the Driver uses the Stage classes to do all the heaby lifting. The Pass and Transform classes remain as "structs" that hold the initializers for the stages.

It also fixes the lacking support for transform arguments in the descriptor (now using the same infra as the driver) and allows one to include from our "standard library of schedules" (inside lighthouse/schedule) without having to pass the full path (which can be unknown when the lighthouse module is pip installed).

I have changed two schedules to accept the `options` dictionary, so that we can call them from the descriptor/driver, but we need to define on a real API and commit to it.