### PR TITLE
[KB] Update level1 & level2 status

### DIFF
--- a/examples/end-to-end/KernelBench/level1.yaml
+++ b/examples/end-to-end/KernelBench/level1.yaml
@@ -85,7 +85,7 @@
   initializations: [rnd, rnd]
   output_shape: 4096x4096
   dtypes: [f32, bf16]
-  warning: "error: failed to legalize operation torch.operator that was explicitly marked illegal"
+  warning: "error: failed to legalize operation 'torch.operator' that was explicitly marked illegal"
 
 - kernel: level1/13_Matmul_for_symmetric_matrices.py
   input_shapes: [4096x4096, 4096x4096]
@@ -190,7 +190,6 @@
   output_shape: 4096x393216
   dtypes: [f32, bf16]
   gflops: (4096 * 393216) / 1e9
-  warning: "missing `LLVMTranslationDialectInterface` registration for dialect for op: 'math.erf'"
 
 - kernel: level1/27_SELU_.py
   input_shapes: [4096x393216]

--- a/examples/end-to-end/KernelBench/level2.yaml
+++ b/examples/end-to-end/KernelBench/level2.yaml
@@ -15,7 +15,6 @@
   initializations: [rnd]
   output_shape: 32x64x16x32x32
   dtypes: [f32, bf16]
-  warning: "missing `LLVMTranslationDialectInterface` registration for dialect for op: math.erf"
 
 - kernel: level2/4_Conv2d_Mish_Mish.py
   input_shapes: [64x64x256x256]
@@ -40,7 +39,6 @@
   initializations: [rnd]
   output_shape: 64x32x30x62x62
   dtypes: [f32, bf16]
-  warning: "missing `LLVMTranslationDialectInterface` registration for dialect for op: math.erf"
 
 - kernel: level2/8_Conv3d_Divide_Max_GlobalAvgPool_BiasAdd_Sum.py
   input_shapes: [128x8x16x64x64]
@@ -65,6 +63,7 @@
   initializations: [rnd]
   output_shape: 512x128x17x17
   dtypes: [f32, bf16]
+  warning: "Segmentation fault"
 
 - kernel: level2/12_Gemm_Multiply_LeakyReLU.py
   input_shapes: [1024x8192]
@@ -89,6 +88,7 @@
   initializations: [rnd]
   output_shape: 16x32x31x63x63
   dtypes: [f32, bf16]
+  warning: "Segmentation fault"
 
 - kernel: level2/16_ConvTranspose2d_Mish_Add_Hardtanh_Scaling.py
   input_shapes: [128x64x128x128]
@@ -101,20 +101,20 @@
   initializations: [rnd]
   output_shape: 128x128x126x126
   dtypes: [f32, bf16]
+  warning: "LLVM ERROR: SmallVector unable to grow (93TB! > 4GB)"
 
 - kernel: level2/18_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x1
   dtypes: [f32, bf16]
-  warning: "'ERROR: torch_mlir.compiler_utils.TorchMlirCompilerError: Lowering TorchFX IR -> Torch Backend IR failed with the following diagnostics: python exception: Failure while executing pass pipeline'"
+  warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/19_ConvTranspose2d_GELU_GroupNorm.py
   input_shapes: [128x64x256x256]
   initializations: [rnd]
   output_shape: 128x64x258x258
   dtypes: [f32, bf16]
-  warning: "missing `LLVMTranslationDialectInterface` registration for dialect for op: math.erf"
 
 - kernel: level2/20_ConvTranspose3d_Sum_ResidualAdd_Multiply_ResidualAdd.py
   input_shapes: [16x32x16x32x32]
@@ -133,7 +133,7 @@
   initializations: [rnd]
   output_shape: 1024x1
   dtypes: [f32, bf16]
-  warning: "'ERROR: torch_mlir.compiler_utils.TorchMlirCompilerError: failed to legalize operation torch.constant.bool'"
+  warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/23_Conv3d_GroupNorm_Mean.py
   input_shapes: [128x3x24x32x32]
@@ -170,6 +170,7 @@
   initializations: [rnd, rnd]
   output_shape: 1024x8192
   dtypes: [f32, bf16]
+  warning: "LLVM ERROR: SmallVector unable to grow (93TB! > 4GB) + Input size at dim=1 does not match num_features"
 
 - kernel: level2/29_Matmul_Mish_Mish.py
   input_shapes: [1024x8192]
@@ -200,13 +201,13 @@
   initializations: [rnd]
   output_shape: 1024x8192
   dtypes: [f32, bf16]
