### PR TITLE
Create Descriptor for all Stage types

### DIFF
--- a/lighthouse/pipeline/descriptor.py
+++ b/lighthouse/pipeline/descriptor.py
@@ -1,14 +1,237 @@
 import yaml
 import os
+import re
 
-from lighthouse.pipeline.helper import remove_args_and_opts, update_filename
+import lighthouse.pipeline.stage as lhs
+
+
+class Descriptor:
+    """
+    A data class to represent a pipeline descriptor, containing:
+    - The basename of the descriptor, for pass/transform identification.
+    - The arguments [] to the transform, if any, in the form of a dictionary.
+    - The options {} to the transform, if any, in the form of a dictionary.
+    - The type of the descriptor, if specified. Can be inferred.
+    - The base_path of the parent descriptor, for resolving includes.
+    """
+
+    search_path = {
+        ".py": "../schedule",
+        ".yaml": "./descriptors",
+    }
+
+    def __init__(
+        self,
+        descriptor: str = "",
+        args: dict = None,
+        opts: dict = None,
+        type: str = None,
+        base_path: str = None,
+    ):
+        self.type = type
+        self.base_path = base_path
+        if descriptor and not args and not opts:
+            self.basename, self.args, self.opts = self._parse_args_and_opts(descriptor)
+        else:
+            self.basename = descriptor
+            self.args = args if args is not None else {}
+            self.opts = opts if opts is not None else {}
+
+        # Normalize the include path if the descriptor is an include or transform
+        if self.is_include() or self.is_transform():
+            self.basename = self._normalize_include_path()
+
+        # If no base_path is passed, set it to the directory of the descriptor.
+        if self.base_path is None and self.basename:
+            self.base_path = os.path.dirname(self.basename)
+
+    def is_pass(self) -> bool:
+        if self.type == "pass":
+            return True
+        if self.type in ("transform", "bundle", "include"):
+            return False
+        # If type not passed
+        pattern = re.compile(r"\.\w+$")
+        if (
+            self.basename
+            and not self.args
+            and not self.opts
+            and self.basename not in lhs.PassBundles
+            and not pattern.search(self.basename)
+        ):
+            self.type = "pass"
+            return True
+        return False
+
+    def is_bundle(self) -> bool:
+        if self.type == "bundle":
+            return True
+        if self.type in ("pass", "transform", "include"):
+            return False
+        # If type not passed
+        if (
+            self.basename
+            and not self.args
+            and not self.opts
+            and self.basename in lhs.PassBundles
+        ):
+            self.type = "bundle"
+            return True
+        return False
+
+    def is_include(self) -> bool:
+        if self.type == "include":
+            return True
+        if self.type in ("pass", "transform", "bundle"):
+            return False
+        # If type not passed
+        if (
+            self.basename
+            and not self.args
+            and not self.opts
+            and self.basename.endswith(".yaml")
+        ):
+            self.type = "include"
+            return True
+        return False
+
+    def is_transform(self) -> bool:
+        if self.type == "transform":
+            return True
+        if self.type in ("pass", "bundle", "include"):
+            return False
+        # If type not passed
+        if self.basename and (
+            self.basename.endswith(".mlir") or self.basename.endswith(".py")
+        ):
+            self.type = "transform"
+            return True
+        return False
+
+    def _normalize_include_path(self) -> str:
+        """
+        Finds the file in some standard locations, in order:
+            * The path of the descriptor file that includes it. This allows for relative includes.
+            * The path of the Lighthouse schedule module, where all the standard pipelines are located.
+        """
+        # If absolute path, check if it exists and return.
+        if os.path.isabs(self.basename):
+            if os.path.exists(self.basename):
+                return self.basename
+            else:
+                raise ValueError(
+                    f"Included pipeline descriptor file does not exist: {self.basename}"
+                )
+
+        # First look in the same directory as the including file, to allow for relative includes.
+        filename = self._remove_args_and_opts(self.basename)
+        if self.base_path and os.path.exists(self.base_path):
+            file = os.path.join(self.base_path, filename)
+            if os.path.exists(file):
+                return file
+
+        # If not found, look for an include path, based on the file extension.
+        file_ext = os.path.splitext(filename)[1]
+        if file_ext not in self.search_path:
+            raise ValueError(
+                f"Included pipeline descriptor file does not exist: {filename} \
+                    (searched in {self.base_path})"
+            )
+
+        # If include path, look in the descriptor/schedule module path.
+        schedule_module_path = os.path.normpath(
+            os.path.join(os.path.dirname(__file__), self.search_path[file_ext])
+        )
+        file = os.path.join(schedule_module_path, filename)
+        if os.path.exists(file):
+            return file
+
+        raise ValueError(
+            f"Included pipeline descriptor file does not exist: {filename} \
+                (searched in {self.base_path} and {schedule_module_path})"
+        )
+
+    def _string_to_type(self, value: str) -> str | int | float | bool:
+        value = str(value)
+        if value == "True":
+            return True
+        elif value == "False":
+            return False
+        try:
+            return int(value)
+        except ValueError:
+            try:
+                return float(value)
+            except ValueError:
+                return value
+
+    def _parse_csv(self, line: str, separator: str = ",") -> dict:
+        line = str(line)
+        result = {}
+        arg_tuples = line.split(separator)
+        for arg in arg_tuples:
+            if not arg:
+                continue
+            if "=" in arg:
+                key, value = arg.split("=")
+                result[key] = self._string_to_type(value)
+            else:
+                result[arg] = True
+        return result
+
+    def _remove_args_and_opts(self, line: str) -> str:
+        line = str(line)
+        if m := re.search(r"^([^[{]*)", line):
+            line = m.group(1)
+        return line
+
+    def _parse_args_and_opts(self, line: str) -> tuple[str, dict, dict]:
+        line = str(line)
+        args = {}
+        options = {}
+
+        # Args: [arg1=val1,args2]
+        if m := re.search(r"\[([^]]*)\]", line):
+            args_str = m.group(1)
+            args = self._parse_csv(args_str, ",")
+
+        # Opts: {arg1=val1 args2}
+        if m := re.search(r"\{([^}]+)\}", line):
+            opts_str = m.group(1)
+            options = self._parse_csv(opts_str, " ")
+
+        # Cleanup the original string
+        line = self._remove_args_and_opts(line)
+
+        return [line, args, options]
+
+    def __str__(self) -> str:
+        """serialize basename + args + opts for transform consumption"""
+        # Arguments have name and value, and are serialized as [name=value,...]
+        args_str = (
+            "[" + ",".join(f"{key}={value}" for key, value in self.args.items()) + "]"
+            if self.args
+            else ""
+        )
+        # Boolean options are serialized without the =True/False
+        opts_str = (
+            "{"
+            + " ".join(
+                f"{key}" if isinstance(value, bool) and value else f"{key}={value}"
+                for key, value in self.opts.items()
+            )
+            + "}"
+            if self.opts
+            else ""
+        )
+        return f"{self.basename}{args_str}{opts_str}"
 
 
 class PipelineDescriptor:
     """
     A descriptor for an optimization pipeline in YAML format.
     This class is responsible for parsing the pipeline description from a YAML file,
-    and keeping a list of stages for comsumption by the Driver.
+    and keeping a list of stages for consumption by the Driver.
 
     The format here is just text. The main job of this class is to handle includes,
     to verify that the files for the stages exist, normalize their paths, etc.
@@ -24,55 +247,20 @@ class PipelineDescriptor:
       ...
     """
 
