### PR TITLE
[transform][x86] Generalize cache tiling transform

### DIFF
--- a/examples/cpu/x86/matmul.py
+++ b/examples/cpu/x86/matmul.py
@@ -167,7 +167,7 @@ class Matmul:
             ops = lh_transform.match_op(named_seq.bodyTarget, gemm_op)
             with lh_transform.foreach(ops) as op:
                 lh_transform_x86.matmul_cache_tiling(
-                    op, num_tiles=6, tile_size=self.tile_size, fuse_producers=True
+                    op, tile_size=self.tile_size, fuse_producers=True
                 )
                 transform.yield_()
             transform.yield_()

--- a/lighthouse/dialects/transform/transform_ext/ops/get_tiling_sizes.py
+++ b/lighthouse/dialects/transform/transform_ext/ops/get_tiling_sizes.py
@@ -160,13 +160,13 @@ def get_tiling_sizes(
     snake_case wrapper to create a GetTilingSizesOp.
 
     Args:
-        target: Handle to target op
-        tile_dim: Optional size used for tile dimensions (default: 32)
+        target: Handle to target op.
+        tile_dim: Optional size used for tile dimensions (default: 32).
     Returns:
-        Created op
+        Handle holding tile size values.
     """
     if isinstance(tile_dim, int):
         param_attr = GetTilingSizesOp.tile_param_attr(tile_dim)
         tile_dim = transform.ParamConstantOp(transform.AnyParamType.get(), param_attr)
 
-    return GetTilingSizesOp(target=target, tile_dim=tile_dim)
+    return GetTilingSizesOp(target=target, tile_dim=tile_dim).result

--- a/lighthouse/transform/x86/cache_tiling.py
+++ b/lighthouse/transform/x86/cache_tiling.py
@@ -1,5 +1,4 @@
 from mlir import ir
-from mlir.dialects import transform
 from mlir.dialects.transform import structured
 
 from lighthouse.dialects.transform import transform_ext
@@ -7,7 +6,6 @@ from lighthouse.dialects.transform import transform_ext
 
 def matmul_cache_tiling(
     target,
-    num_tiles: int,
     tile_size: int = 32,
     fuse_producers: bool = False,
 ) -> tuple[ir.Value, ir.Value]:
@@ -23,30 +21,24 @@ def matmul_cache_tiling(
 
     Args:
         target: Handle to target operation.
-        num_tiles: Number of expected tile handles.
-            Currently, it has to match target op's number of iterators.
-            TODO: Remove when tiling ops accept variadic tiles handle.
         tile_size: Target size for tile dimensions.
         fuse_producers: Apply extra producer ops fusion after tiling.
     Returns:
         Handles to the tiled op and created loop
     """
     tiles = transform_ext.get_tiling_sizes(target, tile_dim=tile_size)
-    tile_sizes = transform.split_handle(
-        results_=[transform.AnyParamType.get()] * num_tiles, handle=tiles
-    )
     if fuse_producers:
         # Tile the target and greedily fuse its producers.
         tiled_op, forall_op = structured.FuseOp(
             target,
-            tile_sizes=tile_sizes,
+            tile_sizes=tiles,
             apply_cleanup=True,
             use_forall=True,
         ).results
     else:
         # Only tile the target.
         tiled_op, forall_op = structured.TileUsingForallOp(
-            target, sizes=tile_sizes
+            target, tile_sizes=tiles
         ).results
     # TODO: Fuse elementwise consumers.
 


### PR DESCRIPTION
Uses the update fuse transform op interface to remove the need for known number of tiles at the transform construction.

This generalization allows to apply the tiling transformation to any variation of supported contraction ops by delaying specific tiling decision to runtime. Particulary, it enables creation of schedules that are less payload-specific.