### PR TITLE
[KB] Use --dtype instead of --bf16

### DIFF
--- a/examples/KernelBench/README.md
+++ b/examples/KernelBench/README.md
@@ -74,8 +74,7 @@ The key arguments in `test-kernel-bench` are:
 * `--kernel`: Specifies the kernel's `startsWith` name. Use to run one or more kernels.
 * `--benchmark`: Selects to run benchmarks (import mode only for now), and dispatches 100 iterations.
   The entry in `levelN.yaml` file must have the `gflops` set to calculate performance.
-* `--bf16`: Selects the BF16 kernel in addition to the F32. Some kernels do not support this yet.
-  (TODO: make this a selectable type instead of one flag per type).
+* `--dtype`: Selects the data type for the kernel. Some kernels only support f32. Default is f32.
 * `--infer-shapes`: Uses the Kernel Bench module's own functions to infer input/output shapes.
   Default is to read from the YAML file. Some kernels are too big and the YAML has smaller sizes override.
 * `--target` and `--feature`: Decides which schedule sub-class to search schedules from.
@@ -89,7 +88,6 @@ The key arguments in `test-kernel-bench` are:
   initializations: [rnd, id]
   output_shape: 1024x1024
   init_args: []
-  dtypes: [f32, bf16]
   gflops: (1024 * 1024 * 1024 * 2) / 1e9
   pipeline: matmul
 ```
@@ -98,7 +96,6 @@ The key arguments in `test-kernel-bench` are:
 * `input_shapes` and `output_shapes`: Dimensions and sizes for input/output shapes.
 * `init_args`: Arguments to initialize the module with (before compilation).
 * `initializations`: What type to initialize the inputs (`rnd`, `id`, `0`)
-* `dtypes`: Supported data types.
 * `gflops`: Calculation on how to get the number of floating point operations in this kernel (for performance measurement).
 * `pipeline`: Name of the sub-dir, replaces: `schedules/$target/$pipeline/$dtype.yaml`.
 

--- a/examples/KernelBench/level1.yaml
+++ b/examples/KernelBench/level1.yaml
@@ -2,7 +2,6 @@
   input_shapes: [1024x1024, 1024x1024]
   initializations: [rnd, id]
   output_shape: 1024x1024
-  dtypes: [f32, bf16]
   gflops: (1024 * 1024 * 1024 * 2) / 1e9
   pipeline: matmul
 
@@ -10,7 +9,6 @@
   input_shapes: [512x1024, 1024x512]
   initializations: [rnd, rnd]
   output_shape: 512x512
-  dtypes: [f32, bf16]
   gflops: (512 * 1024 * 512 * 2) / 1e9
   pipeline: matmul
 
@@ -18,28 +16,24 @@
   input_shapes: [4x64x32, 4x32x64]
   initializations: [rnd, rnd]
   output_shape: 4x64x64
-  dtypes: [f32, bf16]
   gflops: (4 * 64 * 32 * 64 * 2) / 1e9
 
 - kernel: level1/4_Matrix_vector_multiplication_.py
   input_shapes: [1024x1024, 1024x1]
   initializations: [rnd, rnd]
   output_shape: 1024x1
-  dtypes: [f32, bf16]
   gflops: (1024 * 1024 * 1 * 2) / 1e9
 
 - kernel: level1/5_Matrix_scalar_multiplication.py
   input_shapes: [1024x1024, "1"]
   initializations: [rnd, rnd]
   output_shape: 1024x1024
-  dtypes: [f32, bf16]
   gflops: (1024 * 1024) / 1e9
 
 - kernel: level1/6_Matmul_with_large_K_dimension_.py
   input_shapes: [256x524288, 524288x256]
   initializations: [rnd, rnd]
   output_shape: 256x256
-  dtypes: [f32, bf16]
   gflops: (256 * 524288 * 256 * 2) / 1e9
   pipeline: matmul
 
@@ -47,7 +41,6 @@
   input_shapes: [4096x64, 64x4096]
   initializations: [rnd, rnd]
   output_shape: 4096x4096
-  dtypes: [f32, bf16]
   gflops: (4096 * 64 * 4096 * 2) / 1e9
   pipeline: matmul
 
@@ -55,7 +48,6 @@
   input_shapes: [8205x2949, 2949x5921]
   initializations: [rnd, rnd]
   output_shape: 8205x5921
-  dtypes: [f32, bf16]
   gflops: (8205 * 2949 * 5921 * 2) / 1e9
   pipeline: matmul
 
@@ -63,35 +55,30 @@
   input_shapes: [1024x32, 32x1024]
   initializations: [rnd, rnd]
   output_shape: 1024x1024
-  dtypes: [f32, bf16]
   gflops: (1024 * 32 * 1024 * 2) / 1e9
 
 - kernel: level1/10_3D_tensor_matrix_multiplication.py
   input_shapes: [16x1024x2048, 2048x768]
   initializations: [rnd, rnd]
   output_shape: 16x1024x768
-  dtypes: [f32, bf16]
   gflops: (16 * 1024 * 2048 * 768 * 2) / 1e9
 
 - kernel: level1/11_4D_tensor_matrix_multiplication.py
   input_shapes: [8x256x512x256, 256x768]
   initializations: [rnd, rnd]
   output_shape: 8x256x512x768
-  dtypes: [f32, bf16]
   gflops: (8 * 256 * 512 * 256 * 768 * 2) / 1e9
 
 - kernel: level1/12_Matmul_with_diagonal_matrices_.py
   input_shapes: ["4096", 4096x4096]
   initializations: [rnd, rnd]
   output_shape: 4096x4096
-  dtypes: [f32, bf16]
   warning: "error: failed to legalize operation 'torch.operator' that was explicitly marked illegal"
 
 - kernel: level1/13_Matmul_for_symmetric_matrices.py
   input_shapes: [4096x4096, 4096x4096]
   initializations: [rnd, rnd]
   output_shape: 4096x4096
-  dtypes: [f32, bf16]
   gflops: (4096 * 4096 * 4096 * 2) / 1e9
   pipeline: matmul
 
@@ -99,7 +86,6 @@
   input_shapes: [4096x4096, 4096x4096]
   initializations: [rnd, rnd]
   output_shape: 4096x4096
-  dtypes: [f32, bf16]
   gflops: (4096 * 4096 * 4096 * 2) / 1e9
   pipeline: matmul
 
@@ -107,7 +93,6 @@
   input_shapes: [4096x4096, 4096x4096]
   initializations: [rnd, rnd]
   output_shape: 4096x4096
-  dtypes: [f32, bf16]
   gflops: (4096 * 4096 * 4096 * 2) / 1e9
   pipeline: matmul
 
@@ -115,7 +100,6 @@
   input_shapes: [8192x2048, 8192x4096]
   initializations: [rnd, rnd]
   output_shape: 2048x4096
-  dtypes: [f32, bf16]
   gflops: (2048 * 8192 * 4096 * 2) / 1e9
   pipeline: matmul
 
@@ -123,7 +107,6 @@
   input_shapes: [2048x8192, 4096x8192]
   initializations: [rnd, rnd]
   output_shape: 2048x4096
-  dtypes: [f32, bf16]
   gflops: (2048 * 8192 * 4096 * 2) / 1e9
   pipeline: matmul
 
@@ -131,7 +114,6 @@
   input_shapes: [8192x2048, 4096x8192]
   initializations: [rnd, rnd]
   output_shape: 2048x4096
-  dtypes: [f32, bf16]
   gflops: (2048 * 8192 * 4096 * 2) / 1e9
   pipeline: matmul
 
@@ -139,112 +121,96 @@
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/20_LeakyReLU.py
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/21_Sigmoid.py
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/22_Tanh.py
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/23_Softmax.py
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/24_LogSoftmax.py
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/25_Swish.py
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/26_GELU_.py
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/27_SELU_.py
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/28_HardSigmoid.py
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/29_Softplus.py
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/30_Softsign.py
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/31_ELU.py
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/32_HardTanh.py
   input_shapes: [4096x8192]
   initializations: [rnd]
   output_shape: 4096x8192
-  dtypes: [f32, bf16]
   gflops: (4096 * 8192) / 1e9
 
 - kernel: level1/33_BatchNorm.py
   input_shapes: [64x64x32x32]
   initializations: [rnd]
   output_shape: 64x64x32x32
-  dtypes: [f32, bf16]
   gflops: (64 * 64 * 32 * 32) / 1e9
 
 - kernel: level1/34_InstanceNorm.py
   input_shapes: [12x64x512x512]
   initializations: [rnd]
   output_shape: 12x64x512x512
-  dtypes: [f32, bf16]
   gflops: (12 * 64 * 512 * 512) / 1e9
   warning: "LLVM ERROR: SmallVector unable to grow (93TB! > 4GB)"
 
@@ -252,350 +218,295 @@
   input_shapes: [12x64x512x512]
   initializations: [rnd]
   output_shape: 12x64x512x512
-  dtypes: [f32, bf16]
   gflops: (12 * 64 * 512 * 512) / 1e9
 
 - kernel: level1/36_RMSNorm_.py
   input_shapes: [12x64x512x512]
   initializations: [rnd]
   output_shape: 12x64x512x512
-  dtypes: [f32, bf16]
   gflops: (12 * 64 * 512 * 512) / 1e9
 
 - kernel: level1/37_FrobeniusNorm_.py
   input_shapes: [12x64x512x512]
   initializations: [rnd]
   output_shape: 12x64x512x512
-  dtypes: [f32, bf16]
   gflops: (12 * 64 * 512 * 512) / 1e9
 
 - kernel: level1/38_L1Norm_.py
   input_shapes: [8192x8191]
   initializations: [rnd]
   output_shape: 8192x8191
-  dtypes: [f32, bf16]
   gflops: (8192 * 8191) / 1e9
 
 - kernel: level1/39_L2Norm_.py
   input_shapes: [8192x8191]
   initializations: [rnd]
   output_shape: 8192x8191
-  dtypes: [f32, bf16]
   gflops: (8192 * 8191) / 1e9
 
 - kernel: level1/40_LayerNorm.py
   input_shapes: [16x64x256x256]
   initializations: [rnd]
   output_shape: 16x64x256x256
-  dtypes: [f32, bf16]
   gflops: (16 * 64 * 256 * 256) / 1e9
 
 - kernel: level1/41_Max_Pooling_1D.py
   input_shapes: [64x192x65536]
   initializations: [rnd]
   output_shape: 64x192x65523
-  dtypes: [f32, bf16]
   gflops: (64 * 192 * 65523) / 1e9
 
 - kernel: level1/42_Max_Pooling_2D.py
   input_shapes: [32x64x512x512]
   initializations: [rnd]
   output_shape: 32x64x511x511
-  dtypes: [f32, bf16]
   gflops: (32 * 64 * 511 * 511) / 1e9
 
 - kernel: level1/43_Max_Pooling_3D.py
   input_shapes: [16x32x128x128x128]
   initializations: [rnd]
   output_shape: 16x32x62x62x62
-  dtypes: [f32, bf16]
   gflops: (16 * 32 * 62 * 62 * 62) / 1e9
 
 - kernel: level1/44_Average_Pooling_1D.py
   input_shapes: [64x128x65536]
   initializations: [rnd]
   output_shape: 64x128x65537
-  dtypes: [f32, bf16]
   gflops: (64 * 128 * 65537) / 1e9
 
 - kernel: level1/45_Average_Pooling_2D.py
   input_shapes: [16x64x512x512]
   initializations: [rnd]
   output_shape: 16x64x46x46
-  dtypes: [f32, bf16]
   gflops: (16 * 64 * 512 * 512) / 1e9
 
 - kernel: level1/46_Average_Pooling_3D.py
   input_shapes: [16x32x128x128x256]
   initializations: [rnd]
   output_shape: 16x32x64x64x128
-  dtypes: [f32, bf16]
   gflops: (16 * 32 * 64 * 64 * 128) / 1e9
 
 - kernel: level1/47_Sum_reduction_over_a_dimension.py
   input_shapes: [128x512x4095]
   initializations: [rnd]
   output_shape: 128x1x4095
-  dtypes: [f32, bf16]
   gflops: (128 * 512 * 4095) / 1e9
 
 - kernel: level1/48_Mean_reduction_over_a_dimension.py
   input_shapes: [128x512x4095]
   initializations: [rnd]
   output_shape: 128x4095
-  dtypes: [f32, bf16]
   gflops: (128 * 512 * 4095) / 1e9
 
 - kernel: level1/49_Max_reduction_over_a_dimension.py
   input_shapes: [128x512x4095]
   initializations: [rnd]
   output_shape: 128x4095
-  dtypes: [f32, bf16]
   gflops: (128 * 512 * 4095) / 1e9
 
 - kernel: level1/50_conv_standard_2D__square_input__square_kernel.py
   input_shapes: [256x3x224x224]
   initializations: [rnd]
   output_shape: 256x96x55x55
-  dtypes: [f32, bf16]
 
 - kernel: level1/51_Argmax_over_a_dimension.py
   input_shapes: [128x512x4095]
   initializations: [rnd]
   output_shape: 128x4095
-  dtypes: [f32, bf16]
   gflops: (128 * 512 * 4095) / 1e9
 
 - kernel: level1/52_Argmin_over_a_dimension.py
   input_shapes: [128x512x4095]
   initializations: [rnd]
   output_shape: 128x4095
-  dtypes: [f32, bf16]
   gflops: (128 * 512 * 4095) / 1e9
 
 - kernel: level1/53_Min_reduction_over_a_dimension.py
   input_shapes: [128x512x4095]
   initializations: [rnd]
   output_shape: 128x4095
-  dtypes: [f32, bf16]
   gflops: (128 * 512 * 4095) / 1e9
 
 - kernel: level1/54_conv_standard_3D__square_input__square_kernel.py
   input_shapes: [16x3x64x64x64]
   initializations: [rnd]
   output_shape: 16x64x62x62x62
-  dtypes: [f32, bf16]
 
 - kernel: level1/55_conv_standard_2D__asymmetric_input__square_kernel.py
   input_shapes: [8x64x512x1024]
   initializations: [rnd]
   output_shape: 8x128x510x1022
-  dtypes: [f32, bf16]
 
 - kernel: level1/56_conv_standard_2D__asymmetric_input__asymmetric_kernel.py
   input_shapes: [8x64x512x256]
   initializations: [rnd]
   output_shape: 8x128x508x250
-  dtypes: [f32, bf16]
 
 - kernel: level1/57_conv_transposed_2D__square_input__square_kernel.py
   input_shapes: [8x64x1024x1024]
   initializations: [rnd]
   output_shape: 8x64x1026x1026
-  dtypes: [f32, bf16]
 
 - kernel: level1/58_conv_transposed_3D__asymmetric_input__asymmetric_kernel.py
   input_shapes: [16x32x16x32x64]
   initializations: [rnd]
   output_shape: 16x16x18x36x70
-  dtypes: [f32, bf16]
 
 - kernel: level1/59_conv_standard_3D__asymmetric_input__square_kernel.py
   input_shapes: [16x3x256x256x10]
   initializations: [rnd]
   output_shape: 16x64x254x254x10
-  dtypes: [f32, bf16]
 
 - kernel: level1/60_conv_standard_3D__square_input__asymmetric_kernel.py
   input_shapes: [16x3x64x64x64]
   initializations: [rnd]
   output_shape: 16x64x62x60x58
-  dtypes: [f32, bf16]
 
 - kernel: level1/61_conv_transposed_3D__square_input__square_kernel.py
   input_shapes: [8x48x64x64x64]
   initializations: [rnd]
   output_shape: 8x48x66x66x66
-  dtypes: [f32, bf16]
 
 - kernel: level1/62_conv_standard_2D__square_input__asymmetric_kernel.py
   input_shapes: [8x32x512x512]
   initializations: [rnd]
   output_shape: 8x64x508x504
-  dtypes: [f32, bf16]
 
 - kernel: level1/63_conv_standard_2D__square_input__square_kernel.py
   input_shapes: [16x16x1024x1024]
   initializations: [rnd]
   output_shape: 16x128x1022x1022
-  dtypes: [f32, bf16]
 
 - kernel: level1/64_conv_transposed_1D.py
   input_shapes: [64x128x65536]
   initializations: [rnd]
   output_shape: 64x128x65538
-  dtypes: [f32, bf16]
 
 - kernel: level1/65_conv_transposed_2D__square_input__asymmetric_kernel.py
   input_shapes: [8x64x512x512]
   initializations: [rnd]
   output_shape: 8x64x514x518
-  dtypes: [f32, bf16]
 
 - kernel: level1/66_conv_standard_3D__asymmetric_input__asymmetric_kernel.py
   input_shapes: [8x3x16x128x128]
   initializations: [rnd]
   output_shape: 8x64x14x124x122
-  dtypes: [f32, bf16]
 
 - kernel: level1/67_conv_standard_1D.py
   input_shapes: [32x64x131072]
   initializations: [rnd]
   output_shape: 32x128x131070
-  dtypes: [f32, bf16]
 
 - kernel: level1/68_conv_transposed_3D__square_input__asymmetric_kernel.py
   input_shapes: [16x32x64x64x64]
   initializations: [rnd]
   output_shape: 16x64x66x68x68
-  dtypes: [f32, bf16]
 
 - kernel: level1/69_conv_transposed_2D__asymmetric_input__asymmetric_kernel.py
   input_shapes: [64x64x128x256]
   initializations: [rnd]
   output_shape: 64x128x130x260
-  dtypes: [f32, bf16]
 
 - kernel: level1/70_conv_transposed_3D__asymmetric_input__square_kernel.py
   input_shapes: [8x48x96x96x96]
   initializations: [rnd]
   output_shape: 8x24x98x98x98
-  dtypes: [f32, bf16]
 
 - kernel: level1/71_conv_transposed_2D__asymmetric_input__square_kernel.py
   input_shapes: [8x32x512x1024]
   initializations: [rnd]
   output_shape: 8x32x514x1026
-  dtypes: [f32, bf16]
 
 - kernel: level1/72_conv_transposed_3D_asymmetric_input_asymmetric_kernel___strided_padded_grouped_.py
   input_shapes: [8x32x12x24x48]
   initializations: [rnd]
   output_shape: 8x32x24x48x96
-  dtypes: [f32, bf16]
 
 - kernel: level1/73_conv_transposed_3D_asymmetric_input_square_kernel__strided_padded__grouped.py
   input_shapes: [4x32x32x64x128]
   initializations: [rnd]
   output_shape: 4x32x63x127x255
-  dtypes: [f32, bf16]
 
 - kernel: level1/74_conv_transposed_1D_dilated.py
   input_shapes: [32x32x131072]
   initializations: [rnd]
   output_shape: 32x64x131084
-  dtypes: [f32, bf16]
 
 - kernel: level1/75_conv_transposed_2D_asymmetric_input_asymmetric_kernel_strided__grouped____padded____dilated__.py
   input_shapes: [16x32x128x256]
   initializations: [rnd]
   output_shape: 16x64x257x766
-  dtypes: [f32, bf16]
 
 - kernel: level1/76_conv_standard_1D_dilated_strided__.py
   input_shapes: [64x64x3072]
   initializations: [rnd]
   output_shape: 64x128x1022
-  dtypes: [f32, bf16]
 
 - kernel: level1/77_conv_transposed_3D_square_input_square_kernel___padded____dilated____strided__.py
   input_shapes: [16x32x16x32x32]
   initializations: [rnd]
   output_shape: 16x64x33x65x65
-  dtypes: [f32, bf16]
 
 - kernel: level1/78_conv_transposed_2D_asymmetric_input_asymmetric_kernel___padded__.py
   input_shapes: [8x32x512x1024]
   initializations: [rnd]
   output_shape: 8x32x512x1024
-  dtypes: [f32, bf16]
 
 - kernel: level1/79_conv_transposed_1D_asymmetric_input_square_kernel___padded____strided____dilated__.py
   input_shapes: [16x32x131072]
   initializations: [rnd]
   output_shape: 16x64x262145
-  dtypes: [f32, bf16]
 
 - kernel: level1/80_conv_standard_2D_square_input_asymmetric_kernel___dilated____padded__.py
   input_shapes: [8x32x512x512]
   initializations: [rnd]
   output_shape: 8x64x508x496
-  dtypes: [f32, bf16]
 
 - kernel: level1/81_conv_transposed_2D_asymmetric_input_square_kernel___dilated____padded____strided__.py
   input_shapes: [16x32x64x128]
   initializations: [rnd]
   output_shape: 16x64x318x638
-  dtypes: [f32, bf16]
 
 - kernel: level1/82_conv_depthwise_2D_square_input_square_kernel.py
   input_shapes: [16x64x512x512]
   initializations: [rnd]
   output_shape: 16x64x510x510
-  dtypes: [f32, bf16]
 
 - kernel: level1/83_conv_depthwise_2D_square_input_asymmetric_kernel.py
   input_shapes: [64x8x512x512]
   initializations: [rnd]
   output_shape: 64x8x510x512
-  dtypes: [f32, bf16]
 
 - kernel: level1/84_conv_depthwise_2D_asymmetric_input_square_kernel.py
   input_shapes: [64x128x256x512]
   initializations: [rnd]
   output_shape: 64x128x254x510
-  dtypes: [f32, bf16]
 
 - kernel: level1/85_conv_depthwise_2D_asymmetric_input_asymmetric_kernel.py
   input_shapes: [32x128x128x256]
   initializations: [rnd]
   output_shape: 32x128x126x250
-  dtypes: [f32, bf16]
 
 - kernel: level1/86_conv_depthwise_separable_2D.py
   input_shapes: [16x64x512x512]
   initializations: [rnd]
   output_shape: 16x128x512x512
-  dtypes: [f32, bf16]
 
 - kernel: level1/87_conv_pointwise_2D.py
   input_shapes: [16x64x1024x1024]
   initializations: [rnd]
   output_shape: 16x128x1024x1024
-  dtypes: [f32, bf16]
 
 - kernel: level1/88_MinGPTNewGelu.py
   input_shapes: [8192x8192]
   initializations: [rnd]
   output_shape: 8192x8192
-  dtypes: [f32, bf16]
   gflops: (8192 * 8192) / 1e9
 
 - kernel: level1/89_cumsum.py
   input_shapes: [32768x32768]
   initializations: [rnd]
   output_shape: 32768x32768
-  dtypes: [f32, bf16]
   gflops: (32768 * 32768) / 1e9
   warning: "error: Dialect `tm_tensor' not found for custom op 'tm_tensor.scan'"
 
