### PR TITLE
[config][runner] Central runtime configuration

### DIFF
--- a/lighthouse/config/__init__.py
+++ b/lighthouse/config/__init__.py
@@ -1,0 +1,3 @@
+from .config import config
+
+__all__ = ["config"]

--- a/lighthouse/config/config.py
+++ b/lighthouse/config/config.py
@@ -1,0 +1,31 @@
+"""
+Central runtime configuration.
+
+Settings are initialised from environment variables and can be overridden at
+any time by assigning to the corresponding attribute on the `config` singleton.
+"""
+
+import os
+from dataclasses import dataclass, field
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    """Read an env var as a boolean flag."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes")
+
+
+@dataclass
+class _Config:
+    """Mutable container for lighthouse runtime settings."""
+
+    # Dump MLIR object file.
+    mlir_dump_obj: bool = field(
+        default_factory=lambda: _bool_env("LH_MLIR_DUMP_OBJ", False)
+    )
+
+
+# Module-level singleton – import and modify this directly.
+config = _Config()

--- a/lighthouse/execution/__init__.py
+++ b/lighthouse/execution/__init__.py
@@ -1,6 +1,8 @@
 from .memory_manager import MemoryManager, GPUMemoryManager
+from .debug import dump_mlir_object_file
 
 __all__ = [
     "GPUMemoryManager",
     "MemoryManager",
+    "dump_mlir_object_file",
 ]

--- a/lighthouse/execution/debug.py
+++ b/lighthouse/execution/debug.py
@@ -1,0 +1,20 @@
+import uuid
+import sys
+
+from mlir.execution_engine import ExecutionEngine
+
+
+def dump_mlir_object_file(engine: ExecutionEngine) -> str:
+    """
+    Dump the compiled MLIR object file.
+
+    Args:
+        engine: MLIR execution engine.
+
+    Returns:
+        str: The created file name.
+    """
+    file = "lh-mlir-dump-" + uuid.uuid4().hex + ".o"
+    engine.dump_to_object_file(file)
+    print(f"MLIR JIT - object file: {file}", file=sys.stderr)
+    return file

--- a/lighthouse/execution/runner.py
+++ b/lighthouse/execution/runner.py
@@ -16,6 +16,7 @@ from mlir.dialects.transform import structured
 from mlir.execution_engine import ExecutionEngine
 from mlir.runtime.np_to_memref import get_ranked_memref_descriptor
 
+import lighthouse.config as lh_config
 from lighthouse.dialects.transform import transform_ext
 from lighthouse.schedule import schedule_boilerplate
 from lighthouse.utils.memref import to_packed_args
@@ -88,6 +89,12 @@ class Runner:
             self.payload, opt_level=self.opt_level, shared_libs=self.shared_libs
         )
         execution_engine.initialize()
+
+        if lh_config.config.mlir_dump_obj:
+            from lighthouse.execution.debug import dump_mlir_object_file
+
+            dump_mlir_object_file(execution_engine)
+
         return execution_engine
 
     @contextmanager

--- a/lighthouse/workload/runner.py
+++ b/lighthouse/workload/runner.py
@@ -10,6 +10,7 @@ from mlir.dialects.transform import structured
 from mlir.execution_engine import ExecutionEngine
 from mlir.runtime.np_to_memref import get_ranked_memref_descriptor
 
+import lighthouse.config as lh_config
 from lighthouse.dialects.transform import transform_ext
 from lighthouse.schedule import schedule_boilerplate
 from lighthouse.utils.memref import to_packed_args
@@ -50,6 +51,12 @@ def execute(
     if c_runner_lib not in libs:
         libs.append(c_runner_lib)
     engine = get_engine(payload_module, shared_libs=libs)
+
+    # optionally dump the compiled MLIR object file
+    if lh_config.config.mlir_dump_obj:
+        from lighthouse.execution.debug import dump_mlir_object_file
+
+        dump_mlir_object_file(engine)
 
     with workload.allocate_inputs(execution_engine=engine) as inputs:
         # prepare function arguments


### PR DESCRIPTION
Adds a central configuratiob submodule that gathers all possible lighthouse options.

The new config is added to allow optional MLIR object file creation for debugging purposes. The MLIR dump can be triggered either by an env var or overriding central config singleton from a program.

Assisted-by: Claude