+  warning: "Segmentation fault"
 
 - kernel: level2/34_ConvTranspose3d_LayerNorm_GELU_Scaling.py
   input_shapes: [32x32x16x32x32]
   initializations: [rnd]
   output_shape: 32x64x32x64x64
   dtypes: [f32, bf16]
-  warning: "missing `LLVMTranslationDialectInterface` registration for dialect for op: math.erf"
 
 - kernel: level2/35_Conv2d_Subtract_HardSwish_MaxPool_Mish.py
   input_shapes: [128x64x128x128]
@@ -219,7 +220,6 @@
   initializations: [rnd]
   output_shape: 16x1x1x256
   dtypes: [f32, bf16]
-  warning: "missing `LLVMTranslationDialectInterface` registration for dialect for op: math.erf"
 
 - kernel: level2/37_Matmul_Swish_Sum_GroupNorm.py
   input_shapes: [32768x1024]
@@ -238,6 +238,7 @@
   initializations: [rnd]
   output_shape: 16384x4096
   dtypes: [f32, bf16]
+  warning: "Segmentation fault"
 
 - kernel: level2/40_Matmul_Scaling_ResidualAdd.py
   input_shapes: [16384x4096]
@@ -250,21 +251,20 @@
   initializations: [rnd]
   output_shape: 16384x4096
   dtypes: [f32, bf16]
-  warning: "missing `LLVMTranslationDialectInterface` registration for dialect for op: math.erf"
 
 - kernel: level2/42_ConvTranspose2d_GlobalAvgPool_BiasAdd_LogSumExp_Sum_Multiply.py
   input_shapes: [16x64x512x512]
   initializations: [rnd]
   output_shape: 16x1
   dtypes: [f32, bf16]
-  warning: "error: failed to legalize operation torch.constant.bool"
+  warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/43_Conv3d_Max_LogSumExp_ReLU.py
   input_shapes: [4x32x32x128x128]
   initializations: [rnd]
   output_shape: 4x1x16x64x64
   dtypes: [f32, bf16]
-  warning: "error: failed to legalize operation torch.constant.bool"
+  warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/44_ConvTranspose2d_Multiply_GlobalAvgPool_GlobalAvgPool_Mean.py
   input_shapes: [16x64x128x128]
@@ -277,7 +277,7 @@
   initializations: [rnd]
   output_shape: 16384
   dtypes: [f32, bf16]
-  warning: "'ERROR: torch_mlir.compiler_utils.TorchMlirCompilerError: failed to legalize operation torch.constant.bool'"
+  warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/46_Conv2d_Subtract_Tanh_Subtract_AvgPool.py
   input_shapes: [128x64x128x128]
@@ -314,15 +314,14 @@
   initializations: [rnd]
   output_shape: 2048x8192
   dtypes: [f32, bf16]
-  warning: "'ERROR: torch_mlir.compiler_utils.TorchMlirCompilerError: Lowering TorchFX IR -> Torch Backend IR failed with the following diagnostics: python exception: Failure while executing pass pipeline'"
+  warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/52_Conv2d_Activation_BatchNorm.py
   input_shapes: [64x64x128x128]
   initializations: [rnd]
   output_shape: 64x128x126x126
   dtypes: [f32, bf16]
-  warning: '''ERROR: torch_mlir.compiler_utils.TorchMlirCompilerError:
-              error: failed to legalize operation torch.operator that was explicitly marked illegal'''
+  warning: "error: failed to legalize operation 'torch.operator' that was explicitly marked illegal"
 
 - kernel: level2/53_Gemm_Scaling_Hardtanh_GELU.py
   input_shapes: [2048x8192]
@@ -335,21 +334,18 @@
   initializations: [rnd]
   output_shape: 64x64x254x254
   dtypes: [f32, bf16]
-  warning: "missing `LLVMTranslationDialectInterface` registration for dialect for op: math.erf"
 
 - kernel: level2/55_Matmul_MaxPool_Sum_Scale.py
   input_shapes: [128x32768]
   initializations: [rnd]
   output_shape: 128
   dtypes: [f32, bf16]
-  warning: 'Execution just fails, return code -9, no errors reported.'
 
 - kernel: level2/56_Matmul_Sigmoid_Sum.py
   input_shapes: [128x32768]
   initializations: [rnd]
   output_shape: 128x1
   dtypes: [f32, bf16]
-  warning: 'Execution just fails, return code -9, no errors reported.'
 
 - kernel: level2/57_Conv2d_ReLU_HardSwish.py
   input_shapes: [128x8x128x128]
@@ -362,14 +358,13 @@
   initializations: [rnd]
   output_shape: 128x1x31x63x63
   dtypes: [f32, bf16]