@@ -603,7 +514,6 @@
   input_shapes: [32768x32768]
   initializations: [rnd]
   output_shape: 32768x32768
-  dtypes: [f32, bf16]
   gflops: (32768 * 32768) / 1e9
   warning: "error: Dialect `tm_tensor' not found for custom op 'tm_tensor.scan'"
 
@@ -611,7 +521,6 @@
   input_shapes: [32768x32768]
   initializations: [rnd]
   output_shape: 32768x32768
-  dtypes: [f32, bf16]
   gflops: (32768 * 32768) / 1e9
   warning: "error: Dialect `tm_tensor' not found for custom op 'tm_tensor.scan'"
 
@@ -619,7 +528,6 @@
   input_shapes: [32768x32768]
   initializations: [rnd]
   output_shape: 32767x32769
-  dtypes: [f32, bf16]
   gflops: (32768 * 32768) / 1e9
   warning: "error: Dialect `tm_tensor' not found for custom op 'tm_tensor.scan'"
 
@@ -627,7 +535,6 @@
   input_shapes: [32768x32768, 32768x32768]
   initializations: [rnd, rnd]
   output_shape: 32768x32768
-  dtypes: [f32, bf16]
   gflops: (32768 * 32768) / 1e9
   warning: "error: Dialect `tm_tensor' not found for custom op 'tm_tensor.scan'"
 
