### PR TITLE
[Descriptor] Allow variable replacement in descriptor files

### DIFF
--- a/examples/KernelBench/level1.yaml
+++ b/examples/KernelBench/level1.yaml
@@ -13,10 +13,10 @@
   pipeline: matmul
 
 - kernel: level1/3_Batched_matrix_multiplication.py
-  input_shapes: [128x64x32, 128x32x64]
+  input_shapes: [8x64x32, 8x32x64]
   initializations: [rnd, rnd]
-  output_shape: 128x64x64
-  gflops: (128 * 64 * 32 * 64 * 2) / 1e9
+  output_shape: 8x64x64
+  gflops: (8 * 64 * 32 * 64 * 2) / 1e9
   pipeline: batch_matmul
 
 - kernel: level1/4_Matrix_vector_multiplication_.py

--- a/examples/KernelBench/schedules/x86_64/batch_matmul/bf16.yaml
+++ b/examples/KernelBench/schedules/x86_64/batch_matmul/bf16.yaml
@@ -1,15 +1,14 @@
-# This is an optimizing pipeline for kernel_bench matmuls on bf16 types.
-# This is basically a copy of the fp32 pipeline, with ONE CHANGE:
-#  - register_tiling.py -> reg_unroll_k=2 (instead of 1)
+# This is an optimizing pipeline for simple GEMM kernels.
 Pipeline:
-  - include: ../pack_and_tile.yaml
-
-  ## CPU specific register tiling (depends on uArch & data type)
-  - schedule: "x86/register_tiling.py[gen=matmul_register_tiling]{target=linalg.contract reg_tile_m=8 reg_tile_n=32 reg_tile_k=2}"
-  - schedule: "x86/register_tiling.py[gen=matmul_register_unroll]{target=linalg.contract reg_tile_m=8 reg_tile_n=32 reg_tile_k=2 reg_unroll_m=1 reg_unroll_n=16 reg_unroll_k=2}"
-  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.fill tile_sizes=[1,1,1]}"
-  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic tile_sizes=[1,8]}"
-
-  - include: ../vectorize.yaml
-
-  - include: ../lower.yaml
+  - include: ../matmul-like.yaml {
+                                reg_tile_batch=0
+                                reg_tile_m=8
+                                reg_tile_n=32
+                                reg_tile_k=2
+                                batch=0
+                                reg_unroll_m=1
+                                reg_unroll_n=16
+                                reg_unroll_k=2
+                                fill_tiling=[1,1,1]
+                                generic_tiling=[1,8]
+                              }

--- a/examples/KernelBench/schedules/x86_64/batch_matmul/f32.yaml
+++ b/examples/KernelBench/schedules/x86_64/batch_matmul/f32.yaml
@@ -1,15 +1,14 @@
-# This is an optimizing pipeline for kernel_bench matmuls on fp32 types.
-# Tested on x86_64 with AVX512 reaching good performance for simple KB kernels.
-# It may not apply to other workloads / extensions / architectures, so use with caution.
+# This is an optimizing pipeline for simple GEMM kernels.
 Pipeline:
-  - include: ../pack_and_tile.yaml
-
-  ## CPU specific register tiling (depends on uArch & data type)
-  - schedule: "x86/register_tiling.py[gen=matmul_register_tiling]{target=linalg.contract reg_tile_m=8 reg_tile_n=32 reg_tile_k=2}"
-  - schedule: "x86/register_tiling.py[gen=matmul_register_unroll]{target=linalg.contract reg_tile_m=8 reg_tile_n=32 reg_tile_k=2 reg_unroll_m=1 reg_unroll_n=16 reg_unroll_k=1}"
-  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.fill tile_sizes=[1,1,1]}"
-  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic tile_sizes=[1,8]}"
-
-  - include: ../vectorize.yaml
-
-  - include: ../lower.yaml
+  - include: ../matmul-like.yaml {
+                                reg_tile_batch=0
+                                reg_tile_m=8
+                                reg_tile_n=32
+                                reg_tile_k=2
+                                batch=0
+                                reg_unroll_m=1
+                                reg_unroll_n=16
+                                reg_unroll_k=1
+                                fill_tiling=[1,1,1]
+                                generic_tiling=[1,8]
+                              }

--- a/examples/KernelBench/schedules/x86_64/matmul-like.yaml
+++ b/examples/KernelBench/schedules/x86_64/matmul-like.yaml
@@ -4,21 +4,21 @@ Pipeline:
 
   ## CPU specific register tiling (depends on uArch & data type)
   - schedule: "x86/register_tiling.py[gen=matmul_register_tiling] {
-                                                                    target=linalg.contract \
-                                                                    reg_tile_batch=$reg_tile_batch \
-                                                                    reg_tile_m=$reg_tile_m \
-                                                                    reg_tile_n=$reg_tile_n \
-                                                                    reg_tile_k=$reg_tile_k \
+                                                                    target=linalg.contract
+                                                                    reg_tile_batch=$reg_tile_batch
+                                                                    reg_tile_m=$reg_tile_m
+                                                                    reg_tile_n=$reg_tile_n
+                                                                    reg_tile_k=$reg_tile_k
                                                                   }"
   - schedule: "x86/register_tiling.py[gen=matmul_register_unroll] {
