### PR TITLE
[KB] Fix "Float did not match Long"

### DIFF
--- a/examples/end-to-end/KernelBench/level1.yaml
+++ b/examples/end-to-end/KernelBench/level1.yaml
@@ -234,12 +234,11 @@
   gflops: (4096 * 393216) / 1e9
 
 - kernel: level1/33_BatchNorm.py
-  input_shapes: [64x64x512x512]
+  input_shapes: [64x64x32x32]
   initializations: [rnd]
-  output_shape: 64x64x512x512
+  output_shape: 64x64x32x32
   dtypes: [f32, bf16]
-  gflops: (64 * 64 * 512 * 512) / 1e9
-  warning: "Segmentation fault"
+  gflops: (64 * 64 * 32 * 32) / 1e9
 
 - kernel: level1/34_InstanceNorm.py
   input_shapes: [112x64x512x512]
@@ -366,7 +365,6 @@
   output_shape: 128x4095
   dtypes: [f32, bf16]
   gflops: (128 * 4096 * 4095) / 1e9
-  warning: "Segmentation fault"
 
 - kernel: level1/52_Argmin_over_a_dimension.py
   input_shapes: [128x4096x4095]
@@ -374,7 +372,6 @@
   output_shape: 128x4095
   dtypes: [f32, bf16]
   gflops: (128 * 4096 * 4095) / 1e9
-  warning: "Segmentation fault"
 
 - kernel: level1/53_Min_reduction_over_a_dimension.py
   input_shapes: [128x4096x4095]

--- a/examples/end-to-end/KernelBench/level2.yaml
+++ b/examples/end-to-end/KernelBench/level2.yaml
@@ -59,11 +59,10 @@
   dtypes: [f32, bf16]
 
 - kernel: level2/11_ConvTranspose2d_BatchNorm_Tanh_MaxPool_GroupNorm.py
-  input_shapes: [512x64x32x32]
+  input_shapes: [8x64x32x32]
   initializations: [rnd]
-  output_shape: 512x128x17x17
+  output_shape: 8x128x17x17
   dtypes: [f32, bf16]
-  warning: "Segmentation fault"
 
 - kernel: level2/12_Gemm_Multiply_LeakyReLU.py
   input_shapes: [1024x8192]
@@ -84,11 +83,10 @@
   dtypes: [f32, bf16]
 
 - kernel: level2/15_ConvTranspose3d_BatchNorm_Subtract.py
-  input_shapes: [16x16x16x32x32]
+  input_shapes: [4x16x16x32x32]
   initializations: [rnd]
-  output_shape: 16x32x31x63x63
+  output_shape: 4x32x31x63x63
   dtypes: [f32, bf16]
-  warning: "Segmentation fault"
 
 - kernel: level2/16_ConvTranspose2d_Mish_Add_Hardtanh_Scaling.py
   input_shapes: [128x64x128x128]
@@ -197,11 +195,10 @@
   dtypes: [f32, bf16]
 
 - kernel: level2/33_Gemm_Scale_BatchNorm.py
-  input_shapes: [1024x8192]
+  input_shapes: [8x8192]
   initializations: [rnd]
-  output_shape: 1024x8192
+  output_shape: 8x8192
   dtypes: [f32, bf16]
-  warning: "Segmentation fault"
 
 - kernel: level2/34_ConvTranspose3d_LayerNorm_GELU_Scaling.py
   input_shapes: [32x32x16x32x32]
@@ -234,11 +231,10 @@
   dtypes: [f32, bf16]
 
 - kernel: level2/39_Gemm_Scale_BatchNorm.py
-  input_shapes: [16384x4096]
+  input_shapes: [8x4096]
   initializations: [rnd]
-  output_shape: 16384x4096
+  output_shape: 8x4096
   dtypes: [f32, bf16]
-  warning: "Segmentation fault"
 
 - kernel: level2/40_Matmul_Scaling_ResidualAdd.py
   input_shapes: [16384x4096]
@@ -440,18 +436,16 @@
   dtypes: [f32, bf16]
 
 - kernel: level2/72_ConvTranspose3d_BatchNorm_AvgPool_AvgPool.py
-  input_shapes: [64x3x32x32x32]
+  input_shapes: [4x3x32x32x32]
   initializations: [rnd]
-  output_shape: 64x16x15x15x15
+  output_shape: 4x16x15x15x15
   dtypes: [f32, bf16]
-  warning: "Segmentation fault"
 
 - kernel: level2/73_Conv2d_BatchNorm_Scaling.py
-  input_shapes: [128x8x128x128]
+  input_shapes: [8x8x128x128]
   initializations: [rnd]
-  output_shape: 128x64x126x126
+  output_shape: 8x64x126x126
   dtypes: [f32, bf16]
-  warning: "Segmentation fault"
 
 - kernel: level2/74_ConvTranspose3d_LeakyReLU_Multiply_LeakyReLU_Max.py
   input_shapes: [16x16x16x32x32]
@@ -472,11 +466,10 @@
   dtypes: [f32, bf16]
 
 - kernel: level2/77_ConvTranspose3d_Scale_BatchNorm_GlobalAvgPool.py
-  input_shapes: [16x64x16x32x32]
+  input_shapes: [4x64x16x32x32]
   initializations: [rnd]
-  output_shape: 16x128x1x1x1
+  output_shape: 4x128x1x1x1
   dtypes: [f32, bf16]
-  warning: "Segmentation fault"
 
 - kernel: level2/78_ConvTranspose3d_Max_Max_Sum.py
   input_shapes: [16x32x32x32x32]