-    search_path = {
-        ".py": "../schedule",
-        ".yaml": "./descriptors",
-    }
-
-    def __init__(self, filename: str):
-        self.filename = filename
-        with open(filename, "r") as f:
+    def __init__(self, desc: Descriptor):
+        if not isinstance(desc, Descriptor):
+            raise ValueError(
+                f"PipelineDescriptor requires a Descriptor as input, got {type(desc)}"
+            )
+        self.descriptor = desc
+        with open(desc.basename, "r") as f:
             self.pipeline_desc = yaml.safe_load(f)
         self.stages: list[str] = []
         self._parse_stages()
         if not self.stages:
             raise ValueError(
-                f"Pipeline description file {self.filename} does not contain a valid 'Pipeline'."
+                f"Pipeline description file {desc.basename} does not contain a valid 'Pipeline'."
             )
-
-    def _normalize_include_path(self, filename) -> str:
-        """
-        Finds the file in some standard locations, in order:
-            * The path of the descriptor file that includes it. This allows for relative includes.
-            * The path of the Lighthouse schedule module, where all the standard pipelines are located.
-        """
-        # First look in the same directory as the including file, to allow for relative includes.
-        filename = remove_args_and_opts(filename)
-        descriptor_path = os.path.normpath(os.path.dirname(self.filename))
-        file = os.path.join(descriptor_path, filename)
-        if os.path.exists(file):
-            return file
-
-        # If not found, look for an include path, based on the file extension.
-        file_ext = os.path.splitext(file)[1]
-        if file_ext not in self.search_path:
-            raise ValueError(
-                f"Included pipeline descriptor file does not exist: {filename} \
-                    (searched in {descriptor_path})"
-            )
-
-        # If include path, look in the descriptor/schedule module path.
-        schedule_module_path = os.path.normpath(
-            os.path.join(os.path.dirname(__file__), self.search_path[file_ext])
-        )
-        file = os.path.join(schedule_module_path, filename)
-        if os.path.exists(file):
-            return file
-
-        raise ValueError(
-            f"Included pipeline descriptor file does not exist: {filename} \
-                (searched in {descriptor_path} and {schedule_module_path})"
-        )
 
     def _parse_stages(self) -> None:
         """
@@ -81,44 +269,32 @@ class PipelineDescriptor:
         pipeline = self.pipeline_desc["Pipeline"]
         if not pipeline:
             raise ValueError(
-                f"Pipeline description file {self.filename} does not contain a 'Pipeline' key."
+                f"Pipeline description file {self.descriptor.basename} does not contain a 'Pipeline' key."
             )
 
         for stage in pipeline:
-            if "include" in stage:
-                # Includes recurr into the parser and return the stages.
-                self._include_pipeline(stage["include"])
+            key, value = next(iter(stage.items()))
+            desc = Descriptor(value, type=key, base_path=self.descriptor.base_path)
+            if desc.is_include():
+                self._include_pipeline(desc)
 
-            elif "transform" in stage:
-                # Transforms need to be MLIR files, and need to exist.
-                filename = self._normalize_include_path(stage["transform"])
-                if not filename.endswith(".mlir") and not filename.endswith(".py"):
-                    raise ValueError(
-                        f"Transform file must be an MLIR or Python file: {filename}"
-                    )
-                self.stages.append(update_filename(stage["transform"], filename))
+            elif desc.is_transform():
+                self.stages.append(desc)
 
-            elif "pass" in stage:
-                # Passes are just strings, let the pass manager validate.
-                self.stages.append(stage["pass"])
+            elif desc.is_bundle():
+                self.stages.append(desc)
 
-            elif "bundle" in stage:
-                # Bundle needs to exist in the driver, but to avoid cross import
-                # we keep as text here. It's safe, as the stage will check if it exits.
-                # TODO: Add a verification at this stage too.
-                self.stages.append(stage["bundle"])
+            elif desc.is_pass():
+                self.stages.append(desc)
 
             else:
-                raise ValueError(
-                    f"Invalid stage in pipeline description: {stage}. Must be one of 'pass', 'transform', 'bundle' or 'include'."
-                )
+                raise ValueError(f"Invalid stage in pipeline description: {desc}.")
 
-    def _include_pipeline(self, filename: str) -> None:
+    def _include_pipeline(self, desc: Descriptor) -> None:
         """
         Helper function to include another pipeline descriptor file.
         """
-        filename = self._normalize_include_path(filename)
-        included_pipeline = PipelineDescriptor(filename)
+        included_pipeline = PipelineDescriptor(desc)
         self.stages.extend(included_pipeline.get_stages())
 
     def get_stages(self) -> list[str]:

--- a/lighthouse/pipeline/descriptor.py
+++ b/lighthouse/pipeline/descriptor.py
@@ -151,7 +151,8 @@ class Descriptor:
                 (searched in {self.base_path} and {schedule_module_path})"
         )
 
-    def _string_to_type(self, value: str) -> str | int | float | bool:
+    @staticmethod
+    def _string_to_type(value: str) -> str | int | float | bool:
         value = str(value)
         if value == "True":
             return True
@@ -165,7 +166,8 @@ class Descriptor:
             except ValueError:
                 return value
 
-    def _parse_csv(self, line: str, separator: str = ",") -> dict:
+    @staticmethod
+    def _parse_csv(line: str, separator: str = ",") -> dict:
         line = str(line)
         result = {}
         arg_tuples = line.split(separator)
@@ -174,18 +176,20 @@ class Descriptor:
                 continue
             if "=" in arg:
                 key, value = arg.split("=")
-                result[key] = self._string_to_type(value)
+                result[key] = Descriptor._string_to_type(value)
             else:
                 result[arg] = True
         return result
 
-    def _remove_args_and_opts(self, line: str) -> str:
+    @staticmethod
+    def _remove_args_and_opts(line: str) -> str:
         line = str(line)
         if m := re.search(r"^([^[{]*)", line):
             line = m.group(1)
         return line
 
-    def _parse_args_and_opts(self, line: str) -> tuple[str, dict, dict]:
+    @staticmethod
+    def _parse_args_and_opts(line: str) -> tuple[str, dict, dict]:
         line = str(line)
         args = {}
         options = {}
@@ -193,15 +197,15 @@ class Descriptor:
         # Args: [arg1=val1,args2]
         if m := re.search(r"\[([^]]*)\]", line):
             args_str = m.group(1)
-            args = self._parse_csv(args_str, ",")
+            args = Descriptor._parse_csv(args_str, ",")
 
         # Opts: {arg1=val1 args2}
         if m := re.search(r"\{([^}]+)\}", line):
             opts_str = m.group(1)
-            options = self._parse_csv(opts_str, " ")
+            options = Descriptor._parse_csv(opts_str, " ")
 
         # Cleanup the original string
-        line = self._remove_args_and_opts(line)
+        line = Descriptor._remove_args_and_opts(line)
 
         return [line, args, options]
 

--- a/lighthouse/pipeline/driver.py
+++ b/lighthouse/pipeline/driver.py
@@ -2,8 +2,8 @@ import os
 
 from mlir import ir
 import lighthouse.pipeline.stage as lhs
-from lighthouse.pipeline.helper import import_mlir_module, remove_args_and_opts
-from lighthouse.pipeline.descriptor import PipelineDescriptor
+from lighthouse.pipeline.helper import import_mlir_module
+from lighthouse.pipeline.descriptor import PipelineDescriptor, Descriptor
 
 
 class PipelineDriver:
@@ -18,33 +18,65 @@ class PipelineDriver:
     def __init__(self, context: ir.Context):
         self.context = context
         self.stages = []
+        self.bundles = lhs.PassBundles
 
-    def add_pass(self, name: str) -> None:
+    def add_pass(self, stage: Descriptor) -> None:
         # Assume the pass name exists, will crash later if it does not.
-        self.stages.append(lhs.PassStage([lhs.Pass(name)], self.context))
+        self.stages.append(lhs.PassStage([lhs.Pass(stage)], self.context))
 
-    def add_transform(self, stage: str | ir.Module) -> None:
+    def add_transform(self, stage: Descriptor | ir.Module) -> None:
         # Transform will figure out if this is MLIR, Python or Module, and will handle it accordingly.
         if isinstance(stage, ir.Module):
             # This is a transform already in module form. Assume it has been verified already.
             if stage.context != self.context:
                 raise ValueError("Module context does not match driver context.")
             self.stages.append(lhs.TransformStage(stage, self.context))
-        elif isinstance(stage, str):
+        elif isinstance(stage, Descriptor):
             self.stages.append(lhs.TransformStage(lhs.Transform(stage), self.context))
         else:
             raise ValueError(f"Unsupported stage type: {type(stage)}")
 
-    def add_bundle(self, name: str) -> None:
+    def add_bundle(self, stage: Descriptor) -> None:
         # A bundle name that must exist.
-        if name not in lhs.PassBundles:
-            raise ValueError(f"Unknown pass bundle: {name}")
-        self.stages.append(lhs.PassStage(lhs.PassBundles[name], self.context))
+        if stage.basename not in lhs.PassBundles:
+            raise ValueError(f"Unknown pass bundle: {stage.basename}")
+        self.stages.append(lhs.PassStage(lhs.PassBundles[stage.basename], self.context))
 
-    def add_stage(self, stage: lhs.Stage) -> None:
+    def add_stage(self, stage: lhs.Stage | Descriptor) -> None:
         # A generit stage that isn't covered by the existing infrastructure.
         # Users can derive their own classes from Stage and add them to the pipeline with this method.
-        self.stages.append(stage)
+        if isinstance(stage, lhs.Stage):
+            self.stages.append(stage)
+            return
+
+        if not isinstance(stage, Descriptor):
+            raise ValueError(f"Unsupported stage type: {type(stage)}")
+
+        # Stages can contain arguments and options, clean up for os checks
+        filename = stage.basename
+
+        if stage.basename in self.bundles:
+            # Pass Bundle
+            self.add_bundle(stage)
+
+        elif os.path.exists(filename):
+            # Transform or YAML
+            if filename.endswith(".mlir") or filename.endswith(".py"):
+                self.add_transform(stage)
+            elif filename.endswith(".yaml"):
+                self.add_stages(PipelineDescriptor(stage).get_stages())
+            else:
+                _, ext = os.path.splitext(filename)
+                raise ValueError(f"Unknown file type '{ext}' for stage '{stage}'.")
+
+        else:
+            # Assume random strings represent a single pass
+            # Will crash later if the pass name is not registered.
+            self.add_pass(stage)
+
+    def add_stages(self, stages: list[Descriptor]) -> None:
+        for s in stages:
+            self.add_stage(s)
 
     def apply(self, module: ir.Module, print_after_all: bool = False) -> ir.Module:
         if module.context != self.context:
@@ -101,9 +133,8 @@ class CompilerDriver:
             self.import_payload(filename)
         self.pipeline = PipelineDriver(self.context)
         self.pipeline_fixed = False
-        self.bundles = lhs.PassBundles
         if stages:
-            self.add_stages(stages)
+            self.add_stages([Descriptor(s) for s in stages])
 
     def import_payload(self, path: str) -> None:
         """Import the payload module and set it as the current module in the pipeline."""
@@ -111,40 +142,15 @@ class CompilerDriver:
             raise ValueError("Module already imported. Reset to start again.")
         self.module = import_mlir_module(path, self.context)
 
-    def add_stage(self, stage_name: str) -> None:
+    def add_stage(self, stage: str) -> None:
         if self.pipeline_fixed:
             raise ValueError("Pipeline is fixed. Reset to start again.")
-
-        # Stages can contain arguments and options, clean up for os checks
-        filename = remove_args_and_opts(stage_name)
-
-        if stage_name in self.bundles:
-            # Pass Bundle
-            self.pipeline.add_bundle(stage_name)
-
-        elif os.path.exists(filename):
-            # Transform or YAML
-            if filename.endswith(".mlir") or filename.endswith(".py"):
-                self.pipeline.add_transform(stage_name)
-            elif filename.endswith(".yaml"):
-                desc = PipelineDescriptor(stage_name)
-                for s in desc.get_stages():
-                    self.add_stage(s)
-            else:
-                _, ext = os.path.splitext(filename)
-                raise ValueError(f"Unknown file type '{ext}' for stage '{stage_name}'.")
-
-        else:
-            # Assume random strings represent a single pass
-            # Will crash later if the pass name is not registered.
-            self.pipeline.add_pass(stage_name)
+        self.pipeline.add_stage(Descriptor(stage))
 
     def add_stages(self, stages: list[str]) -> None:
-        """
-        Add multiple stages to the pipeline.
-        """
-        for s in stages:
-            self.add_stage(s)
+        if self.pipeline_fixed:
+            raise ValueError("Pipeline is fixed. Reset to start again.")
+        self.pipeline.add_stages([Descriptor(s) for s in stages])
 
     def add_module_stage(self, stage_module: ir.Module) -> None:
         """

