### PR TITLE
Remove pass bundles in favour of yaml files

### DIFF
--- a/examples/execution/example.py
+++ b/examples/execution/example.py
@@ -18,8 +18,8 @@ from mlir.dialects import transform
 
 from lighthouse import dialects as lh_dialects
 from lighthouse.execution.runner import Runner
-from lighthouse.pipeline.helper import match
-from lighthouse.pipeline.stage import PassBundles, apply_bundle
+from lighthouse.pipeline.helper import apply_registered_pass, match
+from lighthouse.pipeline.stage import apply_bundle
 from lighthouse.pipeline.driver import TransformDriver
 
 
@@ -112,15 +112,15 @@ class ElementwiseSum:
                     op_name="builtin.module",
                     deduplicate=True,
                 )
-                mod = apply_bundle(mod, PassBundles["BufferizationBundle"])
-                mod = apply_bundle(mod, PassBundles["MLIRLoweringBundle"])
-                mod = apply_bundle(mod, PassBundles["CleanupBundle"])
+                mod = apply_bundle(mod, "bufferization.yaml")
+                mod = apply_registered_pass(mod, "convert-linalg-to-loops")
+                mod = apply_bundle(mod, "cleanup.yaml")
 
                 if stop_at_stage == "bufferized":
                     transform.YieldOp()
                     return [schedule_module]
 