@@ -635,14 +542,12 @@
   input_shapes: [32768x32768, 32768x32768]
   initializations: [rnd, rnd]
   output_shape: "1"
-  dtypes: [f32, bf16]
   gflops: (32768 * 32768) / 1e9
 
 - kernel: level1/95_CrossEntropyLoss.py
   input_shapes: [32768x4096, 32768]
   initializations: [rnd, rnd]
   output_shape: "1"
-  dtypes: [f32, bf16]
   gflops: (32768 * 4096) / 1e9
   warning: "RuntimeError: gather(): Expected dtype int32/int64 for index, but got torch.float32"
 
@@ -650,7 +555,6 @@
   input_shapes: [32768x32768, 32768x32768]
   initializations: [rnd, rnd]
   output_shape: "1"
-  dtypes: [f32, bf16]
   gflops: (32768 * 32768) / 1e9
   warning: "error: failed to legalize operation 'torch.operator' that was explicitly marked illegal"
 
@@ -658,21 +562,18 @@
   input_shapes: [32x32x512x1024, 32x32x512x1024, 32x32x512x1024]
   initializations: [rnd, rnd, rnd]
   output_shape: 32x32x512x1024
-  dtypes: [f32, bf16]
   gflops: (4 * 32 * 32 * 512 * 512 * 1024) / 1e9
 
 - kernel: level1/98_KLDivLoss.py
   input_shapes: [16384x16384, 16384x16384]
   initializations: [rnd, rnd]
   output_shape: "1"
