### PR TITLE
Batch matmul pipeline

### DIFF
--- a/examples/KernelBench/level1.yaml
+++ b/examples/KernelBench/level1.yaml
@@ -13,10 +13,11 @@
   pipeline: matmul
 
 - kernel: level1/3_Batched_matrix_multiplication.py
-  input_shapes: [4x64x32, 4x32x64]
+  input_shapes: [128x64x32, 128x32x64]
   initializations: [rnd, rnd]
-  output_shape: 4x64x64
-  gflops: (4 * 64 * 32 * 64 * 2) / 1e9
+  output_shape: 128x64x64
+  gflops: (128 * 64 * 32 * 64 * 2) / 1e9
+  pipeline: batch_matmul
 
 - kernel: level1/4_Matrix_vector_multiplication_.py
   input_shapes: [1024x1024, 1024x1]

--- a/examples/KernelBench/schedules/x86_64/batch_matmul/bf16.yaml
+++ b/examples/KernelBench/schedules/x86_64/batch_matmul/bf16.yaml
@@ -1,0 +1,15 @@
+# This is an optimizing pipeline for kernel_bench matmuls on bf16 types.
+# This is basically a copy of the fp32 pipeline, with ONE CHANGE:
+#  - register_tiling.py -> reg_unroll_k=2 (instead of 1)
+Pipeline:
+  - include: ../pack_and_tile.yaml
+
+  ## CPU specific register tiling (depends on uArch & data type)
+  - schedule: "x86/register_tiling.py[gen=matmul_register_tiling]{target=linalg.contract reg_tile_m=8 reg_tile_n=32 reg_tile_k=2}"
+  - schedule: "x86/register_tiling.py[gen=matmul_register_unroll]{target=linalg.contract reg_tile_m=8 reg_tile_n=32 reg_tile_k=2 reg_unroll_m=1 reg_unroll_n=16 reg_unroll_k=2}"
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.fill tile_sizes=[1,1,1]}"
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic tile_sizes=[1,8]}"
+
+  - include: ../vectorize.yaml
+
+  - include: ../lower.yaml

--- a/examples/KernelBench/schedules/x86_64/batch_matmul/f32.yaml
+++ b/examples/KernelBench/schedules/x86_64/batch_matmul/f32.yaml
@@ -1,0 +1,15 @@
+# This is an optimizing pipeline for kernel_bench matmuls on fp32 types.
+# Tested on x86_64 with AVX512 reaching good performance for simple KB kernels.
+# It may not apply to other workloads / extensions / architectures, so use with caution.
+Pipeline:
+  - include: ../pack_and_tile.yaml
+
+  ## CPU specific register tiling (depends on uArch & data type)
+  - schedule: "x86/register_tiling.py[gen=matmul_register_tiling]{target=linalg.contract reg_tile_m=8 reg_tile_n=32 reg_tile_k=2}"
+  - schedule: "x86/register_tiling.py[gen=matmul_register_unroll]{target=linalg.contract reg_tile_m=8 reg_tile_n=32 reg_tile_k=2 reg_unroll_m=1 reg_unroll_n=16 reg_unroll_k=1}"
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.fill tile_sizes=[1,1,1]}"
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic tile_sizes=[1,8]}"
+
+  - include: ../vectorize.yaml
+
+  - include: ../lower.yaml


### PR DESCRIPTION
Reaching twice the performance of compiler vectorized code, and about 2/3 of peak for matmul, so not bad, but also nothing special.

This is basically a single change from the matmul ones, so will serve as a way to test parametrization next more than anything, but already makes the CI faster.