--- a/lighthouse/pipeline/helper.py
+++ b/lighthouse/pipeline/helper.py
@@ -1,69 +1,8 @@
 import os
-import re
 
 from mlir import ir
 from mlir.dialects import transform
 from mlir.dialects.transform import structured
-
-
-def convert_string(value: str) -> str | int | float | bool:
-    if value == "True":
-        return True
-    elif value == "False":
-        return False
-    try:
-        return int(value)
-    except ValueError:
-        try:
-            return float(value)
-        except ValueError:
-            return value
-
-
-def parse_csv(line: str, separator: str = ",") -> dict:
-    result = {}
-    arg_tuples = line.split(separator)
-    for arg in arg_tuples:
-        if not arg:
-            continue
-        if "=" in arg:
-            key, value = arg.split("=")
-            result[key] = convert_string(value)
-        else:
-            result[arg] = True
-    return result
-
-
-def remove_args_and_opts(line: str) -> str:
-    if m := re.search(r"^([^[{]*)", line):
-        line = m.group(1)
-    return line
-
-
-def update_filename(line: str, filename: str) -> str:
-    if m := re.search(r"^([^[{]+)(.*)$", line):
-        line = filename + m.group(2)
-    return line
-
-
-def parse_args_and_opts(line: str) -> tuple[str, dict, dict]:
-    args = {}
-    options = {}
-
-    # Args: [arg1=val1,args2]
-    if m := re.search(r"\[([^]]*)\]", line):
-        args_str = m.group(1)
-        args = parse_csv(args_str, ",")
-
-    # Opts: {arg1=val1 args2}
-    if m := re.search(r"\{([^}]+)\}", line):
-        opts_str = m.group(1)
-        options = parse_csv(opts_str, " ")
-
-    # Cleanup the original string
-    line = remove_args_and_opts(line)
-
-    return [line, args, options]
 
 
 def import_mlir_module(path: str, context: ir.Context) -> ir.Module:

--- a/lighthouse/pipeline/stage.py
+++ b/lighthouse/pipeline/stage.py
@@ -7,7 +7,8 @@ import os
 from mlir import ir
 from mlir.passmanager import PassManager
 from mlir.dialects import transform
-from lighthouse.pipeline.helper import import_mlir_module, parse_args_and_opts
+from lighthouse.pipeline.helper import import_mlir_module
+from lighthouse.pipeline.descriptor import Descriptor
 
 
 class Pass:
@@ -17,9 +18,13 @@ class Pass:
     Or used directly with the Transform Schedule by passing the options as a dictionary.
     """
 
-    def __init__(self, name: str, options: dict = {}):
-        self.name = name
-        self.options = options
+    def __init__(self, desc: Descriptor):
+        if not isinstance(desc, Descriptor):
+            raise ValueError(
+                f"Pass must be initialized with a Descriptor, got {type(desc)}"
+            )
+        self.name = desc.basename
+        self.options = desc.opts
 
     def __str__(self) -> str:
         """serialize name + options dictionary for pass manager consumption"""
@@ -39,30 +44,32 @@ PassBundles = {
     # This is self consistent and should be used together.
     "BufferizationBundle": [
         Pass(
-            "one-shot-bufferize",
-            {
-                "function-boundary-type-conversion": "identity-layout-map",
-                "bufferize-function-boundaries": True,
-            },
+            Descriptor(
+                "one-shot-bufferize",
+                opts={
+                    "function-boundary-type-conversion": "identity-layout-map",
+                    "bufferize-function-boundaries": True,
+                },
+            )
         ),
-        Pass("drop-equivalent-buffer-results"),
+        Pass(Descriptor("drop-equivalent-buffer-results")),
         # This last pass only works with the pass manager, not schedules.
-        # Pass("buffer-deallocation-pipeline"),
+        # Pass(Descriptor("buffer-deallocation-pipeline")),
     ],
     # Lowers most dialects to basic control flow.
     "MLIRLoweringBundle": [
-        Pass("convert-linalg-to-loops"),
+        Pass(Descriptor("convert-linalg-to-loops")),
     ],
     # Lowers most dialects to LLVM Dialect
     "LLVMLoweringBundle": [
-        Pass("convert-scf-to-cf"),
-        Pass("convert-to-llvm"),
-        Pass("reconcile-unrealized-casts"),
+        Pass(Descriptor("convert-scf-to-cf")),
+        Pass(Descriptor("convert-to-llvm")),
+        Pass(Descriptor("reconcile-unrealized-casts")),
     ],
     # Canonicalization bundle.
     "CleanupBundle": [
-        Pass("cse"),
-        Pass("canonicalize"),
+        Pass(Descriptor("cse")),
+        Pass(Descriptor("canonicalize")),
     ],
 }
 
@@ -105,23 +112,26 @@ class Transform:
         MLIR = 1
         Python = 2
 
-    def __init__(self, filename: str):
-        # First, eliminate arguments and options
-        filename, args, self.options = parse_args_and_opts(filename)
-        if filename.endswith(".mlir"):
+    def __init__(self, desc: Descriptor):
+        if not isinstance(desc, Descriptor):
+            raise ValueError(
+                f"Transform must be initialized with a Descriptor, got {type(desc)}"
+            )
+        if desc.basename.endswith(".mlir"):
             self.type = Transform.Type.MLIR
-        elif filename.endswith(".py"):
+        elif desc.basename.endswith(".py"):
             self.type = Transform.Type.Python
         else:
-            raise ValueError(f"Unsupported transform file type: {filename}")
-        self.filename = filename
-        self.generator = args["gen"] if "gen" in args else "create_schedule"
-        self.sequence = args["seq"] if "seq" in args else ""
+            raise ValueError(f"Unsupported transform file type: {desc.basename}")
+        self.filename = desc.basename
+        self.options = desc.opts
+        self.generator = desc.args["gen"] if "gen" in desc.args else "create_schedule"
+        self.sequence = desc.args["seq"] if "seq" in desc.args else ""
 
     def __str__(self) -> str:
         """serialize name + filename for debugging purposes"""
         if not self.options:
-            return self.name
+            return self.filename
         return f"{self.filename}{{{self.options}}}"
 
 


### PR DESCRIPTION
This PR modifies the drivers, passes, transforms, stages, etc. to receive a Descriptor object instead of loose strings and dictionaries.

The key main benefit of this is that it centralizes the handling of filenames, arguments, options into one place and avoids having to export internal functions to other modules.

Another main benefit is that it allows Python programs to "construct" stages on the fly, using filenames, arguments and options from their Python data structures directly, without needing to serialize / deserialize strings to match.

Passing the string format to the constructor of Descriptor does the decomposition automatically, so the internal representation is _always_ in Python data structures. This helps when parsing from the command line, to have the same behaviour as when constructing from Python.

This is a big change, but localized in the pipeline module, so no external users should see any difference. This is required for upcoming changes to the `kernel_bench` tool, when we start decomposing the existing CPU and GPU pipelines into a dynamic pipeline.

assisted-by: GitHub Copilot