### PR TITLE
[ingress][torch][runner] PyTorch backend - dump object file

### DIFF
--- a/lighthouse/execution/runner.py
+++ b/lighthouse/execution/runner.py
@@ -6,7 +6,6 @@ import typing
 import numpy as np
 import ctypes
 import os
-import tempfile
 from contextlib import contextmanager
 from functools import partial
 from typing import Optional, Callable
@@ -213,20 +212,18 @@ class Runner:
             benchmark=False,
         )
 
-    def dump_object_file(self, file_name: str = "") -> str:
+    def dump_object_file(self, file_name: str) -> str:
         """
         Dump the compiled object file.
 
         Args:
-            file_name: Optional target file.
-                If not provided, a temporary file is created.
+            file_name: Target output file.
 
         Returns:
             Name of the dumped file.
         """
         if not file_name:
-            with tempfile.NamedTemporaryFile(suffix=".o", delete=False) as tmp:
-                file_name = tmp.name
+            raise ValueError("non-empty file_name must be provided")
         self.engine.dump_to_object_file(file_name)
         return file_name
 

--- a/lighthouse/ingress/torch/compile.py
+++ b/lighthouse/ingress/torch/compile.py
@@ -3,7 +3,6 @@ from collections.abc import Sequence
 import contextlib
 from dataclasses import dataclass
 from enum import Enum
-import sys
 
 from lighthouse import utils as lh_utils
 from lighthouse.ingress.torch import import_from_model
@@ -62,9 +61,7 @@ class JITFunction:
         n_outputs: Number of last N outputs to return.
             Used to skip extra torch-mlir prepended results that might not
             be necessary.
-        dump_obj: Output compiled object file.
-            Optionally, a file name can be provided. Otherwise, a temporary
-            file is created.
+        dump_obj_file: Target output object file.
     """
 
     def __init__(
@@ -74,17 +71,13 @@ class JITFunction:
         shared_libs: Sequence[str] = [],
         entry_func: str = "main",
         n_outputs: int | None = None,
-        dump_obj: str | bool = False,
+        dump_obj_file: str = "",
     ):
         self.runner = Runner(
             module, mem_manager_cls=TorchMemoryManager, shared_libs=shared_libs
         )
-        if dump_obj:
-            file_name = ""
-            if isinstance(dump_obj, str):
-                file_name = dump_obj
-            file_name = self.runner.dump_object_file(file_name)
-            print(f"MLIR object file: {file_name}", file=sys.stderr)
+        if dump_obj_file:
+            self.runner.dump_object_file(dump_obj_file)
         self.entry_func = entry_func
         self.results = results
         self.n_outputs = n_outputs if n_outputs is not None else len(results)
@@ -145,9 +138,7 @@ class MLIRBackend:
         shared_libs: Paths to external runtime libraries used to execute
             compiled MLIR function.
         entry_func: Name of the entry function.
-        dump_obj: Output compiled object file.
-            Optionally, a file name can be provided. Otherwise, a temporary
-            file is created.
+        dump_obj_file: Target output object file.
     """
 
     def __init__(
@@ -158,7 +149,7 @@ class MLIRBackend:
         ir_context: ir.Context | None = None,
         shared_libs: Sequence[str] = [],
         entry_func: str = "main",
-        dump_obj: str | bool = False,
+        dump_obj_file: str = "",
     ):
         self.device = device
         self.fn_compile = fn_compile
@@ -166,7 +157,7 @@ class MLIRBackend:
         self.ctx = ir_context if ir_context is not None else ir.Context()
         self.shared_libs = list(shared_libs)
         self.entry_func = entry_func
-        self.dump_obj = dump_obj
+        self.dump_obj_file = dump_obj_file
 
     def get_entry_func(self, module: ir.Module) -> func.FuncOp | None:
         """
@@ -357,7 +348,7 @@ class MLIRBackend:
             shared_libs=self.shared_libs,
             entry_func=self.entry_func,
             n_outputs=n_fx_outputs,
-            dump_obj=self.dump_obj,
+            dump_obj_file=self.dump_obj_file,
         )
 
 
@@ -367,7 +358,7 @@ def cpu_backend(
     ir_context: ir.Context | None = None,
     shared_libs: Sequence[str] = [],
     entry_func: str = "main",
-    dump_obj: str | bool = False,
+    dump_obj_file: str = "",
 ) -> Callable[[torch.fx.GraphModule, list[torch.Tensor]], Callable]:
     """
     CPU backend for JIT-compiling a PyTorch model using MLIR.
