### PR TITLE
[runner] Dump object file

### DIFF
--- a/lighthouse/execution/runner.py
+++ b/lighthouse/execution/runner.py
@@ -6,6 +6,7 @@ import typing
 import numpy as np
 import ctypes
 import os
+import tempfile
 from contextlib import contextmanager
 from functools import partial
 from typing import Optional, Callable
@@ -206,6 +207,25 @@ class Runner:
             argument_access_callback=argument_access_callback,
             benchmark=False,
         )
+
+    def dump_object_file(self, file_name: str = "") -> str:
+        """
+        Dump the compiled object file.
+
+        Args:
+            file_name: Optional target file.
+                If not provided, a temporary file is created.
+
+        Returns:
+            Name of the dumped file.
+        """
+        if file_name:
+            self.engine.dump_to_object_file(file_name)
+            return file_name
+
+        with tempfile.NamedTemporaryFile(suffix=".o", delete=False) as tmp:
+            self.engine.dump_to_object_file(tmp.name)
+            return tmp.name
 
     @staticmethod
     def get_bench_wrapper_schedule(payload_func: str) -> ir.Module:

--- a/lighthouse/execution/runner.py
+++ b/lighthouse/execution/runner.py
@@ -219,13 +219,11 @@ class Runner:
         Returns:
             Name of the dumped file.
         """
-        if file_name:
-            self.engine.dump_to_object_file(file_name)
-            return file_name
-
-        with tempfile.NamedTemporaryFile(suffix=".o", delete=False) as tmp:
-            self.engine.dump_to_object_file(tmp.name)
-            return tmp.name
+        if not file_name:
+            with tempfile.NamedTemporaryFile(suffix=".o", delete=False) as tmp:
+                file_name = tmp.name
+        self.engine.dump_to_object_file(file_name)
+        return file_name
 
     @staticmethod
     def get_bench_wrapper_schedule(payload_func: str) -> ir.Module:


### PR DESCRIPTION
Allows the Runner to output compiled object file.
It can be further processed with `objdump` to produce readable assembly.

Fixes #164