-                                                                    target=linalg.contract \
-                                                                    batch=$batch \
-                                                                    reg_tile_m=$reg_tile_m \
-                                                                    reg_tile_n=$reg_tile_n \
-                                                                    reg_tile_k=$reg_tile_k \
-                                                                    reg_unroll_m=$reg_unroll_m \
-                                                                    reg_unroll_n=$reg_unroll_n \
-                                                                    reg_unroll_k=$reg_unroll_k \
+                                                                    target=linalg.contract
+                                                                    batch=$batch
+                                                                    reg_tile_m=$reg_tile_m
+                                                                    reg_tile_n=$reg_tile_n
+                                                                    reg_tile_k=$reg_tile_k
+                                                                    reg_unroll_m=$reg_unroll_m
+                                                                    reg_unroll_n=$reg_unroll_n
+                                                                    reg_unroll_k=$reg_unroll_k
                                                                   }"
   - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.fill tile_sizes=$fill_tiling}"
   - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic tile_sizes=$generic_tiling}"

--- a/examples/KernelBench/schedules/x86_64/matmul-like.yaml
+++ b/examples/KernelBench/schedules/x86_64/matmul-like.yaml
@@ -1,0 +1,28 @@
+# This is an optimizing pipeline for kernel_bench matmul-like kernels.
+Pipeline:
+  - include: pack_and_tile.yaml
+
+  ## CPU specific register tiling (depends on uArch & data type)
+  - schedule: "x86/register_tiling.py[gen=matmul_register_tiling] {
+                                                                    target=linalg.contract \
+                                                                    reg_tile_batch=$reg_tile_batch \
+                                                                    reg_tile_m=$reg_tile_m \
+                                                                    reg_tile_n=$reg_tile_n \
+                                                                    reg_tile_k=$reg_tile_k \
+                                                                  }"
+  - schedule: "x86/register_tiling.py[gen=matmul_register_unroll] {
+                                                                    target=linalg.contract \
+                                                                    batch=$batch \
+                                                                    reg_tile_m=$reg_tile_m \
+                                                                    reg_tile_n=$reg_tile_n \
+                                                                    reg_tile_k=$reg_tile_k \
+                                                                    reg_unroll_m=$reg_unroll_m \
+                                                                    reg_unroll_n=$reg_unroll_n \
+                                                                    reg_unroll_k=$reg_unroll_k \
+                                                                  }"
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.fill tile_sizes=$fill_tiling}"
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic tile_sizes=$generic_tiling}"
+
+  - include: vectorize.yaml
+
+  - include: lower.yaml

--- a/examples/KernelBench/schedules/x86_64/matmul/bf16.yaml
+++ b/examples/KernelBench/schedules/x86_64/matmul/bf16.yaml
@@ -1,15 +1,14 @@
-# This is an optimizing pipeline for kernel_bench matmuls on bf16 types.
-# This is basically a copy of the fp32 pipeline, with ONE CHANGE:
-#  - register_tiling.py -> reg_unroll_k=2 (instead of 1)
+# This is an optimizing pipeline for simple GEMM kernels.
 Pipeline:
-  - include: ../pack_and_tile.yaml
-
-  ## CPU specific register tiling (depends on uArch & data type)
-  - schedule: "x86/register_tiling.py[gen=matmul_register_tiling]{target=linalg.contract reg_tile_batch=1 reg_tile_m=8 reg_tile_n=32 reg_tile_k=2}"
-  - schedule: "x86/register_tiling.py[gen=matmul_register_unroll]{target=linalg.contract batch=1 reg_tile_m=8 reg_tile_n=32 reg_tile_k=2 reg_unroll_m=1 reg_unroll_n=16 reg_unroll_k=2}"
-  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.fill tile_sizes=[1,1,1]}"
-  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic tile_sizes=[1,8]}"
-
-  - include: ../vectorize.yaml
-
-  - include: ../lower.yaml
+  - include: ../matmul-like.yaml {
+                                reg_tile_batch=1
+                                reg_tile_m=8
+                                reg_tile_n=32
+                                reg_tile_k=2
+                                batch=1
+                                reg_unroll_m=1
+                                reg_unroll_n=16
+                                reg_unroll_k=2
+                                fill_tiling=[1,1,1]
+                                generic_tiling=[1,8]
+                              }

--- a/examples/KernelBench/schedules/x86_64/matmul/f32.yaml
+++ b/examples/KernelBench/schedules/x86_64/matmul/f32.yaml
@@ -1,15 +1,14 @@
-# This is an optimizing pipeline for kernel_bench matmuls on fp32 types.
-# Tested on x86_64 with AVX512 reaching good performance for simple KB kernels.
-# It may not apply to other workloads / extensions / architectures, so use with caution.
+# This is an optimizing pipeline for simple GEMM kernels.
 Pipeline:
-  - include: ../pack_and_tile.yaml
-
-  ## CPU specific register tiling (depends on uArch & data type)
-  - schedule: "x86/register_tiling.py[gen=matmul_register_tiling]{target=linalg.contract reg_tile_batch=1 reg_tile_m=8 reg_tile_n=32 reg_tile_k=2}"
-  - schedule: "x86/register_tiling.py[gen=matmul_register_unroll]{target=linalg.contract batch=1 reg_tile_m=8 reg_tile_n=32 reg_tile_k=2 reg_unroll_m=1 reg_unroll_n=16 reg_unroll_k=1}"
-  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.fill tile_sizes=[1,1,1]}"
-  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic tile_sizes=[1,8]}"
-
-  - include: ../vectorize.yaml
-
-  - include: ../lower.yaml
+  - include: ../matmul-like.yaml {
+                                reg_tile_batch=1
+                                reg_tile_m=8
+                                reg_tile_n=32
+                                reg_tile_k=2
+                                batch=1
+                                reg_unroll_m=1
+                                reg_unroll_n=16
+                                reg_unroll_k=1
+                                fill_tiling=[1,1,1]
+                                generic_tiling=[1,8]
+                              }

--- a/lighthouse/pipeline/descriptor.py
+++ b/lighthouse/pipeline/descriptor.py
@@ -144,9 +144,9 @@ class Descriptor:
                 continue
             if "=" in arg:
                 key, value = arg.split("=")
-                result[key] = string_to_type(value)
+                result[key.strip()] = string_to_type(value.strip())
             else:
-                result[arg] = True
+                result[arg.strip()] = True
         return result
 
     @staticmethod
@@ -163,19 +163,22 @@ class Descriptor:
         options = {}
 
         # Args: [arg1=val1,args2]
-        if m := re.search(r"\[([^]]*)\]", line):
-            args_str = m.group(1)
-            args = Descriptor._parse_csv(args_str, ",")
+        # Note: Lists can occur inside options: { ... val=[1,2,3] ... }
+        # So we make sure the [] is not inside {}
+        if m := re.match(r"[^{]+\[", line):
+            if m := re.search(r"\[([^]]*)\]", line):
+                args_str = m.group(1).strip()
+                args = Descriptor._parse_csv(args_str, ",")
 
         # Opts: {arg1=val1 args2}
         if m := re.search(r"\{([^}]+)\}", line):
-            opts_str = m.group(1)
+            opts_str = m.group(1).strip()
             options = Descriptor._parse_csv(opts_str, " ")
 
         # Cleanup the original string
-        line = Descriptor._remove_args_and_opts(line)
+        basename = Descriptor._remove_args_and_opts(line).strip()
 
-        return [line, args, options]
+        return [basename, args, options]
 
     def __str__(self) -> str:
         """serialize basename + args + opts for transform consumption"""
@@ -224,14 +227,33 @@ class PipelineDescriptor:
                 f"PipelineDescriptor requires a Descriptor as input, got {type(desc)}"
             )
         self.descriptor = desc
+        self.base_path = (
+            os.path.dirname(desc.basename) if desc.basename else desc.base_path
+        )
         with open(desc.basename, "r") as f:
             self.pipeline_desc = yaml.safe_load(f)
+        self._apply_variables()
         self.stages: list[str] = []
         self._parse_stages()
         if not self.stages:
             raise ValueError(
                 f"Pipeline description file {desc.basename} does not contain a valid 'Pipeline'."
             )
+
+    def _apply_variables(self) -> None:
+        """
+        Apply variables to the stages in the pipeline. Variables are defined in the descriptor
+        as opts, and can be used in the stage definitions as $var_name.
+        """
+        pipeline = self.pipeline_desc.get("Pipeline", [])
+        for idx, item in enumerate(pipeline):
+            key, line = next(iter(item.items()))
+            for var, value in self.descriptor.opts.items():
+                var = "$" + var
+                value = str(value).replace(" ", "")
+                if var in line:
+                    line = line.replace(var, value)
+            pipeline[idx] = {key: line}
 
     def _parse_stages(self) -> None:
         """
@@ -245,7 +267,7 @@ class PipelineDescriptor:
 
         for stage in pipeline:
             key, value = next(iter(stage.items()))
-            desc = Descriptor(value, type=key, base_path=self.descriptor.base_path)
+            desc = Descriptor(value, type=key, base_path=self.base_path)
             if desc.is_include():
                 self._include_pipeline(desc)
 


### PR DESCRIPTION
This PR adds support for variables in descriptor files. It uses the same mechanism for passing options to schedules and the existing syntax so the only difference is to add a variable replacement in PipelineDescriptor's constructor to parse and update.

This simplifies considerably the pipelines in the kernel bench testing framework and allows for choices to be propagated through the includes to build trully parametric pipelines from one set of top-level arguments.