@@ -381,9 +372,7 @@ def cpu_backend(
         shared_libs: Paths to external runtime libraries used to execute
             compiled MLIR function.
         entry_func: Name of the entry function.
-        dump_obj: Output compiled object file.
-            Optionally, a file name can be provided. Otherwise, a temporary
-            file is created.
+        dump_obj_file: Target output object file.
 
     Returns:
         A torch.compile backend object.
@@ -395,7 +384,7 @@ def cpu_backend(
         ir_context=ir_context,
         shared_libs=shared_libs,
         entry_func=entry_func,
-        dump_obj=dump_obj,
+        dump_obj_file=dump_obj_file,
     )
 
 
@@ -406,7 +395,7 @@ def gpu_backend(
     ir_context: ir.Context | None = None,
     shared_libs: Sequence[str] = [],
     entry_func: str = "main",
-    dump_obj: str | bool = False,
+    dump_obj_file: str = "",
 ) -> Callable[[torch.fx.GraphModule, list[torch.Tensor]], Callable]:
     """
     GPU backend for JIT-compiling a PyTorch model using MLIR.
@@ -421,9 +410,7 @@ def gpu_backend(
         shared_libs: Paths to external runtime libraries used to execute
             compiled MLIR function.
         entry_func: Name of the entry function.
-        dump_obj: Output compiled object file.
-            Optionally, a file name can be provided. Otherwise, a temporary
-            file is created.
+        dump_obj_file: Target output object file.
 
     Returns:
         A torch.compile backend object.
@@ -437,5 +424,5 @@ def gpu_backend(
         ir_context=ir_context,
         shared_libs=shared_libs,
         entry_func=entry_func,
-        dump_obj=dump_obj,
+        dump_obj_file=dump_obj_file,
     )

--- a/lighthouse/ingress/torch/compile.py
+++ b/lighthouse/ingress/torch/compile.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 import contextlib
 from dataclasses import dataclass
 from enum import Enum
+import sys
 
 from lighthouse import utils as lh_utils
 from lighthouse.ingress.torch import import_from_model
@@ -58,6 +59,12 @@ class JITFunction:
         shared_libs: Paths to external runtime libraries used to execute
             compiled MLIR function.
         entry_func: Name of the entry function.
+        n_outputs: Number of last N outputs to return.
+            Used to skip extra torch-mlir prepended results that might not
+            be necessary.
+        dump_obj: Output compiled object file.
+            Optionally, a file name can be provided. Otherwise, a temporary
+            file is created.
     """
 
     def __init__(
@@ -67,10 +74,17 @@ class JITFunction:
         shared_libs: Sequence[str] = [],
         entry_func: str = "main",
         n_outputs: int | None = None,
+        dump_obj: str | bool = False,
     ):
         self.runner = Runner(
             module, mem_manager_cls=TorchMemoryManager, shared_libs=shared_libs
         )
+        if dump_obj:
+            file_name = ""
+            if isinstance(dump_obj, str):
+                file_name = dump_obj
+            file_name = self.runner.dump_object_file(file_name)
+            print(f"MLIR object file: {file_name}", file=sys.stderr)
         self.entry_func = entry_func
         self.results = results
         self.n_outputs = n_outputs if n_outputs is not None else len(results)
@@ -131,6 +145,9 @@ class MLIRBackend:
         shared_libs: Paths to external runtime libraries used to execute
             compiled MLIR function.
         entry_func: Name of the entry function.
+        dump_obj: Output compiled object file.
+            Optionally, a file name can be provided. Otherwise, a temporary
+            file is created.
     """
 
     def __init__(
@@ -141,6 +158,7 @@ class MLIRBackend:
         ir_context: ir.Context | None = None,
         shared_libs: Sequence[str] = [],
         entry_func: str = "main",
+        dump_obj: str | bool = False,
     ):
         self.device = device
         self.fn_compile = fn_compile
@@ -148,6 +166,7 @@ class MLIRBackend:
         self.ctx = ir_context if ir_context is not None else ir.Context()
         self.shared_libs = list(shared_libs)
         self.entry_func = entry_func
+        self.dump_obj = dump_obj
 
     def get_entry_func(self, module: ir.Module) -> func.FuncOp | None:
         """
@@ -338,6 +357,7 @@ class MLIRBackend:
             shared_libs=self.shared_libs,
             entry_func=self.entry_func,
             n_outputs=n_fx_outputs,
+            dump_obj=self.dump_obj,
         )
 
 