-  dtypes: [f32, bf16]
   gflops: (16384 * 16384) / 1e9
 
 - kernel: level1/99_TripletMarginLoss.py
   input_shapes: [32768x8192, 32768x8192, 32768x8192]
   initializations: [rnd, rnd, rnd]
   output_shape: "1"
-  dtypes: [f32, bf16]
   gflops: (32768 * 8192) / 1e9
   warning: "error: failed to legalize operation 'torch.operator' that was explicitly marked illegal"
 
@@ -680,5 +581,4 @@
   input_shapes: [32768x32768, 32768]
   initializations: [rnd, rnd]
   output_shape: "1"
-  dtypes: [f32, bf16]
   gflops: (32768 * 32768) / 1e9

--- a/examples/KernelBench/level2.yaml
+++ b/examples/KernelBench/level2.yaml
@@ -2,612 +2,512 @@
   input_shapes: [128x64x128x128]
   initializations: [rnd]
   output_shape: 128x128x126x126
-  dtypes: [f32, bf16]
 
 - kernel: level2/2_ConvTranspose2d_BiasAdd_Clamp_Scaling_Clamp_Divide.py
   input_shapes: [128x64x128x128]
   initializations: [rnd]
   output_shape: 128x64x256x256
-  dtypes: [f32, bf16]
 
 - kernel: level2/3_ConvTranspose3d_Sum_LayerNorm_AvgPool_GELU.py
   input_shapes: [32x32x16x32x32]
   initializations: [rnd]
   output_shape: 32x64x16x32x32
-  dtypes: [f32, bf16]
 
 - kernel: level2/4_Conv2d_Mish_Mish.py
   input_shapes: [64x64x256x256]
   initializations: [rnd]
   output_shape: 64x128x254x254
-  dtypes: [f32, bf16]
 
 - kernel: level2/5_ConvTranspose2d_Subtract_Tanh.py
   input_shapes: [32x64x256x256]
   initializations: [rnd]
   output_shape: 32x64x513x513
-  dtypes: [f32, bf16]
 
 - kernel: level2/6_Conv3d_Softmax_MaxPool_MaxPool.py
   input_shapes: [128x3x16x32x32]
   initializations: [rnd]
   output_shape: 128x16x3x7x7
-  dtypes: [f32, bf16]
 
 - kernel: level2/7_Conv3d_ReLU_LeakyReLU_GELU_Sigmoid_BiasAdd.py
   input_shapes: [64x8x32x64x64]
   initializations: [rnd]
   output_shape: 64x32x30x62x62
-  dtypes: [f32, bf16]
 
 - kernel: level2/8_Conv3d_Divide_Max_GlobalAvgPool_BiasAdd_Sum.py
   input_shapes: [128x8x16x64x64]
   initializations: [rnd]
   output_shape: 128x1x1x1
-  dtypes: [f32, bf16]
 
 - kernel: level2/9_Matmul_Subtract_Multiply_ReLU.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/10_ConvTranspose2d_MaxPool_Hardtanh_Mean_Tanh.py
   input_shapes: [128x64x256x256]
   initializations: [rnd]
   output_shape: 128x64x1x1
-  dtypes: [f32, bf16]
 
 - kernel: level2/11_ConvTranspose2d_BatchNorm_Tanh_MaxPool_GroupNorm.py
   input_shapes: [8x64x32x32]
   initializations: [rnd]
   output_shape: 8x128x17x17
-  dtypes: [f32, bf16]
 
 - kernel: level2/12_Gemm_Multiply_LeakyReLU.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/13_ConvTranspose3d_Mean_Add_Softmax_Tanh_Scaling.py
   input_shapes: [16x16x32x128x128]
   initializations: [rnd]
   output_shape: 16x64x1x128x128