-                mod = apply_bundle(mod, PassBundles["LLVMLoweringBundle"])
+                mod = apply_bundle(mod, "llvm_lowering.yaml")
                 transform.YieldOp()
 
         return [

--- a/examples/ingress/torch/compile_model.py
+++ b/examples/ingress/torch/compile_model.py
@@ -8,7 +8,7 @@ from mlir import ir
 from mlir.passmanager import PassManager
 
 from lighthouse.ingress.torch import cpu_backend, TargetDialect
-from lighthouse.pipeline.stage import PassBundles, add_bundle
+from lighthouse.pipeline.stage import add_bundle
 
 
 def lower_to_llvm(module: ir.Module) -> ir.Module:
@@ -32,15 +32,15 @@ def lower_to_llvm(module: ir.Module) -> ir.Module:
     pm.add("func.func(llvm-request-c-wrappers)")
 
     # Bufferize.
-    add_bundle(pm, PassBundles["BufferizationBundle"])
-    add_bundle(pm, PassBundles["CleanupBundle"])
+    add_bundle(pm, "bufferization.yaml")
+    add_bundle(pm, "bufferization_cleanup.yaml")
 
     # Middle-end lowering.
-    add_bundle(pm, PassBundles["MLIRLoweringBundle"])
+    pm.add("convert-linalg-to-loops")
 
     # Lower to LLVM.
-    add_bundle(pm, PassBundles["LLVMLoweringBundle"])
-    add_bundle(pm, PassBundles["CleanupBundle"])
+    add_bundle(pm, "llvm_lowering.yaml")
+    add_bundle(pm, "cleanup.yaml")
 
     # IR is transformed in-place.
     pm.run(module.operation)

--- a/lighthouse/pipeline/descriptor.py
+++ b/lighthouse/pipeline/descriptor.py
@@ -2,8 +2,6 @@ import yaml
 import os
 import re
 
-import lighthouse.pipeline.stage as lhs
-
 
 class Descriptor:
     """
@@ -48,7 +46,7 @@ class Descriptor:
     def is_pass(self) -> bool:
         if self.type == "pass":
             return True
-        if self.type in ("transform", "bundle", "include"):
+        if self.type in ("transform", "include"):
             return False
         # If type not passed
         pattern = re.compile(r"\.\w+$")
@@ -56,33 +54,16 @@ class Descriptor:
             self.basename
             and not self.args
             and not self.opts
-            and self.basename not in lhs.PassBundles
             and not pattern.search(self.basename)
         ):
             self.type = "pass"
             return True
         return False
 
-    def is_bundle(self) -> bool:
-        if self.type == "bundle":
-            return True
-        if self.type in ("pass", "transform", "include"):
-            return False
-        # If type not passed
-        if (
-            self.basename
-            and not self.args
-            and not self.opts
-            and self.basename in lhs.PassBundles
-        ):
-            self.type = "bundle"
-            return True
-        return False
-
     def is_include(self) -> bool:
         if self.type == "include":
             return True
-        if self.type in ("pass", "transform", "bundle"):
+        if self.type in ("pass", "transform"):
             return False
         # If type not passed
         if (
@@ -98,7 +79,7 @@ class Descriptor:
     def is_transform(self) -> bool:
         if self.type == "transform":
             return True
-        if self.type in ("pass", "bundle", "include"):
+        if self.type in ("pass", "include"):
             return False
         # If type not passed
         if self.basename and (
@@ -247,7 +228,6 @@ class PipelineDescriptor:
       - transform: TransformFile.py[gen=generator_name,seq=sequence_name]{opt1=val1 opt2=val2}
       - transform: TransformFile.mlir
       - include: OtherPipeline.yaml
-      - bundle: BundleName
       ...
     """
 
@@ -283,9 +263,6 @@ class PipelineDescriptor:
                 self._include_pipeline(desc)
 
             elif desc.is_transform():
-                self.stages.append(desc)
-
-            elif desc.is_bundle():
                 self.stages.append(desc)
 
             elif desc.is_pass():

--- a/lighthouse/pipeline/descriptors/bufferization.yaml
+++ b/lighthouse/pipeline/descriptors/bufferization.yaml
@@ -2,5 +2,3 @@ Pipeline:
   - pass: "eliminate-empty-tensors"
   - pass: "one-shot-bufferize{function-boundary-type-conversion=identity-layout-map bufferize-function-boundaries}"
   - pass: "drop-equivalent-buffer-results"
-  - pass: "buffer-deallocation-pipeline"
-  - pass: "convert-bufferization-to-memref"

--- a/lighthouse/pipeline/descriptors/bufferization_cleanup.yaml
+++ b/lighthouse/pipeline/descriptors/bufferization_cleanup.yaml
@@ -1,0 +1,5 @@
+Pipeline:
+  - pass: buffer-deallocation-pipeline
+  - pass: convert-bufferization-to-memref
+  - pass: cse
+  - pass: canonicalize

--- a/lighthouse/pipeline/descriptors/llvm_lowering.yaml
+++ b/lighthouse/pipeline/descriptors/llvm_lowering.yaml
@@ -1,5 +1,4 @@
 Pipeline:
-  - pass: "convert-linalg-to-loops"
   - pass: "fold-memref-alias-ops"
   - pass: "expand-strided-metadata"
   - pass: "canonicalize"

--- a/lighthouse/pipeline/driver.py
+++ b/lighthouse/pipeline/driver.py
@@ -18,7 +18,6 @@ class PipelineDriver:
     def __init__(self, context: ir.Context):
         self.context = context
         self.stages = []
-        self.bundles = lhs.PassBundles
 
     def add_pass(self, stage: Descriptor) -> None:
         # Assume the pass name exists, will crash later if it does not.
@@ -36,12 +35,6 @@ class PipelineDriver:
         else:
             raise ValueError(f"Unsupported stage type: {type(stage)}")
 
-    def add_bundle(self, stage: Descriptor) -> None:
-        # A bundle name that must exist.
-        if stage.basename not in lhs.PassBundles:
-            raise ValueError(f"Unknown pass bundle: {stage.basename}")
-        self.stages.append(lhs.PassStage(lhs.PassBundles[stage.basename], self.context))
-
     def add_stage(self, stage: lhs.Stage | Descriptor) -> None:
         # A generit stage that isn't covered by the existing infrastructure.
         # Users can derive their own classes from Stage and add them to the pipeline with this method.
@@ -55,11 +48,7 @@ class PipelineDriver:
         # Stages can contain arguments and options, clean up for os checks
         filename = stage.basename
 
-        if stage.basename in self.bundles:
-            # Pass Bundle
-            self.add_bundle(stage)
-
-        elif os.path.exists(filename):
+        if os.path.exists(filename):
             # Transform or YAML
             if filename.endswith(".mlir") or filename.endswith(".py"):
                 self.add_transform(stage)

--- a/lighthouse/pipeline/stage.py
+++ b/lighthouse/pipeline/stage.py
@@ -8,7 +8,7 @@ from mlir import ir
 from mlir.passmanager import PassManager
 from mlir.dialects import transform
 from lighthouse.pipeline.helper import import_mlir_module
-from lighthouse.pipeline.descriptor import Descriptor
+from lighthouse.pipeline.descriptor import Descriptor, PipelineDescriptor
 
 
 class Pass:
@@ -34,57 +34,27 @@ class Pass:
         return f"{self.name}{{{options_str}}}"
 
 
-# Predefined pass bundles for common transformations.
-# These are not exhaustive and can be extended as needed.
-# The idea is to group together passes that are commonly used together in a pipeline,
-# so that they can be easily added to a PassManager or Transform Schedule with a single function call.
-# FIXME: Deprecate bundles in favor of YAML pipeline descriptors.
-PassBundles = {
-    # All in one bufferization bundle.
-    # This is self consistent and should be used together.
-    "BufferizationBundle": [
-        Pass(
-            Descriptor(
-                "one-shot-bufferize",
-                opts={
-                    "function-boundary-type-conversion": "identity-layout-map",
-                    "bufferize-function-boundaries": True,
-                },
-            )
-        ),
-        Pass(Descriptor("drop-equivalent-buffer-results")),
-        # This last pass only works with the pass manager, not schedules.
-        # Pass(Descriptor("buffer-deallocation-pipeline")),
-    ],
-    # Lowers most dialects to basic control flow.
-    "MLIRLoweringBundle": [
-        Pass(Descriptor("convert-linalg-to-loops")),
-    ],
-    # Lowers most dialects to LLVM Dialect
-    "LLVMLoweringBundle": [
-        Pass(Descriptor("convert-scf-to-cf")),
-        Pass(Descriptor("convert-to-llvm")),
-        Pass(Descriptor("reconcile-unrealized-casts")),
-    ],
-    # Canonicalization bundle.
-    "CleanupBundle": [
-        Pass(Descriptor("cse")),
-        Pass(Descriptor("canonicalize")),
-    ],
-}
-
-
 # Utility function to add a bundle of passes to a PassManager.
-def add_bundle(pm: PassManager, bundle: list[Pass]) -> None:
-    for p in bundle:
-        pm.add(str(p))
+def add_bundle(pm: PassManager, filename: str) -> None:
+    desc = PipelineDescriptor(Descriptor(filename))
+    for p in desc.get_stages():
+        if not isinstance(p, Descriptor) or not p.is_pass():
+            raise ValueError(
+                f"Expected Descriptor of type Pass in bundle, got {type(p)}"
+            )
+        pm.add(str(Pass(p)))
 
 
 # Utility function to add a bundle of passes to a Schedule.
-def apply_bundle(op, bundle: list[Pass], *args, **kwargs) -> None:
-    for p in bundle:
+def apply_bundle(op, filename: str, *args, **kwargs) -> None:
+    desc = PipelineDescriptor(Descriptor(filename))
+    for p in desc.get_stages():
+        if not isinstance(p, Descriptor) or not p.is_pass():
+            raise ValueError(
+                f"Expected Descriptor of type Pass in bundle, got {type(p)}"
+            )
         op = transform.apply_registered_pass(
-            transform.AnyOpType.get(), op, p.name, options=p.options, *args, **kwargs
+            transform.AnyOpType.get(), op, p.basename, options=p.opts, *args, **kwargs
         )
     return op
 
@@ -158,7 +128,8 @@ class PassStage(Stage):
         self.context = context
         self.pm = PassManager("builtin.module", self.context)
         self.passes = passes
-        add_bundle(self.pm, passes)
+        for p in passes:
+            self.pm.add(str(p))
 
     def apply(self, module: ir.Module) -> ir.Module:
         if module is None:

--- a/test/opt/pipeline-check.mlir
+++ b/test/opt/pipeline-check.mlir
@@ -1,6 +1,3 @@
-// RUN: lh-opt --stage=BufferizationBundle %s | FileCheck %s --check-prefixes=BUFFERIZED
-// RUN: lh-opt --stage=BufferizationBundle --stage=canonicalize --stage=MLIRLoweringBundle %s | FileCheck %s --check-prefixes=LINALG_LOWERED
-// RUN: lh-opt --stage=BufferizationBundle --stage=canonicalize --stage=MLIRLoweringBundle --stage=canonicalize --stage=LLVMLoweringBundle %s | FileCheck %s --check-prefixes=LLVM_LOWERED
 // RUN: lh-opt --stage=%TEST/opt/transforms/pipeline-check.mlir %s | FileCheck %s --check-prefixes=LLVM_LOWERED
 // RUN: lh-opt --stage=%TEST/opt/stages/pipeline-check.yaml %s | FileCheck %s --check-prefixes=LLVM_LOWERED
 // RUN: lh-opt --stage=%TEST/opt/stages/my-transform.yaml %s | FileCheck %s --check-prefixes=LLVM_LOWERED

--- a/test/opt/stages/pipeline-check.yaml
+++ b/test/opt/stages/pipeline-check.yaml
@@ -1,9 +1,10 @@
 Pipeline:
   - include: bufferization.yaml
+  - include: bufferization_cleanup.yaml
   - include: cleanup.yaml
   - transform: linalg.py[gen=linalg_contract_fold_unit_dims]
-  - bundle: MLIRLoweringBundle
-  - bundle: CleanupBundle
+  - pass: convert-linalg-to-loops
+  - include: cleanup.yaml
   - transform: x86/tile_and_vector_matmul.py
-  - bundle: LLVMLoweringBundle
+  - include: llvm_lowering.yaml
   - pass: canonicalize

--- a/test/opt/transforms/pipeline-check.py
+++ b/test/opt/transforms/pipeline-check.py
@@ -1,7 +1,7 @@
 from mlir import ir
 from mlir.dialects import transform
-from lighthouse.pipeline.helper import match
-from lighthouse.pipeline.stage import PassBundles, apply_bundle
+from lighthouse.pipeline.helper import apply_registered_pass, match
+from lighthouse.pipeline.stage import apply_bundle
 
 
 def create_schedule(options: dict = {}) -> ir.Module:
@@ -27,12 +27,13 @@ def create_schedule(options: dict = {}) -> ir.Module:
                 op_name="builtin.module",
                 deduplicate=True,
             )