@@ -347,6 +367,7 @@ def cpu_backend(
     ir_context: ir.Context | None = None,
     shared_libs: Sequence[str] = [],
     entry_func: str = "main",
+    dump_obj: str | bool = False,
 ) -> Callable[[torch.fx.GraphModule, list[torch.Tensor]], Callable]:
     """
     CPU backend for JIT-compiling a PyTorch model using MLIR.
@@ -360,6 +381,9 @@ def cpu_backend(
         shared_libs: Paths to external runtime libraries used to execute
             compiled MLIR function.
         entry_func: Name of the entry function.
+        dump_obj: Output compiled object file.
+            Optionally, a file name can be provided. Otherwise, a temporary
+            file is created.
 
     Returns:
         A torch.compile backend object.
@@ -371,6 +395,7 @@ def cpu_backend(
         ir_context=ir_context,
         shared_libs=shared_libs,
         entry_func=entry_func,
+        dump_obj=dump_obj,
     )
 
 
@@ -381,6 +406,7 @@ def gpu_backend(
     ir_context: ir.Context | None = None,
     shared_libs: Sequence[str] = [],
     entry_func: str = "main",
+    dump_obj: str | bool = False,
 ) -> Callable[[torch.fx.GraphModule, list[torch.Tensor]], Callable]:
     """
     GPU backend for JIT-compiling a PyTorch model using MLIR.
@@ -395,6 +421,9 @@ def gpu_backend(
         shared_libs: Paths to external runtime libraries used to execute
             compiled MLIR function.
         entry_func: Name of the entry function.
+        dump_obj: Output compiled object file.
+            Optionally, a file name can be provided. Otherwise, a temporary
+            file is created.
 
     Returns:
         A torch.compile backend object.
@@ -408,4 +437,5 @@ def gpu_backend(
         ir_context=ir_context,
         shared_libs=shared_libs,
         entry_func=entry_func,
+        dump_obj=dump_obj,
     )

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -217,7 +217,7 @@ def torch_compile(args, model: torch.nn.Module, sample_tensors: list):
         model.compile(
             dynamic=False,
             backend=cpu_backend(
-                compiler_pipeline, shared_libs=[c_runner_lib], dump_obj=obj_file
+                compiler_pipeline, shared_libs=[c_runner_lib], dump_obj_file=obj_file
             ),
         )
         out = model(*sample_tensors, **sample_kwargs)

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -262,7 +262,8 @@ def torch_import(args, model: torch.nn.Module, buffers: list, sample_tensors: li
         )
 
     if args.dump_assembly:
-        dump_assembly(args, runner.dump_object_file())
+        obj_file = Path(args.kernel_bench_model).stem + ".o"
+        dump_assembly(args, runner.dump_object_file(obj_file))
 
     return from_numpy(buffers[0])
 

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -8,7 +8,6 @@ import ml_dtypes
 import numpy as np
 from pathlib import Path
 import torch
-import tempfile
 
 from mlir import ir
 from lighthouse.execution.runner import Runner
@@ -204,8 +203,7 @@ def torch_compile(args, model: torch.nn.Module, sample_tensors: list):
 
     obj_file = ""
     if args.dump_assembly:
-        with tempfile.NamedTemporaryFile(suffix=".o", delete=False) as tmp:
-            obj_file = tmp.name
+        obj_file = Path(args.kernel_bench_model).stem + ".o"
 
     # TODO: Implement benchmarking
     if args.benchmark:

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -8,6 +8,7 @@ import ml_dtypes
 import numpy as np
 from pathlib import Path
 import torch
+import tempfile
 
 from mlir import ir
 from lighthouse.execution.runner import Runner
@@ -201,6 +202,11 @@ def torch_compile(args, model: torch.nn.Module, sample_tensors: list):
             print(module)
         return module
 
+    obj_file = ""
+    if args.dump_assembly:
+        with tempfile.NamedTemporaryFile(suffix=".o", delete=False) as tmp:
+            obj_file = tmp.name
+
     # TODO: Implement benchmarking
     if args.benchmark:
         raise NotImplementedError(
@@ -210,9 +216,14 @@ def torch_compile(args, model: torch.nn.Module, sample_tensors: list):
         # Reconfigure the model to be compiled using torch.compile, take the compiled output.
         model.compile(
             dynamic=False,
-            backend=cpu_backend(compiler_pipeline, shared_libs=[c_runner_lib]),
+            backend=cpu_backend(
+                compiler_pipeline, shared_libs=[c_runner_lib], dump_obj=obj_file
+            ),
         )
         out = model(*sample_tensors, **sample_kwargs)
+
+        if args.dump_assembly and obj_file:
+            dump_assembly(args, obj_file)
 
     return out
 


### PR DESCRIPTION
Enables MLIR object file creation in the PyTorch backend.
Removes temporary file creation for the object files. Instead, users must explicitly provide a file name for the dumps.

Tools are updated accordingly.
The new functionality is used in kernel-bench tool to enable assembly dumps when torch-compile option is enabled.