-  dtypes: [f32, bf16]
 
 - kernel: level2/14_Gemm_Divide_Sum_Scaling.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x1
-  dtypes: [f32, bf16]
 
 - kernel: level2/15_ConvTranspose3d_BatchNorm_Subtract.py
   input_shapes: [4x16x16x32x32]
   initializations: [rnd]
   output_shape: 4x32x31x63x63
-  dtypes: [f32, bf16]
 
 - kernel: level2/16_ConvTranspose2d_Mish_Add_Hardtanh_Scaling.py
   input_shapes: [128x64x128x128]
   initializations: [rnd]
   output_shape: 128x64x256x256
-  dtypes: [f32, bf16]
 
 - kernel: level2/17_Conv2d_InstanceNorm_Divide.py
   input_shapes: [128x64x128x128]
   initializations: [rnd]
   output_shape: 128x128x126x126
-  dtypes: [f32, bf16]
   warning: "LLVM ERROR: SmallVector unable to grow (93TB! > 4GB)"
 
 - kernel: level2/18_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x1
-  dtypes: [f32, bf16]
   warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/19_ConvTranspose2d_GELU_GroupNorm.py
   input_shapes: [128x64x256x256]
   initializations: [rnd]
   output_shape: 128x64x258x258
-  dtypes: [f32, bf16]
 
 - kernel: level2/20_ConvTranspose3d_Sum_ResidualAdd_Multiply_ResidualAdd.py
   input_shapes: [16x32x16x32x32]
   initializations: [rnd]
   output_shape: 16x64x32x64x64
-  dtypes: [f32, bf16]
 
 - kernel: level2/21_Conv2d_Add_Scale_Sigmoid_GroupNorm.py
   input_shapes: [128x8x256x256]
   initializations: [rnd]
   output_shape: 128x32x254x254
-  dtypes: [f32, bf16]
 
 - kernel: level2/22_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x1
-  dtypes: [f32, bf16]
   warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/23_Conv3d_GroupNorm_Mean.py
   input_shapes: [128x3x24x32x32]
   initializations: [rnd]
   output_shape: 128
-  dtypes: [f32, bf16]
 
 - kernel: level2/24_Conv3d_Min_Softmax.py
   input_shapes: [128x3x24x32x32]
   initializations: [rnd]
   output_shape: 128x24x30x30
-  dtypes: [f32, bf16]
 
 - kernel: level2/25_Conv2d_Min_Tanh_Tanh.py
   input_shapes: [128x16x256x256]
   initializations: [rnd]
   output_shape: 128x1x254x254
-  dtypes: [f32, bf16]
 
 - kernel: level2/26_ConvTranspose3d_Add_HardSwish.py
   input_shapes: [128x32x16x16x16, 128x64x32x32x32]
   initializations: [rnd, rnd]
   output_shape: 128x64x32x32x32
-  dtypes: [f32, bf16]
 
 - kernel: level2/27_Conv3d_HardSwish_GroupNorm_Mean.py
   input_shapes: [1024x3x16x32x32]
   initializations: [rnd]
   output_shape: 1024x16
