### PR TITLE
[transform_ext] Op to convert function return values to arguments

### DIFF
--- a/lighthouse/dialects/transform_ext.py
+++ b/lighthouse/dialects/transform_ext.py
@@ -1,8 +1,18 @@
 from typing import Sequence, Optional
 
 from mlir import ir
-from mlir.dialects import ext, transform, func, arith, scf, memref, linalg
+from mlir.dialects import (
+    ext,
+    transform,
+    func,
+    arith,
+    scf,
+    memref,
+    linalg,
+    bufferization,
+)
 from mlir.dialects.transform import DiagnosedSilenceableFailure
+from lighthouse.ingress.mlir_gen.gpu_utils import emit_buf_to_tensor
 
 from lighthouse.utils.mlir import func_cif
 
@@ -714,3 +724,130 @@ def extract_handle(
         index = transform.ParamConstantOp(transform.AnyParamType.get(), param_attr)
 
     return ExtractHandleOp(target=target, index=index).result
+
+
+class ConvertFuncResultsToArgsOp(
+    TransformExtensionDialect.Operation, name="convert_func_results_to_args"
+):
+    """Converts all function return values to function arguments.
+
+    Function return values are placed in the beginning of the argument list, followed by the original function arguments.
+
+    Function arguments are converted to memrefs with appropriate bufferization annotations for inputs (bufferization.to_tensor with restrict=True) and outputs (bufferization.materialize_in_destination).
+
+    Currently supports only functions with tensor arguments and return values.
+    """
+
+    target: ext.Operand[transform.AnyOpType]
+    converted_func: ext.Result[transform.AnyOpType[()]] = ext.result(infer_type=True)
+
+    @classmethod
+    def attach_interface_impls(cls, context=None):
+        cls.TransformOpInterfaceModel.attach(cls.OPERATION_NAME, context=context)
+        cls.MemoryEffectsOpInterfaceModel.attach(cls.OPERATION_NAME, context=context)
+
+    @staticmethod
+    def convert_func(target: func.FuncOp) -> func.FuncOp:
+        def memref_t(ttype: ir.Type) -> ir.MemRefType:
+            return ir.MemRefType.get(ttype.shape, ttype.element_type)
+
+        func_name = target.sym_name.value
+        func_inputs = list(target.type.inputs)
+        func_results = list(target.type.results)
+        assert all(isinstance(ty, ir.RankedTensorType) for ty in func_inputs), (
+            "Only tensors are supported as input types"
+        )
+        assert all(isinstance(ty, ir.RankedTensorType) for ty in func_results), (
+            "Only tensors are supported as return types"
+        )
+
+        nresults = len(func_results)
+        new_args = [memref_t(ty) for ty in func_results + func_inputs]
+
+        @func_cif(*new_args, name=func_name)
+        def f(*args):
+            outputs = args[:nresults]
+            inputs = args[nresults:]
+            # convert input memrefs to tensors
+            input_tensors = []
+            for input in inputs:
+                t = emit_buf_to_tensor(input, restrict=True)
+                input_tensors.append(t)
+
+            # clone function body and map args and return values
+            cloned_map = {}
+            for op in target.regions[0].blocks[0].operations:
+                if isinstance(op, func.ReturnOp):
+                    # emit materialize_in_destination for each return value
+                    for i, res_val in enumerate(op.operands):
+                        if res_val.owner not in cloned_map:
+                            raise NotImplementedError("Unsupported return value")
+                        iresult = res_val.result_number
+                        new_val = cloned_map[res_val.owner].results[iresult]
+                        bufferization.materialize_in_destination(
+                            None,
+                            new_val,
+                            outputs[i],
+                            restrict=True,
+                            writable=True,
+                        )
+                else:
+                    new_op = op.clone()
+                    for i, oo in enumerate(op.operands):
+                        if isinstance(oo, ir.BlockArgument):
+                            # operand is func argument
+                            # replace with new input tensors
+                            new_op.operands[i] = input_tensors[oo.arg_number]
+                        else:
+                            # replace operands with cloned values
+                            if oo.owner in cloned_map:
+                                iresult = oo.result_number
+                                new_op.operands[i] = cloned_map[oo.owner].results[
+                                    iresult
+                                ]
+                    cloned_map[op] = new_op
+
+        return f.func_op
+
+    class TransformOpInterfaceModel(transform.TransformOpInterface):
+        @staticmethod
+        def apply(
+            op: "ConvertFuncResultsToArgsOp",
+            _rewriter: transform.TransformRewriter,
+            results: transform.TransformResults,
+            state: transform.TransformState,
+        ) -> DiagnosedSilenceableFailure:
+            targets = state.get_payload_ops(op.target)
+            converted_funcs = []
+
+            for target in targets:
+                if not isinstance(target, func.FuncOp):
+                    return DiagnosedSilenceableFailure.SilenceableFailure
+
+                with ir.InsertionPoint(target), target.location:
+                    new_func = ConvertFuncResultsToArgsOp.convert_func(target)
+                    target.erase()
+                converted_funcs.append(new_func)
+
+            results.set_ops(op.converted_func, converted_funcs)
+
+            return DiagnosedSilenceableFailure.Success
+
+        @staticmethod
+        def allow_repeated_handle_operands(_op: "ConvertFuncResultsToArgsOp") -> bool:
+            return False
+
+    class MemoryEffectsOpInterfaceModel(ir.MemoryEffectsOpInterface):
+        @staticmethod
+        def get_effects(op: "ConvertFuncResultsToArgsOp", effects):
+            transform.consumes_handle(op.op_operands, effects)
+            transform.produces_handle(op.results, effects)
+            transform.modifies_payload(effects)
+
+
+def convert_func_results_to_args(
+    target: ir.Value[transform.AnyOpType], bench_name: str | None = None
+) -> ir.Value[transform.AnyOpType]:
+    """snake_case wrapper to create a ConvertFuncResultsToArgsOp."""
+    op = ConvertFuncResultsToArgsOp(target=target)
+    return op.converted_func

--- a/lighthouse/dialects/transform_ext.py
+++ b/lighthouse/dialects/transform_ext.py
@@ -12,7 +12,7 @@ from mlir.dialects import (
     bufferization,
 )
 from mlir.dialects.transform import DiagnosedSilenceableFailure
-from lighthouse.ingress.mlir_gen.gpu_utils import emit_buf_to_tensor
+from lighthouse.ingress.mlir_gen.utils import emit_buf_to_tensor
 
 from lighthouse.utils.mlir import func_cif
 

--- a/lighthouse/dialects/transform_ext.py
+++ b/lighthouse/dialects/transform_ext.py
@@ -731,9 +731,12 @@ class ConvertFuncResultsToArgsOp(
 ):
     """Converts all function return values to function arguments.
 
-    Function return values are placed in the beginning of the argument list, followed by the original function arguments.
+    Function return values are placed in the beginning of the argument list,
+    followed by the original function arguments.
 
-    Function arguments are converted to memrefs with appropriate bufferization annotations for inputs (bufferization.to_tensor with restrict=True) and outputs (bufferization.materialize_in_destination).
+    Function arguments are converted to memrefs with appropriate bufferization
+    annotations for inputs (bufferization.to_tensor with restrict=True) and
+    outputs (bufferization.materialize_in_destination).
 
     Currently supports only functions with tensor arguments and return values.
     """

--- a/lighthouse/ingress/mlir_gen/gpu_mlp_payload.py
+++ b/lighthouse/ingress/mlir_gen/gpu_mlp_payload.py
@@ -1,7 +1,7 @@
 from mlir import ir
 from mlir.dialects import linalg, gpu, bufferization, arith, tensor
 
-from .gpu_utils import emit_buf_to_tensor
+from .utils import emit_buf_to_tensor
 from .named import add_bias, relu, times_weights
 from .generic import convert_float_type
 from lighthouse.utils.mlir import func_cif

--- a/lighthouse/ingress/mlir_gen/gpu_softmax_payload.py
+++ b/lighthouse/ingress/mlir_gen/gpu_softmax_payload.py
@@ -4,10 +4,8 @@ from mlir import ir
 from mlir.dialects import linalg, bufferization, tensor
 
 from lighthouse.utils.mlir import func_cif
-from lighthouse.ingress.mlir_gen.gpu_utils import (
-    emit_gpu_util_funcs,
-    emit_buf_to_tensor,
-)
+from lighthouse.ingress.mlir_gen.gpu_utils import emit_gpu_util_funcs
+from lighthouse.ingress.mlir_gen.utils import emit_buf_to_tensor
 
 
 def generate_gpu_softmax_payload(

--- a/lighthouse/ingress/mlir_gen/gpu_utils.py
+++ b/lighthouse/ingress/mlir_gen/gpu_utils.py
@@ -1,14 +1,6 @@
 from mlir import ir
-from mlir.dialects import gpu, bufferization, arith
+from mlir.dialects import gpu, arith
 from lighthouse.utils.mlir import func_cif
-
-
-def emit_buf_to_tensor(memref_value: ir.Value, **kwargs) -> ir.Value:
-    memref_type = memref_value.type
-    shape = memref_type.shape
-    element_type = memref_type.element_type
-    tensor_type = ir.RankedTensorType.get(shape, element_type)
-    return bufferization.to_tensor(tensor_type, memref_value, **kwargs)
 
 
 def emit_gpu_alloc(suffix: str, element_type: ir.Type, rank: int = 2):

--- a/lighthouse/ingress/mlir_gen/utils.py
+++ b/lighthouse/ingress/mlir_gen/utils.py
@@ -6,7 +6,7 @@ from typing import Union
 import numpy as np
 
 from mlir import ir
-from mlir.dialects import arith, linalg, tensor
+from mlir.dialects import arith, linalg, tensor, bufferization
 
 
 def get_mlir_elem_type(type_str: str):
@@ -29,6 +29,14 @@ def get_mlir_elem_type(type_str: str):
     if type_str == "i1":
         return ir.IntegerType.get(1)
     raise ValueError(f"Unsupported element type string '{type_str}'")
+
+
+def emit_buf_to_tensor(memref_value: ir.Value, **kwargs) -> ir.Value:
+    memref_type = memref_value.type
+    shape = memref_type.shape
+    element_type = memref_type.element_type
+    tensor_type = ir.RankedTensorType.get(shape, element_type)
+    return bufferization.to_tensor(tensor_type, memref_value, **kwargs)
 
 
 class ConstantInitKind(Enum):

--- a/lighthouse/schedule/__init__.py
+++ b/lighthouse/schedule/__init__.py
@@ -2,6 +2,7 @@ from .builders import create_schedule
 from .builders import create_named_sequence
 from .builders import schedule_boilerplate
 from .hoisting import hoist_loops
+from .func import convert_function_results
 from .linalg import linalg_contract_fold_unit_dims
 from .packing import block_pack_matmuls
 from .tiling import tile_ops
@@ -14,6 +15,7 @@ from .debug import print_ir
 __all__ = [
     "block_pack_matmuls",
     "bufferize",
+    "convert_function_results",
     "create_named_sequence",
     "create_schedule",
     "hoist_loops",

--- a/lighthouse/schedule/func.py
+++ b/lighthouse/schedule/func.py
@@ -11,7 +11,8 @@ def convert_function_results(payload_func: str = None) -> ir.Module:
     A schedule that converts the payload function's return values to arguments.
 
     Args:
-        payload_func: The name of the payload function to convert. If None, all func.func ops will be converted.
+        payload_func: The name of the payload function to convert. If None, all
+        func.func ops will be converted.
     Returns:
         Schedule
     """

--- a/lighthouse/schedule/func.py
+++ b/lighthouse/schedule/func.py
@@ -1,0 +1,34 @@
+from mlir import ir
+from mlir.dialects import transform
+from mlir.dialects.transform import structured
+from lighthouse.dialects import transform_ext
+
+from .builders import schedule_boilerplate
+
+
+def convert_function_results(payload_func: str = None) -> ir.Module:
+    """
+    A schedule that converts the payload function's return values to arguments.
+
+    Args:
+        payload_func: The name of the payload function to convert. If None, all func.func ops will be converted.
+    Returns:
+        Schedule
+    """
+    with schedule_boilerplate(result_types=[transform.any_op_t()]) as (
+        schedule,
+        named_seq,
+    ):
+        matched_func = structured.structured_match(
+            transform.AnyOpType.get(),
+            target=named_seq.bodyTarget,
+            ops={"func.func"},
+            op_attrs={"sym_name": ir.StringAttr.get(payload_func)}
+            if payload_func
+            else None,
+        )
+        new_func = transform_ext.convert_func_results_to_args(matched_func)
+        transform.yield_([new_func])
+
+    schedule.body.operations[0].verify()
+    return schedule

--- a/lighthouse/schedule/func.py
+++ b/lighthouse/schedule/func.py
@@ -15,20 +15,21 @@ def convert_function_results(payload_func: str = None) -> ir.Module:
     Returns:
         Schedule
     """
-    with schedule_boilerplate(result_types=[transform.any_op_t()]) as (
-        schedule,
-        named_seq,
-    ):
-        matched_func = structured.structured_match(
-            transform.AnyOpType.get(),
-            target=named_seq.bodyTarget,
-            ops={"func.func"},
-            op_attrs={"sym_name": ir.StringAttr.get(payload_func)}
-            if payload_func
-            else None,
-        )
-        new_func = transform_ext.convert_func_results_to_args(matched_func)
-        transform.yield_([new_func])
+    with ir.Location.unknown():
+        with schedule_boilerplate(result_types=[transform.any_op_t()]) as (
+            schedule,
+            named_seq,
+        ):
+            matched_func = structured.structured_match(
+                transform.AnyOpType.get(),
+                target=named_seq.bodyTarget,
+                ops={"func.func"},
+                op_attrs={"sym_name": ir.StringAttr.get(payload_func)}
+                if payload_func
+                else None,
+            )
+            new_func = transform_ext.convert_func_results_to_args(matched_func)
+            transform.yield_([new_func])
 
     schedule.body.operations[0].verify()
     return schedule


### PR DESCRIPTION
Adds `convert_func_results_to_args` transform op. 

Function return values are placed in the beginning of the argument list, followed by the original function arguments.

Function arguments are converted to memrefs with appropriate bufferization annotations for inputs (bufferization.to_tensor with restrict=True) and outputs (bufferization.materialize_in_destination).

 Currently supports only functions with tensor arguments and return values.

Example: this payload IR

```mlir
func.func @payload(%arg0: tensor<1024x256xf16>, %arg1: tensor<256x512xf16>) -> tensor<1024x512xf32>
    attributes {llvm.emit_c_interface} {
  %0 = tensor.empty() : tensor<1024x512xf32>
  %cst = arith.constant 0.000000e+00 : f32
  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1024x512xf32>) -> tensor<1024x512xf32>
  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<1024x256xf16>, tensor<256x512xf16>) outs(%1 : tensor<1024x512xf32>)
    -> tensor<1024x512xf32>
  return %2 : tensor<1024x512xf32>
}
```

is converted to

```mlir
func.func @payload(%arg0: memref<1024x512xf32>, %arg1: memref<1024x256xf16>, %arg2: memref<256x512xf16>)
    attributes {llvm.emit_c_interface} {
  %0 = bufferization.to_tensor %arg1 restrict : memref<1024x256xf16> to tensor<1024x256xf16>
  %1 = bufferization.to_tensor %arg2 restrict : memref<256x512xf16> to tensor<256x512xf16>
  %2 = tensor.empty() : tensor<1024x512xf32>
  %cst = arith.constant 0.000000e+00 : f32
  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<1024x512xf32>) -> tensor<1024x512xf32>
  %4 = linalg.matmul ins(%0, %1 : tensor<1024x256xf16>, tensor<256x512xf16>) outs(%3 : tensor<1024x512xf32>)
    -> tensor<1024x512xf32>
  bufferization.materialize_in_destination %4 in restrict writable %arg0 : (tensor<1024x512xf32>, memref<1024x512xf32>)
    -> ()
  return
}
```