### PR TITLE
[gpu] Relax buffer dim constraint in GPUMemoryManager

### DIFF
--- a/lighthouse/execution/memory_manager.py
+++ b/lighthouse/execution/memory_manager.py
@@ -85,7 +85,6 @@ class GPUMemoryManager(DeviceMemoryManager):
         ptr_mref = memref_to_ctype(mref)
         ptr_dims = [ctypes.pointer(ctypes.c_int32(d)) for d in shape]
         rank = len(shape)
-        assert rank in (1, 2), "Only 1d or 2d arrays are supported."
         suffix = f"{rank}d_{str(elem_type)}"
         self.execution_engine.invoke("gpu_alloc_" + suffix, ptr_mref, *ptr_dims)
 


### PR DESCRIPTION
GPU memory alloc/dealloc/copy helper functions are already generic n-d so the assertion can just be removed.

Addresses #147.