-  dtypes: [f32, bf16]
 
 - kernel: level2/28_BMM_InstanceNorm_Sum_ResidualAdd_Multiply.py
   input_shapes: [1024x8192, 1024x8192]
   initializations: [rnd, rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
   warning: "LLVM ERROR: SmallVector unable to grow (93TB! > 4GB) + Input size at dim=1 does not match num_features"
 
 - kernel: level2/29_Matmul_Mish_Mish.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/30_Gemm_GroupNorm_Hardtanh.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/31_Conv2d_Min_Add_Multiply.py
   input_shapes: [128x64x128x128]
   initializations: [rnd]
   output_shape: 128x128x126x126
-  dtypes: [f32, bf16]
 
 - kernel: level2/32_Conv2d_Scaling_Min.py
   input_shapes: [64x64x256x256]
   initializations: [rnd]
   output_shape: 64x1x254x254
-  dtypes: [f32, bf16]
 
 - kernel: level2/33_Gemm_Scale_BatchNorm.py
   input_shapes: [8x1024]
   initializations: [rnd]
   output_shape: 8x1024
   init_args: (1024,1024,1024)
-  dtypes: [f32, bf16]
 
 - kernel: level2/34_ConvTranspose3d_LayerNorm_GELU_Scaling.py
   input_shapes: [32x32x16x32x32]
   initializations: [rnd]
   output_shape: 32x64x32x64x64
-  dtypes: [f32, bf16]
 
 - kernel: level2/35_Conv2d_Subtract_HardSwish_MaxPool_Mish.py
   input_shapes: [128x64x128x128]
   initializations: [rnd]
   output_shape: 128x128x63x63
-  dtypes: [f32, bf16]
 
 - kernel: level2/36_ConvTranspose2d_Min_Sum_GELU_Add.py
   input_shapes: [16x64x128x128]
   initializations: [rnd]
   output_shape: 16x1x1x256
-  dtypes: [f32, bf16]
 
 - kernel: level2/37_Matmul_Swish_Sum_GroupNorm.py
   input_shapes: [32768x1024]
   initializations: [rnd]
   output_shape: 32768x4096
-  dtypes: [f32, bf16]
 
 - kernel: level2/38_ConvTranspose3d_AvgPool_Clamp_Softmax_Multiply.py
   input_shapes: [32x32x32x64x64]
   initializations: [rnd]
   output_shape: 32x64x32x64x64
-  dtypes: [f32, bf16]
 
 - kernel: level2/39_Gemm_Scale_BatchNorm.py
   input_shapes: [8x4096]
   initializations: [rnd]
   output_shape: 8x4096
-  dtypes: [f32, bf16]
 
 - kernel: level2/40_Matmul_Scaling_ResidualAdd.py
   input_shapes: [16384x4096]
   initializations: [rnd]
   output_shape: 16384x4096
-  dtypes: [f32, bf16]
 
 - kernel: level2/41_Gemm_BatchNorm_GELU_ReLU.py
   input_shapes: [16384x4096]
   initializations: [rnd]
   output_shape: 16384x4096
-  dtypes: [f32, bf16]
 
 - kernel: level2/42_ConvTranspose2d_GlobalAvgPool_BiasAdd_LogSumExp_Sum_Multiply.py
   input_shapes: [16x64x512x512]
   initializations: [rnd]
   output_shape: 16x1
-  dtypes: [f32, bf16]
   warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/43_Conv3d_Max_LogSumExp_ReLU.py
   input_shapes: [4x32x32x128x128]
   initializations: [rnd]
   output_shape: 4x1x16x64x64
-  dtypes: [f32, bf16]
   warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/44_ConvTranspose2d_Multiply_GlobalAvgPool_GlobalAvgPool_Mean.py
   input_shapes: [16x64x128x128]
   initializations: [rnd]
   output_shape: 16x128x1x1
-  dtypes: [f32, bf16]
 
 - kernel: level2/45_Gemm_Sigmoid_LogSumExp.py
   input_shapes: [16384x2048]
   initializations: [rnd]
   output_shape: 16384
-  dtypes: [f32, bf16]
   warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/46_Conv2d_Subtract_Tanh_Subtract_AvgPool.py
   input_shapes: [128x64x128x128]
   initializations: [rnd]
   output_shape: 128x128x63x63
-  dtypes: [f32, bf16]
 
 - kernel: level2/47_Conv3d_Mish_Tanh.py
   input_shapes: [16x32x32x64x64]
   initializations: [rnd]
   output_shape: 16x64x30x62x62
-  dtypes: [f32, bf16]
 
 - kernel: level2/48_Conv3d_Scaling_Tanh_Multiply_Sigmoid.py
   input_shapes: [128x3x16x64x64]
   initializations: [rnd]
   output_shape: 128x16x14x62x62
-  dtypes: [f32, bf16]
 
 - kernel: level2/49_ConvTranspose3d_Softmax_Sigmoid.py
   input_shapes: [16x32x16x32x32]
   initializations: [rnd]
   output_shape: 16x64x32x64x64
-  dtypes: [f32, bf16]
 
 - kernel: level2/50_ConvTranspose3d_Scaling_AvgPool_BiasAdd_Scaling.py
   input_shapes: [128x3x16x32x32]
   initializations: [rnd]
   output_shape: 128x16x15x31x31
-  dtypes: [f32, bf16]
 
 - kernel: level2/51_Gemm_Subtract_GlobalAvgPool_LogSumExp_GELU_ResidualAdd.py
   input_shapes: [2048x8192]
   initializations: [rnd]
   output_shape: 2048x8192
-  dtypes: [f32, bf16]
   warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/52_Conv2d_Activation_BatchNorm.py
   input_shapes: [64x64x128x128]
   initializations: [rnd]
   output_shape: 64x128x126x126
-  dtypes: [f32, bf16]
   warning: "error: failed to legalize operation 'torch.operator' that was explicitly marked illegal"
 
 - kernel: level2/53_Gemm_Scaling_Hardtanh_GELU.py
   input_shapes: [2048x8192]
   initializations: [rnd]
   output_shape: 2048x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/54_Conv2d_Multiply_LeakyReLU_GELU.py
   input_shapes: [64x64x256x256]
   initializations: [rnd]
   output_shape: 64x64x254x254
-  dtypes: [f32, bf16]
 
 - kernel: level2/55_Matmul_MaxPool_Sum_Scale.py
   input_shapes: [128x32768]
   initializations: [rnd]
   output_shape: 128
-  dtypes: [f32, bf16]
 
 - kernel: level2/56_Matmul_Sigmoid_Sum.py
   input_shapes: [128x32768]
   initializations: [rnd]
   output_shape: 128x1
-  dtypes: [f32, bf16]
 
 - kernel: level2/57_Conv2d_ReLU_HardSwish.py
   input_shapes: [128x8x128x128]
   initializations: [rnd]
   output_shape: 128x64x126x126
-  dtypes: [f32, bf16]
 
 - kernel: level2/58_ConvTranspose3d_LogSumExp_HardSwish_Subtract_Clamp.py
   input_shapes: [128x3x16x32x32]
   initializations: [rnd]
   output_shape: 128x1x31x63x63
-  dtypes: [f32, bf16]
   warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/59_Matmul_Swish_Scaling.py
   input_shapes: [128x32768]
   initializations: [rnd]
   output_shape: 128x32768
-  dtypes: [f32, bf16]
 
 - kernel: level2/60_ConvTranspose3d_Swish_GroupNorm_HardSwish.py
   input_shapes: [128x3x16x32x32]
   initializations: [rnd]
   output_shape: 128x16x31x63x63
-  dtypes: [f32, bf16]
 
 - kernel: level2/61_ConvTranspose3d_ReLU_GroupNorm.py
   input_shapes: [16x64x32x32x32]
   initializations: [rnd]
   output_shape: 16x128x34x34x34
-  dtypes: [f32, bf16]
 
 - kernel: level2/62_Matmul_GroupNorm_LeakyReLU_Sum.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/63_Gemm_ReLU_Divide.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/64_Gemm_LogSumExp_LeakyReLU_LeakyReLU_GELU_GELU.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x1
-  dtypes: [f32, bf16]
   warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/65_Conv2d_AvgPool_Sigmoid_Sum.py
   input_shapes: [128x8x384x384]
   initializations: [rnd]
   output_shape: 128
-  dtypes: [f32, bf16]
 
 - kernel: level2/66_Matmul_Dropout_Softmax.py
   input_shapes: [128x16384]
   initializations: [rnd]
   output_shape: 128x16384
-  dtypes: [f32, bf16]
 
 - kernel: level2/67_Conv2d_GELU_GlobalAvgPool.py
   input_shapes: [128x8x256x256]
   initializations: [rnd]
   output_shape: 128x64
-  dtypes: [f32, bf16]
 
 - kernel: level2/68_Matmul_Min_Subtract.py
   input_shapes: [128x16384]
   initializations: [rnd]
   output_shape: 128x16384
-  dtypes: [f32, bf16]
 
 - kernel: level2/69_Conv2d_HardSwish_ReLU.py
   input_shapes: [128x8x128x128]
   initializations: [rnd]
   output_shape: 128x64x126x126
-  dtypes: [f32, bf16]
 
 - kernel: level2/70_Gemm_Sigmoid_Scaling_ResidualAdd.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/71_Conv2d_Divide_LeakyReLU.py
   input_shapes: [128x8x128x128]
   initializations: [rnd]
   output_shape: 128x64x126x126
-  dtypes: [f32, bf16]
 
 - kernel: level2/72_ConvTranspose3d_BatchNorm_AvgPool_AvgPool.py
   input_shapes: [4x3x32x32x32]
   initializations: [rnd]
   output_shape: 4x16x15x15x15
-  dtypes: [f32, bf16]
 
 - kernel: level2/73_Conv2d_BatchNorm_Scaling.py
   input_shapes: [8x8x128x128]
   initializations: [rnd]
   output_shape: 8x64x126x126
-  dtypes: [f32, bf16]
 
 - kernel: level2/74_ConvTranspose3d_LeakyReLU_Multiply_LeakyReLU_Max.py
   input_shapes: [16x16x16x32x32]
   initializations: [rnd]
   output_shape: 16x32x16x32x32
-  dtypes: [f32, bf16]
 
 - kernel: level2/75_Gemm_GroupNorm_Min_BiasAdd.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1x8192x1024x1
-  dtypes: [f32, bf16]
 
 - kernel: level2/76_Gemm_Add_ReLU.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/77_ConvTranspose3d_Scale_BatchNorm_GlobalAvgPool.py
   input_shapes: [4x64x16x32x32]
   initializations: [rnd]
   output_shape: 4x128x1x1x1
-  dtypes: [f32, bf16]
 
 - kernel: level2/78_ConvTranspose3d_Max_Max_Sum.py
   input_shapes: [16x32x32x32x32]
   initializations: [rnd]
   output_shape: 16x1x10x10x10
-  dtypes: [f32, bf16]
 
 - kernel: level2/79_Conv3d_Multiply_InstanceNorm_Clamp_Multiply_Max.py
   input_shapes: [128x3x16x32x32]
   initializations: [rnd]
   output_shape: 128x14x30x30
-  dtypes: [f32, bf16]
   warning: "LLVM ERROR: SmallVector unable to grow (93TB! > 4GB)"
 
 - kernel: level2/80_Gemm_Max_Subtract_GELU.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x1
-  dtypes: [f32, bf16]
 
 - kernel: level2/81_Gemm_Swish_Divide_Clamp_Tanh_Clamp.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/82_Conv2d_Tanh_Scaling_BiasAdd_Max.py
   input_shapes: [128x8x256x256]
   initializations: [rnd]
   output_shape: 128x64x63x63
-  dtypes: [f32, bf16]
 
 - kernel: level2/83_Conv3d_GroupNorm_Min_Clamp_Dropout.py
   input_shapes: [128x3x16x64x64]
   initializations: [rnd]
   output_shape: 128x16x14x62x62
-  dtypes: [f32, bf16]
 
 - kernel: level2/84_Gemm_BatchNorm_Scaling_Softmax.py
   input_shapes: [8x8192]
   initializations: [rnd]
   output_shape: 8x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/85_Conv2d_GroupNorm_Scale_MaxPool_Clamp.py
   input_shapes: [128x8x128x128]
   initializations: [rnd]
   output_shape: 128x64x31x31
-  dtypes: [f32, bf16]
 
 - kernel: level2/86_Matmul_Divide_GELU.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/87_Conv2d_Subtract_Subtract_Mish.py
   input_shapes: [128x8x256x256]
   initializations: [rnd]
   output_shape: 128x64x254x254
-  dtypes: [f32, bf16]
 
 - kernel: level2/88_Gemm_GroupNorm_Swish_Multiply_Swish.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/89_ConvTranspose3d_MaxPool_Softmax_Subtract_Swish_Max.py
   input_shapes: [128x3x16x32x32]
   initializations: [rnd]
   output_shape: 128x16x32x32
-  dtypes: [f32, bf16]
 
 - kernel: level2/90_Conv3d_LeakyReLU_Sum_Clamp_GELU.py
   input_shapes: [128x8x16x64x64]
   initializations: [rnd]
   output_shape: 128x64x14x62x62
-  dtypes: [f32, bf16]
 
 - kernel: level2/91_ConvTranspose2d_Softmax_BiasAdd_Scaling_Sigmoid.py
   input_shapes: [128x64x64x64]
   initializations: [rnd]
   output_shape: 128x128x129x129
-  dtypes: [f32, bf16]
 
 - kernel: level2/92_Conv2d_GroupNorm_Tanh_HardSwish_ResidualAdd_LogSumExp.py
   input_shapes: [128x8x128x128]
   initializations: [rnd]
   output_shape: 128x1x126x126
-  dtypes: [f32, bf16]
   warning: "error: failed to legalize operation 'torch.constant.bool'"
 
 - kernel: level2/93_ConvTranspose2d_Add_Min_GELU_Multiply.py
   input_shapes: [128x64x64x64]
   initializations: [rnd]
   output_shape: 128x128x130x130
-  dtypes: [f32, bf16]
 
 - kernel: level2/94_Gemm_BiasAdd_Hardtanh_Mish_GroupNorm.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/95_Matmul_Add_Swish_Tanh_GELU_Hardtanh.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/96_ConvTranspose3d_Multiply_Max_GlobalAvgPool_Clamp.py
   input_shapes: [128x3x16x32x32]
   initializations: [rnd]
   output_shape: 128x16x1x1x1
-  dtypes: [f32, bf16]
 
 - kernel: level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.py
   input_shapes: [8x8192]
   initializations: [rnd]
   output_shape: 8x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/98_Matmul_AvgPool_GELU_Scale_Max.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024
-  dtypes: [f32, bf16]
 
 - kernel: level2/99_Matmul_GELU_Softmax.py
   input_shapes: [1024x8192]
   initializations: [rnd]
   output_shape: 1024x8192
-  dtypes: [f32, bf16]
 
 - kernel: level2/100_ConvTranspose3d_Clamp_Min_Divide.py
   input_shapes: [16x64x24x48x48]
   initializations: [rnd]
   output_shape: 16x128x47x95x95
-  dtypes: [f32, bf16]

--- a/examples/KernelBench/test-kernel-bench.py
+++ b/examples/KernelBench/test-kernel-bench.py
@@ -1,7 +1,5 @@
 # RUN: python %s --ci | FileCheck %s
 # RUN: python %s --ci --torch-compile | FileCheck %s
-# RUN: python %s --ci --dtype=bf16 | FileCheck %s
-# RUN: python %s --ci --dtype=bf16 --torch-compile | FileCheck %s
 
 # REQUIRES: torch
 # REQUIRES: kernel_bench
@@ -66,13 +64,6 @@ def get_tests(args: argparse.Namespace) -> list[dict]:
     """
     Returns the list of tests to be executed.
     """
-    if args.ci:
-        print(
-            "Running in CI mode: fewer tests, no bf16, no benchmarking for faster feedback"
-        )
-        args.bf16 = False  # Disable bf16 tests in CI for faster feedback
-        args.benchmark = False  # Disable benchmarking in CI for faster feedback
-
     tests = []
     with open(level1_yaml_path) as f:
         tests = yaml.safe_load(f)

--- a/examples/KernelBench/test-kernel-bench.py
+++ b/examples/KernelBench/test-kernel-bench.py
@@ -1,5 +1,7 @@
 # RUN: python %s --ci | FileCheck %s
 # RUN: python %s --ci --torch-compile | FileCheck %s
+# RUN: python %s --ci --dtype=bf16 | FileCheck %s
+# RUN: python %s --ci --dtype=bf16 --torch-compile | FileCheck %s
 
 # REQUIRES: torch
 # REQUIRES: kernel_bench
@@ -88,33 +90,31 @@ def get_tests(args: argparse.Namespace) -> list[dict]:
         # Smoke tests run on the simplest lowering
         if args.smoke_test:
             test["pipeline"] = str(kb_default_pipeline)
-        for dtype in test["dtypes"]:
-            if not args.bf16 and dtype == "bf16":
-                continue
-            test_list.append(
-                {
-                    "kernel": test["kernel"],
-                    "input_shapes": ",".join(
-                        f"{shape}x{dtype}x{init}"
-                        for shape, init in zip(
-                            test["input_shapes"], test["initializations"]
-                        )
-                    ),
-                    "output_shape": f"{test['output_shape']}x{dtype}x0",
-                    "init_args": test.get("init_args", "None"),
-                    "gflops": eval(test["gflops"])
-                    if "gflops" in test and args.benchmark
-                    else None,
-                    "pipeline": str(
-                        get_pipeline_file(
-                            test.get("pipeline", ""),
-                            dtype,
-                            TargetInfo(args.target, args.feature),
-                        )
-                    ),
-                    "warning": test.get("warning", None),
-                }
-            )
+
+        test_list.append(
+            {
+                "kernel": test["kernel"],
+                "input_shapes": ",".join(
+                    f"{shape}x{args.dtype}x{init}"
+                    for shape, init in zip(
+                        test["input_shapes"], test["initializations"]
+                    )
+                ),
+                "output_shape": f"{test['output_shape']}x{args.dtype}x0",
+                "init_args": test.get("init_args", "None"),
+                "gflops": eval(test["gflops"])
+                if "gflops" in test and args.benchmark
+                else None,
+                "pipeline": str(
+                    get_pipeline_file(
+                        test.get("pipeline", ""),
+                        args.dtype,
+                        TargetInfo(args.target, args.feature),
+                    )
+                ),
+                "warning": test.get("warning", None),
+            }
+        )
     return test_list
 
 
@@ -132,14 +132,15 @@ if __name__ == "__main__":
         description="""Kernel Bench testing & benchmarking."""
     )
     Parser.add_argument(
+        "--dtype",
+        type=str,
+        default="f32",
+        help="Data type. Default f32.",
+    )
+    Parser.add_argument(
         "--benchmark",
         action=argparse.BooleanOptionalAction,
         help="Whether to run the benchmark.",
-    )
-    Parser.add_argument(
-        "--bf16",
-        action=argparse.BooleanOptionalAction,
-        help="Enable bf16 precision kernels.",
     )
     Parser.add_argument(
         "--ci",
@@ -199,16 +200,12 @@ if __name__ == "__main__":
             str(kb_kernel),
             "--pipeline",
             test["pipeline"],
+            "--dtype",
+            args.dtype,
         ]