-            mod = apply_bundle(mod, PassBundles["BufferizationBundle"])
-            mod = apply_bundle(mod, PassBundles["MLIRLoweringBundle"])
-            mod = apply_bundle(mod, PassBundles["CleanupBundle"])
+            mod = apply_bundle(mod, "bufferization.yaml")
+            mod = apply_bundle(mod, "bufferization_cleanup.yaml")
+            mod = apply_registered_pass(mod, "convert-linalg-to-loops")
+            mod = apply_bundle(mod, "cleanup.yaml")
 
             if not options.get("skip_llvm", False):
-                mod = apply_bundle(mod, PassBundles["LLVMLoweringBundle"])
+                mod = apply_bundle(mod, "llvm_lowering.yaml")
             transform.YieldOp()
 
     return schedule_module

--- a/tools/kernel_bench.yaml
+++ b/tools/kernel_bench.yaml
@@ -2,4 +2,5 @@
 # For optimized builds, pass the --pipeline to the kernel_bench program.
 Pipeline:
   - include: bufferization.yaml
+  - pass: convert-linalg-to-loops
   - include: llvm_lowering.yaml

--- a/tools/lh-run
+++ b/tools/lh-run
@@ -6,27 +6,9 @@ import numpy as np
 
 from lighthouse.execution.runner import Runner
 from lighthouse.execution.init import KernelArgumentParser
