### PR TITLE
[KB] Add support for init_args as argument

### DIFF
--- a/examples/end-to-end/KernelBench/level2.yaml
+++ b/examples/end-to-end/KernelBench/level2.yaml
@@ -195,9 +195,10 @@
   dtypes: [f32, bf16]
 
 - kernel: level2/33_Gemm_Scale_BatchNorm.py
-  input_shapes: [8x8192]
+  input_shapes: [8x1024]
   initializations: [rnd]
-  output_shape: 8x8192
+  output_shape: 8x1024
+  init_args: (1024,1024,1024)
   dtypes: [f32, bf16]
 
 - kernel: level2/34_ConvTranspose3d_LayerNorm_GELU_Scaling.py

--- a/examples/end-to-end/KernelBench/schedules/x86_64/pack_and_tile.yaml
+++ b/examples/end-to-end/KernelBench/schedules/x86_64/pack_and_tile.yaml
@@ -2,7 +2,7 @@
 # This is a good default to most CPU based pipelines.
 Pipeline:
   ## Packing & Cache tiling (CPU generic)
-  - schedule: "packing.py[gen=block_pack_matmuls]{block_factors=32,32,32 rhs_transpose_outer_block=True rhs_transpose_inner_block=False}"
+  - schedule: "packing.py[gen=block_pack_matmuls]{block_factors=[32,32,32] rhs_transpose_outer_block=True rhs_transpose_inner_block=False}"
   - schedule: "x86/pack_lowering.py[gen=lower_packs_unpacks]{tile_size=32}"
   - pass: "linalg-morph-ops{named-to-category generic-to-category}"
   - schedule: "x86/cache_tiling.py[gen=matmul_cache_tiling]{target=linalg.contract fuse_producers}"

--- a/examples/end-to-end/KernelBench/test_kernel_bench.py
+++ b/examples/end-to-end/KernelBench/test_kernel_bench.py
@@ -101,6 +101,7 @@ def get_tests(args: argparse.Namespace) -> list[dict]:
                         )
                     ),
                     "output_shape": f"{test['output_shape']}x{dtype}x0",
+                    "init_args": test.get("init_args", "None"),
                     "gflops": eval(test["gflops"])
                     if "gflops" in test and args.benchmark
                     else None,
@@ -215,6 +216,8 @@ if __name__ == "__main__":
                 test["input_shapes"],
                 "--output-shape",
                 test["output_shape"],
+                "--init-args",
+                test["init_args"],
             ]
 
         # For debugging, prefer not to capture output.

--- a/lighthouse/pipeline/descriptor.py
+++ b/lighthouse/pipeline/descriptor.py
@@ -2,6 +2,8 @@ import yaml
 import os
 import re
 
+from lighthouse.utils.types import string_to_type
+
 
 class Descriptor:
     """
@@ -133,33 +135,6 @@ class Descriptor:
         )
 
     @staticmethod
-    def _string_to_type(value: str) -> str | int | float | bool | list:
-        value = str(value)
-        if value == "True":
-            return True
-        elif value == "False":
-            return False
-        try:
-            return int(value)
-        except ValueError:
-            try:
-                return float(value)
-            except ValueError:
-                # List of values, e.g. [val1,val2,...]
-                if value.startswith("[") and value.endswith("]"):
-                    list_str = value[1:-1]
-                # List of values, e.g. val1,val2,...
-                elif value.find(",") != -1:
-                    list_str = value
-                else:
-                    # Something else entirely, return as string
-                    return value
-                # Recursesively parse the list elements
-                return [
-                    Descriptor._string_to_type(v.strip()) for v in list_str.split(",")
-                ]
-
-    @staticmethod
     def _parse_csv(line: str, separator: str = ",") -> dict:
         line = str(line)
         result = {}
@@ -169,7 +144,7 @@ class Descriptor:
                 continue
             if "=" in arg:
                 key, value = arg.split("=")
-                result[key] = Descriptor._string_to_type(value)
+                result[key] = string_to_type(value)
             else:
                 result[arg] = True
         return result

--- a/lighthouse/utils/types.py
+++ b/lighthouse/utils/types.py
@@ -24,3 +24,56 @@ class LazyChainMap(Mapping, Generic[K, V, W]):
 
     def __len__(self):
         return len(self._data)
+
+
+def string_to_type(value: any) -> str | int | float | bool | list | tuple:
+    """
+    Convert a string value to its appropriate type (int, float, bool, list, tuple, or str).
+    If the argument isn't a string, convert to string first.
+    If the argument cannot be converted to string, return None.
+    None and empty strings are returned as-is.
+    """
+    if value is None:
+        return None
+    try:
+        value = str(value)
+    except Exception:
+        return None
+    if not value:
+        return value
+    if value.lower() == "none":
+        return None
+
+    if value.lower() == "true":
+        return True
+    elif value.lower() == "false":
+        return False
+
+    try:
+        return int(value)
+    except ValueError:
+        pass
+
+    try:
+        return float(value)
+    except ValueError:
+        pass
+
+    # List of values, e.g. [val1,val2,...]
+    if value.startswith("[") and value.endswith("]"):
+        list_str = value[1:-1]
+        if not list_str:
+            return []
+        # Recursively parse the list elements
+        return [string_to_type(v.strip()) for v in list_str.split(",")]
+
+    # Tuple of values, e.g. (val1,val2,...)
+    if value.startswith("(") and value.endswith(")"):
+        tuple_str = value[1:-1]
+        if not tuple_str:
+            return ()
+        # Recursively parse the tuple elements
+        return tuple(string_to_type(v.strip()) for v in tuple_str.split(","))
+
+    # Something else entirely, return as string
+    return value

--- a/tools/kernel_bench
+++ b/tools/kernel_bench
@@ -119,7 +119,7 @@ def define_compiler_pipeline(
     return driver
 
 
-def parse_inputs_and_outputs(
+def parse_module_arguments(
     input_shapes_str: str, output_shape_str: str, init_args_str: str
 ) -> tuple[list, list, tuple]:
     """