-  warning: "'ERROR: torch_mlir.compiler_utils.TorchMlirCompilerError: failed to legalize operation torch.constant.bool'"
+  warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/59_Matmul_Swish_Scaling.py
   input_shapes: [128x32768]
   initializations: [rnd]
   output_shape: 128x32768
   dtypes: [f32, bf16]
-  warning: 'Execution just fails, return code -9, no errors reported.'
 
 - kernel: level2/60_ConvTranspose3d_Swish_GroupNorm_HardSwish.py
   input_shapes: [128x3x16x32x32]
@@ -400,7 +395,7 @@
   initializations: [rnd]
   output_shape: 1024x1
   dtypes: [f32, bf16]
-  warning: "'ERROR: torch_mlir.compiler_utils.TorchMlirCompilerError: failed to legalize operation torch.constant.bool'"
+  warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/65_Conv2d_AvgPool_Sigmoid_Sum.py
   input_shapes: [128x8x384x384]
@@ -413,7 +408,6 @@
   initializations: [rnd]
   output_shape: 128x16384
   dtypes: [f32, bf16]
-  warning: "Compiles, but doesn't seem to terminate"
 
 - kernel: level2/67_Conv2d_GELU_GlobalAvgPool.py
   input_shapes: [128x8x256x256]
@@ -426,7 +420,6 @@
   initializations: [rnd]
   output_shape: 128x16384
   dtypes: [f32, bf16]
-  warning: "Compiles, but doesn't seem to terminate"
 
 - kernel: level2/69_Conv2d_HardSwish_ReLU.py
   input_shapes: [128x8x128x128]
@@ -451,12 +444,14 @@
   initializations: [rnd]
   output_shape: 64x16x15x15x15
   dtypes: [f32, bf16]
+  warning: "Segmentation fault"
 
 - kernel: level2/73_Conv2d_BatchNorm_Scaling.py
   input_shapes: [128x8x128x128]
   initializations: [rnd]
   output_shape: 128x64x126x126
   dtypes: [f32, bf16]
+  warning: "Segmentation fault"
 
 - kernel: level2/74_ConvTranspose3d_LeakyReLU_Multiply_LeakyReLU_Max.py
   input_shapes: [16x16x16x32x32]
@@ -481,6 +476,7 @@
   initializations: [rnd]
   output_shape: 16x128x1x1x1
   dtypes: [f32, bf16]
+  warning: "Segmentation fault"
 
 - kernel: level2/78_ConvTranspose3d_Max_Max_Sum.py
   input_shapes: [16x32x32x32x32]
@@ -493,6 +489,7 @@
   initializations: [rnd]
   output_shape: 128x14x30x30
   dtypes: [f32, bf16]
+  warning: "LLVM ERROR: SmallVector unable to grow (93TB! > 4GB)"
 
 - kernel: level2/80_Gemm_Max_Subtract_GELU.py
   input_shapes: [1024x8192]
@@ -523,6 +520,7 @@
   initializations: [rnd]
   output_shape: 1024x8192
   dtypes: [f32, bf16]
+  warning: "Segmentation fault"
 
 - kernel: level2/85_Conv2d_GroupNorm_Scale_MaxPool_Clamp.py
   input_shapes: [128x8x128x128]
@@ -571,6 +569,7 @@
   initializations: [rnd]
   output_shape: 128x1x126x126
   dtypes: [f32, bf16]
+  warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/93_ConvTranspose2d_Add_Min_GELU_Multiply.py
   input_shapes: [128x64x64x64]
@@ -601,6 +600,7 @@
   initializations: [rnd]
   output_shape: 1024x8192
   dtypes: [f32, bf16]
+  warning: "Segmentation fault"
 
 - kernel: level2/98_Matmul_AvgPool_GELU_Scale_Max.py
   input_shapes: [1024x8192]

--- a/lighthouse/pipeline/descriptors/llvm_lowering.yaml
+++ b/lighthouse/pipeline/descriptors/llvm_lowering.yaml
@@ -6,5 +6,7 @@ Pipeline:
   - pass: "lower-affine"
   - pass: "convert-scf-to-cf"
   - pass: "convert-vector-to-llvm"
+  - pass: "convert-math-to-llvm"
+  - pass: "convert-math-to-libm"
   - pass: "convert-to-llvm"
   - pass: "reconcile-unrealized-casts"


### PR DESCRIPTION
Also fixed the math.erf issue with convert-math-to-libm after convert-math-to-llvm to make sure we only apply to those that can't be lowered directly to intrinsics.

Ongoing efforts to #142