@@ -516,11 +509,10 @@
   dtypes: [f32, bf16]
 
 - kernel: level2/84_Gemm_BatchNorm_Scaling_Softmax.py
-  input_shapes: [1024x8192]
+  input_shapes: [8x8192]
   initializations: [rnd]
-  output_shape: 1024x8192
+  output_shape: 8x8192
   dtypes: [f32, bf16]
-  warning: "Segmentation fault"
 
 - kernel: level2/85_Conv2d_GroupNorm_Scale_MaxPool_Clamp.py
   input_shapes: [128x8x128x128]
@@ -596,11 +588,10 @@
   dtypes: [f32, bf16]
 
 - kernel: level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.py
-  input_shapes: [1024x8192]
+  input_shapes: [8x8192]
   initializations: [rnd]
-  output_shape: 1024x8192
+  output_shape: 8x8192
   dtypes: [f32, bf16]
-  warning: "Segmentation fault"
 
 - kernel: level2/98_Matmul_AvgPool_GELU_Scale_Max.py
   input_shapes: [1024x8192]

--- a/examples/end-to-end/KernelBench/test_kernel_bench.py
+++ b/examples/end-to-end/KernelBench/test_kernel_bench.py
@@ -117,9 +117,10 @@ if __name__ == "__main__":
         help="Enable CI mode (faster run, fewer kernels). Incompatible with --smoke-test.",
     )
     Parser.add_argument(
-        "--torch-compile",
+        "--infer-shapes",
         action=argparse.BooleanOptionalAction,
-        help="Enable TorchScript compilation. Default is False.",
+        default=False,
+        help="Enable shape inference mode. Default is to use values in YAML file.",
     )
     Parser.add_argument(
         "--kernel",
@@ -170,11 +171,7 @@ if __name__ == "__main__":
                 f" Skipping benchmark."
             )
 
-        # We allow torch.compile to pick its own shapes (unless it's CI).
-        # TODO: Implement auto-shapes for non-compile mode as well.
-        if args.torch_compile:
-            command_line += ["--torch-compile"]
-        if args.ci or not args.torch_compile:
+        if not args.infer_shapes:
             command_line += [
                 "--input-shapes",
                 test["input_shapes"],

--- a/lighthouse/ingress/torch/compile.py
+++ b/lighthouse/ingress/torch/compile.py
@@ -55,11 +55,13 @@ class JITFunction:
         results: list[BufferMetadata],
         shared_libs: Sequence[str] = [],
         entry_func: str = "main",
+        n_outputs: int | None = None,
     ):
         self.eng = ExecutionEngine(module, opt_level=3, shared_libs=shared_libs)
         self.eng.initialize()
         self.fn = self.eng.lookup(entry_func)
         self.results = results
+        self.n_outputs = n_outputs if n_outputs is not None else len(results)
 
     def __call__(
         self,
@@ -82,12 +84,22 @@ class JITFunction:
 
         # Prepare arguments according to MLIR backend's calling convention:
         # input data followed by output storage buffers.
-        mlir_args = [arg.detach() for arg in args]
-        mlir_args.extend(outs)
-        mlir_args = lh_utils.torch.to_packed_args(mlir_args)
+        all_tensors = [arg.detach() for arg in args]
+        all_tensors.extend(outs)
+        # Keep the ctypes chain alive for the duration of the MLIR call.
+        # to_packed_args() returns only the packed void* array; the intermediate
+        # ctypes structures (memref descriptors and pointers) would be freed
+        # immediately otherwise, causing a use-after-free in the MLIR function.
+        _memrefs = [lh_utils.torch.to_memref(t) for t in all_tensors]
+        _ctype_ptrs = [lh_utils.memref.to_ctype(m) for m in _memrefs]
+        mlir_args = lh_utils.memref.get_packed_arg(_ctype_ptrs)
         self.fn(mlir_args)
 
-        return outs
+        # Return only the outputs corresponding to the FX graph's actual return
+        # values. torch-mlir may prepend extra results for in-place state
+        # mutations (e.g. BatchNorm running statistics), which Dynamo does not
+        # expect in the backend callable's return value.
+        return outs[len(self.results) - self.n_outputs :]
 
 
 class MLIRBackend:
@@ -297,6 +309,12 @@ class MLIRBackend:
                 " - consider using 'torch.compile(..., dynamic=False)'"
             )
 
+        # Count the FX graph's actual outputs before importing to MLIR.
+        # torch-mlir's import may prepend extra results for in-place state
+        # mutations that the FX graph does not expose as outputs.
+        output_node = next(n for n in model.graph.nodes if n.op == "output")
+        n_fx_outputs = len(output_node.args[0])
+
         mlir_mod = self.get_mlir(model, example_inputs)
 
         func_op = self.get_entry_func(mlir_mod)
@@ -310,7 +328,11 @@ class MLIRBackend:
         mlir_mod = self.compile_mlir(mlir_mod)
 
         return JITFunction(
-            mlir_mod, results, shared_libs=self.shared_libs, entry_func=self.entry_func
+            mlir_mod,
+            results,
+            shared_libs=self.shared_libs,
+            entry_func=self.entry_func,
+            n_outputs=n_fx_outputs,
         )
 
 


### PR DESCRIPTION
There was a mismatch between the number of argument FX was expecting and the arguments the MLIR code was returning, added by the MLIR backend.

This PR corrects that imbalance and returns the correct number of arguments.

Tests adapted to avoid OOM-kill of some very large kernels. The allocation of additional multi-GB tensors for return values is not reasonable, we need to change that approach in a future PR.

Fixes the last runtime problem in #142