-        # Benchmarks only if there's data to calculate FLOPS.
-        benchmark = args.benchmark and test.get("gflops") is not None
-        if benchmark:
+        # Benchmark mode.
+        if args.benchmark:
             command_line += ["--benchmark"]
-        elif args.benchmark:
-            print(
-                f"WARNING: Benchmarking enabled but no GFLOPS data for kernel {test['kernel']}."
-                f" Skipping benchmark."
-            )
 
         if not args.infer_shapes:
             command_line += [
@@ -249,10 +246,14 @@ if __name__ == "__main__":
         if capture_output:
             print("STDOUT:")
             print(result.stdout)
-            if benchmark:
+            # Only show "performance" if gflops count is available.
+            if args.benchmark and test["gflops"] is not None:
                 flops_per_second = get_flops_per_second(result.stdout, test["gflops"])
                 if flops_per_second > 0:
                     print(f"Performance: {flops_per_second:.2f} GFLOPS")
+            # Otherwise just keep the timer and let the user calculate GFLOPS themselves.
+            elif args.benchmark:
+                print("Performance: GFLOPS data not available for this test.")
 
             print("STDERR:")
             print(result.stderr)

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -26,11 +26,25 @@ lib_dir = get_mlir_library_path()
 c_runner_lib = os.path.join(lib_dir, "libmlir_c_runner_utils.so")
 
 
+def from_numpy(buf):
+    """
+    Converts a numpy array to a torch tensor.
+    If the numpy array is of type bfloat16, it is first reinterpreted as uint16
+    to be compatible with torch.from_numpy(), and then viewed as bfloat16.
+    """
+    return (
+        torch.from_numpy(buf.view(np.uint16)).view(torch.bfloat16)
+        if buf.dtype == ml_dtypes.bfloat16
+        else torch.from_numpy(buf)
+    )
+
+
 def import_torch(
     filepath: str | Path,
     model_class_name: str = "Model",
     sample_args=None,
     model_init_args=None,
+    dtype=torch.float32,
 ) -> torch.nn.Module:
     """
     Imports a PyTorch model from a KernelBench file and returns the PyTorch module.
@@ -42,6 +56,7 @@ def import_torch(
             model_class_name=model_class_name,
             sample_args=sample_args,
             model_init_args=model_init_args,
+            dtype=dtype,
         )
         assert isinstance(model, torch.nn.Module)
         return model, sample_args, sample_kwargs
@@ -132,18 +147,12 @@ def parse_module_arguments(
     # Parse input shapes first, to create sample tensors for the inputs only
     buffers = [arg.arg for arg in KernelArgumentParser.parse_all(input_shapes_str)]
     # Build sample torch tensors from input shapes to override hard-coded sizes in get_inputs().
-    # torch.from_numpy() does not support ml_dtypes.bfloat16, so reinterpret as uint16 first.
     if any(buf.dtype == ml_dtypes.bfloat16 for buf in buffers):
         print(
             "Warning: bfloat16 is not natively supported by torch.from_numpy(), \
             so we are reinterpreting the buffers as uint16. This may cause issues if the buffers are modified after creation."
         )
-    sample_tensors = [
-        torch.from_numpy(buf.view(np.uint16)).view(torch.bfloat16)
-        if buf.dtype == ml_dtypes.bfloat16
-        else torch.from_numpy(buf)
-        for buf in buffers
-    ]
+    sample_tensors = [from_numpy(buf) for buf in buffers]
     init_args = string_to_type(init_args_str)
 
     # Now include the output shape in the buffers
@@ -220,7 +229,7 @@ def torch_import(args, model: torch.nn.Module, buffers: list, sample_tensors: li
             host_input_buffers=buffers,
         )
 
-    return torch.from_numpy(buffers[0])
+    return from_numpy(buffers[0])
 
 
 def compare_outputs(out_ref, out, tolerance, max_tolerance):
@@ -245,6 +254,15 @@ def compare_outputs(out_ref, out, tolerance, max_tolerance):
             return False, tol / 10
         tol *= 10
     return False, max_tol
+
+
+def get_data_type(dtype_str: str):
+    if dtype_str == "f32":
+        return torch.float32
+    elif dtype_str == "bf16":
+        return ml_dtypes.bfloat16
+    else:
+        raise ValueError(f"Unsupported data type: {dtype_str}")
 
 
 if __name__ == "__main__":
@@ -274,6 +292,12 @@ if __name__ == "__main__":
         "--init-args",
         type=str,
         help="Comma-separated list of arguments to initialize the model.",
+    )
+    Parser.add_argument(
+        "--dtype",
+        type=str,
+        default="f32",
+        help="Data type. Default f32.",
     )
     Parser.add_argument(
         "--seed",
@@ -355,12 +379,16 @@ if __name__ == "__main__":
     else:
         np.random.seed(int(datetime.now().timestamp()))
 
+    # Validate input/output/init arguments
     if (
         args.input_shapes is None or args.output_shape is None
     ) and not args.torch_compile:
         raise ValueError(
             "--input-shapes and --output-shape must be provided together for non-torch-compile mode."
         )
+
+    # Validate data type argument
+    dtype = get_data_type(args.dtype)
 
     # Initialize the device data
     buffers, sample_tensors, init_args = parse_module_arguments(
@@ -369,7 +397,10 @@ if __name__ == "__main__":
 
     # First, import the model and run the reference numbers
     model, sample_args, sample_kwargs = import_torch(
-        args.kernel_bench_model, sample_args=sample_tensors, model_init_args=init_args
+        args.kernel_bench_model,
+        sample_args=sample_tensors,
+        model_init_args=init_args,
+        dtype=dtype,
     )
     if args.validate:
         out_ref = model(*sample_args, **sample_kwargs)

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -256,7 +256,7 @@ def compare_outputs(out_ref, out, tolerance, max_tolerance):
     return False, max_tol
 
 
-def get_data_type(dtype_str: str):
+def get_torch_data_type(dtype_str: str):
     if dtype_str == "f32":
         return torch.float32
     elif dtype_str == "bf16":
@@ -297,6 +297,7 @@ if __name__ == "__main__":
         "--dtype",
         type=str,
         default="f32",
+        choices=["f32", "bf16"],
         help="Data type. Default f32.",
     )
     Parser.add_argument(
@@ -388,7 +389,7 @@ if __name__ == "__main__":
         )
 
     # Validate data type argument
-    dtype = get_data_type(args.dtype)
+    dtype = get_torch_data_type(args.dtype)
 
     # Initialize the device data
     buffers, sample_tensors, init_args = parse_module_arguments(


### PR DESCRIPTION
As noted in the TODO, this PR makes use of #169 to allow conversion of models to an appropriate data type. For now, only F32 and BF16 are supported, but it should not be hard to make other data types available.

Also, fix the bf16 output return and add tests in CI.