### PR TITLE
[KB] Quality of life changes to test / kernel_bench

### DIFF
--- a/examples/end-to-end/KernelBench/test_kernel_bench.py
+++ b/examples/end-to-end/KernelBench/test_kernel_bench.py
@@ -56,8 +56,8 @@ def get_tests(args: argparse.Namespace) -> list[dict]:
 
     test_list = []
     for test in tests:
-        # If a specific test is specified, only include that test
-        if args.test and not test["kernel"].startswith(args.test):
+        # If a specific kernel is specified, only include that kernel
+        if args.kernel and not test["kernel"].startswith(args.kernel):
             continue
         # CI mode runs fewer tests for faster feedback
         if args.ci and len(test_list) >= 5:
@@ -122,14 +122,9 @@ if __name__ == "__main__":
         help="Enable TorchScript compilation. Default is False.",
     )
     Parser.add_argument(
-        "--test",
+        "--kernel",
         type=str,
-        help="Specify a particular test to run.",
-    )
-    Parser.add_argument(
-        "--print-output",
-        action=argparse.BooleanOptionalAction,
-        help="Whether to print the output of the kernel. Default is False.",
+        help="Specify a particular kernel to run.",
     )
     Parser.add_argument(
         "--print-mlir-after-all",
@@ -141,7 +136,7 @@ if __name__ == "__main__":
         action=argparse.BooleanOptionalAction,
         help="Runs every kernel with loops lowering to pipe clean.",
     )
-    args = Parser.parse_args()
+    args, unknown_args = Parser.parse_known_args()
     if args.smoke_test and args.ci:
         print("\nERROR: Smoke test and CI mode are incompatible.\n")
         Parser.print_help()
@@ -149,9 +144,9 @@ if __name__ == "__main__":
 
     tests = get_tests(args)
     if len(tests) == 0:
-        if args.test:
+        if args.kernel:
             print(
-                f"No tests found matching '{args.test}'. Please check your arguments."
+                f"No tests found matching '{args.kernel}'. Please check your arguments."
             )
         else:
             print("No tests to run. Please check your arguments.")
@@ -164,18 +159,21 @@ if __name__ == "__main__":
             str(kb_kernel),
             "--pipeline",
             test["pipeline"],
-            "--seed=42",
         ]
         # Benchmarks only if there's data to calculate FLOPS.
         benchmark = args.benchmark and test.get("gflops") is not None
         if benchmark:
             command_line += ["--benchmark"]
+        elif args.benchmark:
+            print(
+                f"WARNING: Benchmarking enabled but no GFLOPS data for kernel {test['kernel']}."
+                f" Skipping benchmark."
+            )
 
         # We allow torch.compile to pick its own shapes (unless it's CI).
+        # TODO: Implement auto-shapes for non-compile mode as well.
         if args.torch_compile:
             command_line += ["--torch-compile"]
-
-        # TODO: Implement auto-shapes for non-compile mode as well.
         if args.ci or not args.torch_compile:
             command_line += [
                 "--input-shapes",
@@ -184,13 +182,13 @@ if __name__ == "__main__":
                 test["output_shape"],
             ]
 
-        # Smoke tests / CI don't print outputs.
-        if args.print_output:
-            command_line += ["--print-output"]
-
         # For debugging, prefer not to capture output.
         if args.print_mlir_after_all:
             command_line += ["--print-mlir-after-all"]
+
+        # If any extra args are provided, add them to the command line.
+        if unknown_args:
+            command_line += unknown_args
 
         # Print out before we run the test.
         if test.get("warning"):

--- a/tools/kernel_bench
+++ b/tools/kernel_bench
@@ -148,7 +148,7 @@ def parse_inputs_and_outputs(
     return buffers, sample_tensors
 
 
-def torch_compile(args, buffers: list, sample_tensors: list):
+def torch_compile(args, model: torch.nn.Module, sample_tensors: list):
     """
     Compiles the model using torch.compile with a custom MLIR backend.
     """
@@ -301,6 +301,12 @@ if __name__ == "__main__":
         help="Whether to run the benchmark. Default is False.",
     )
     Parser.add_argument(
+        "--validate",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Whether to run the validation. Default is True.",
+    )
+    Parser.add_argument(
         "--torch-compile",
         action=argparse.BooleanOptionalAction,
         help="Whether to use TorchScript compilation. Default is False.",
@@ -355,9 +361,10 @@ if __name__ == "__main__":
     model, sample_args, sample_kwargs = import_torch(
         args.kernel_bench_model, sample_args=sample_tensors
     )
-    out_ref = model(*sample_args, **sample_kwargs)
-    if args.print_output:
-        print(f"Reference output:\n{out_ref}")
+    if args.validate:
+        out_ref = model(*sample_args, **sample_kwargs)
+        if args.print_output:
+            print(f"Reference output:\n{out_ref}")
 
     # Now run the MLIR compiler on either imported or Dynamo plugin
     if sample_tensors is None:
@@ -369,17 +376,19 @@ if __name__ == "__main__":
 
     # Optionally print the output tensors after execution.
     if args.print_output:
-        print(f"MLIR Output:\n{out}")
+        print(f"Output:\n{out}")
 
     # Compare the outputs
-    match, tol = compare_outputs(
-        out_ref, out, tolerance=args.tolerance, max_tolerance=args.max_tolerance
-    )
-    if not match:
-        raise RuntimeError(
-            f"The output of the compiled model does't match the reference output.\n"
-            f"Tolerance requested: [{args.tolerance}, {args.max_tolerance}], got at or beyond: {tol}"
+    if args.validate:
+        match, tol = compare_outputs(
+            out_ref, out, tolerance=args.tolerance, max_tolerance=args.max_tolerance
         )
+        if not match:
+            raise RuntimeError(
+                f"The output of the compiled model does't match the reference output.\n"
+                f"Tolerance requested: [{args.tolerance}, {args.max_tolerance}],\n"
+                f"Got at or beyond: {tol}"
+            )
 
-    print("Success: The output of the compiled model matches the reference output.")
-    print(f"Tolerance: {tol}")
+        print("Success: The output of the compiled model matches the reference output.")
+        print(f"Tolerance: {tol}")


### PR DESCRIPTION
* Cleanup on unused args in torch_compile
* New flag `validate` to skip eager run on IR investigations
* Passing unknown test_kernel_bench args to kernel_bench
* Rename --test to --kernel
* Remove random seed to increase coverage in CI
* Warning when --benchmark is selected but no flops given