### PR TITLE
[testing] Detect host arch

### DIFF
--- a/examples/cpu/x86/matmul.py
+++ b/examples/cpu/x86/matmul.py
@@ -1,11 +1,19 @@
 # RUN: %PYTHON %s --dump-kernel=vectorized | FileCheck %s
 # RUN: %PYTHON %s --dump-kernel=vectorized --tile-size=64 | FileCheck %s
 # RUN: %PYTHON %s --dump-kernel=vectorized --dtype=bf16 --avx512 | FileCheck %s --check-prefix=AVX512
+# RUN: %PYTHON %s --nwarmup 0 --nruns 1 --sizes 128 128 128 | FileCheck %s --check-prefix=BENCH
+
+# REQUIRES: x86
 
 # CHECK: vector.broadcast
 # CHECK: vector.fma
 
 # AVX512: x86.avx512.dot
+
+# BENCH: MxNxK: [128, 128, 128]
+# BENCH: Input dtype: f32
+# BENCH: Timings
+# BENCH: Throughput
 
 """
 Matrix multiplication C = A * B on CPU.

--- a/lit.cfg.py
+++ b/lit.cfg.py
@@ -70,7 +70,7 @@ if os.path.isdir(torch_kernels_dir):
 
 # Detect host architecture.
 arch = platform.machine().lower()
-if arch in ["x86_64", "amd64", "i386", "i686"]:
+if arch in ["x86_64", "amd64"]:
     config.available_features.add("x86")
-elif arch in ["arm", "armv6l", "armv7l", "arm64", "aarch64"]:
+elif arch in ["arm64", "aarch64"]:
     config.available_features.add("arm")

--- a/lit.cfg.py
+++ b/lit.cfg.py
@@ -2,6 +2,7 @@ import os
 import shlex
 import importlib.util
 import shutil
+import platform
 
 import lit.formats
 from lit.TestingConfig import TestingConfig
@@ -66,3 +67,10 @@ for pkg in ["torch", "mpi4py", "mpich", "impi-rt"]:
 torch_kernels_dir = project_root + "/third_party/KernelBench/KernelBench"
 if os.path.isdir(torch_kernels_dir):
     config.available_features.add("kernel_bench")
+
+# Detect host architecture.
+arch = platform.machine().lower()
+if arch in ["x86_64", "amd64", "i386", "i686"]:
+    config.available_features.add("x86")
+elif arch in ["arm", "armv6l", "armv7l", "arm64", "aarch64"]:
+    config.available_features.add("arm")

--- a/precommit.sh
+++ b/precommit.sh
@@ -7,5 +7,10 @@
 
 set -ex
 
+# Certain tests may require a larger stack size.
+# Setting it here to a minimum expected to avoid cryptic
+# runtime errors during test execution.
+ulimit -s 16384
+
 uv run pre-commit run --all-files
 uv run lit -v .


### PR DESCRIPTION
Extends lit config to detect host architecture.
Currently supported: 'x86' and 'arm'.

Sets up x86 matmul test to run only when its corresponding host is available.

Assisted-by: Copilot