@@ -363,7 +363,7 @@ if __name__ == "__main__":
         )
 
     # Initialize the device data
-    buffers, sample_tensors, init_args = parse_inputs_and_outputs(
+    buffers, sample_tensors, init_args = parse_module_arguments(
         args.input_shapes, args.output_shape, args.init_args
     )
 

--- a/tools/kernel_bench
+++ b/tools/kernel_bench
@@ -20,6 +20,8 @@ from lighthouse.ingress.torch import cpu_backend
 from lighthouse.utils.mlir import get_mlir_library_path
 import os
 
+from lighthouse.utils.types import string_to_type
+
 lib_dir = get_mlir_library_path()
 c_runner_lib = os.path.join(lib_dir, "libmlir_c_runner_utils.so")
 
@@ -118,14 +120,14 @@ def define_compiler_pipeline(
 
 
 def parse_inputs_and_outputs(
-    input_shapes_str: str, output_shape_str: str
-) -> tuple[list, list]:
+    input_shapes_str: str, output_shape_str: str, init_args_str: str
+) -> tuple[list, list, tuple]:
     """
     Parses the input and output shape strings to create sample tensors for the inputs and outputs.
     """
     # Empty buffers shortcut (either both or none, ignore either)
     if input_shapes_str is None or output_shape_str is None:
-        return None, None
+        return None, None, None
 
     # Parse input shapes first, to create sample tensors for the inputs only
     buffers = [arg.arg for arg in KernelArgumentParser.parse_all(input_shapes_str)]
@@ -142,10 +144,11 @@ def parse_inputs_and_outputs(
         else torch.from_numpy(buf)
         for buf in buffers
     ]
+    init_args = string_to_type(init_args_str)
 
     # Now include the output shape in the buffers
     buffers = [KernelArgumentParser.parse(output_shape_str).arg, *buffers]
-    return buffers, sample_tensors
+    return buffers, sample_tensors, init_args
 
 
 def torch_compile(args, model: torch.nn.Module, sample_tensors: list):
@@ -255,15 +258,22 @@ if __name__ == "__main__":
     )
     Parser.add_argument(
         "--input-shapes",
+        type=str,
         help="Shape of the input tensors in format: \
               DIMS(MxNx...)xTYPE(f16/f32/f64/bf16/i8)xINIT(0/1/rnd/id). \
               For multiple inputs, separate by comma.",
     )
     Parser.add_argument(
         "--output-shape",
+        type=str,
         help="Shape of the output tensor in format: \
               DIMS(MxNx...)xTYPE(f16/f32/f64/bf16/i8)xINIT(0/1/rnd/id). \
               Single output shape supported.",
+    )
+    Parser.add_argument(
+        "--init-args",
+        type=str,
+        help="Comma-separated list of arguments to initialize the model.",
     )
     Parser.add_argument(
         "--seed",
@@ -353,13 +363,13 @@ if __name__ == "__main__":
         )
 
     # Initialize the device data
-    buffers, sample_tensors = parse_inputs_and_outputs(
-        args.input_shapes, args.output_shape
+    buffers, sample_tensors, init_args = parse_inputs_and_outputs(
+        args.input_shapes, args.output_shape, args.init_args
     )
 
     # First, import the model and run the reference numbers
     model, sample_args, sample_kwargs = import_torch(
-        args.kernel_bench_model, sample_args=sample_tensors
+        args.kernel_bench_model, sample_args=sample_tensors, model_init_args=init_args
     )
     if args.validate:
         out_ref = model(*sample_args, **sample_kwargs)


### PR DESCRIPTION
This PR allows one to pass the Module init arguments through the command line, so that we can match the sizes of the execution with the internal sizes of the module (as we change them).

Key changes:
 * Allow kernel_bench to override the init_args
 * Allow test_kernel_bench to read from yaml and pass to kernel_bench

Minor change:
 * Factor out type parser into helper, allow tuples