+from lighthouse.pipeline.descriptor import Descriptor
 from lighthouse.pipeline.driver import CompilerDriver
 from lighthouse import dialects as lh_dialects
-
-
-def add_lower_to_llvm_stages() -> list[str]:
-    """
-    Adds the LLVM lowering passes to guarantee the IR can be ingested by the ExecutionEngine.
-    """
-    stages = [
-        "convert-linalg-to-loops",
-        "fold-memref-alias-ops",
-        "expand-strided-metadata",
-        "canonicalize",
-        "convert-vector-to-scf",
-        "lower-affine",
-        "convert-scf-to-cf",
-        "convert-vector-to-llvm",
-        "convert-to-llvm",
-        "reconcile-unrealized-casts",
-    ]
-    return stages
 
 
 if __name__ == "__main__":
@@ -118,7 +100,8 @@ if __name__ == "__main__":
     driver.add_stages(args.stage)
 
     # Add the necessary LLVM lowering stages to ensure the module can be executed by the ExecutionEngine.
-    driver.add_stages(add_lower_to_llvm_stages())
+    driver.add_stage(Descriptor("convert-linalg-to-loops"))
+    driver.add_stage(Descriptor("llvm_lowering.yaml"))
 
     # Run the pipeline to get the optimized module.
     optimized_module = driver.run(print_after_all=args.print_mlir_after_all)


### PR DESCRIPTION
Pass bundles were added as a quick hack to help create pipelines, but it was not flexible enough (change main module). Descriptor files are very easy to replace/change/create, and we already have a small library of them inside Lighthouse that replace the old bundles.

With the new Descriptor class, anyone can use yaml files from Python, resolving the include path in the same way, so it becomes very easy to mix and match them into existing pipelines.

This also reinforces the serialization code that goes through the helper functions, and allows us to move the existing examples (CPU, GPU) to move to use PipelineDriver and PipelineDescriptors for everything (in due time).