### PR TITLE
[KB] Matvec schedule - medium perf

### DIFF
--- a/examples/KernelBench/level1.yaml
+++ b/examples/KernelBench/level1.yaml
@@ -24,6 +24,7 @@
   initializations: [rnd, rnd]
   output_shape: 1024x1
   gflops: (1024 * 1024 * 1 * 2) / 1e9
+  pipeline: matvec
 
 - kernel: level1/5_Matrix_scalar_multiplication.py
   input_shapes: [1024x1024, "1"]
@@ -32,10 +33,10 @@
   gflops: (1024 * 1024) / 1e9
 
 - kernel: level1/6_Matmul_with_large_K_dimension_.py
-  input_shapes: [256x524288, 524288x256]
+  input_shapes: [256x8192, 8192x256]
   initializations: [rnd, rnd]
   output_shape: 256x256
-  gflops: (256 * 524288 * 256 * 2) / 1e9
+  gflops: (256 * 8192 * 256 * 2) / 1e9
   pipeline: matmul
 
 - kernel: level1/7_Matmul_with_small_K_dimension_.py
@@ -57,6 +58,7 @@
   initializations: [rnd, rnd]
   output_shape: 1024x1024
   gflops: (1024 * 32 * 1024 * 2) / 1e9
+  pipeline: batch_matmul
 
 - kernel: level1/10_3D_tensor_matrix_multiplication.py
   input_shapes: [16x1024x2048, 2048x768]

--- a/examples/KernelBench/schedules/x86_64/matvec/bf16.yaml
+++ b/examples/KernelBench/schedules/x86_64/matvec/bf16.yaml
@@ -1,0 +1,6 @@
+Pipeline:
+  - include: common.yaml{
+                          cache_tile=64
+                          register_tile=8
+                          unroll_factor=4
+                        }

--- a/examples/KernelBench/schedules/x86_64/matvec/common.yaml
+++ b/examples/KernelBench/schedules/x86_64/matvec/common.yaml
@@ -1,0 +1,29 @@
+# This is an optimizing pipeline for kernel_bench mat-vec-like kernels.
+# Assumption: M, K % 32 = 0, N = 1
+Pipeline:
+  # Pre-ops parallel 2D tiling
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.fill
+                                       tile_sizes=[$cache_tile,$cache_tile]
+                                       use_forall=True}"
+  # Matvec outer parallel M tiling
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.matmul
+                                       tile_sizes=[$cache_tile,1]
+                                       use_forall=True}"
+  # Matvec inner sequential K tiling
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.matmul
+                                       tile_sizes=[0,0,$cache_tile]}"
+  # Register tiling and unroll to fill the pipeline
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.matmul
+                                       tile_sizes=[1,1,$register_tile]
+                                       unroll_factors=[0,$unroll_factor]}"
+  # Tries to vectorize everything still at tensor level
+  - schedule: vectorization.py[gen=vectorize_all]
+
+  - include: bufferization.yaml
+
+  # These passes need bufferized IR
+  - pass: "scf-forall-to-parallel"
+  - pass: "scf-parallel-loop-fusion"
+  - pass: "scf-parallel-loop-tiling"
+
+  - include: ../lower.yaml

--- a/examples/KernelBench/schedules/x86_64/matvec/f32.yaml
+++ b/examples/KernelBench/schedules/x86_64/matvec/f32.yaml
@@ -1,0 +1,6 @@
+Pipeline:
+  - include: common.yaml{
+                          cache_tile=32
+                          register_tile=8
+                          unroll_factor=4
+                        }

--- a/lighthouse/schedule/tiling.py
+++ b/lighthouse/schedule/tiling.py
@@ -13,6 +13,7 @@ def tile_ops(
     tile_interchange: list[int] | None = None,
     peel_loops: list[int] = [],
     unroll_factors: list[int] = [],
+    use_forall: bool = False,
 ) -> ir.Module:
     """
     Tile all matching op.
@@ -49,6 +50,7 @@ def tile_ops(
                 tile_interchange=tile_interchange,
                 peel_loops=peel_loops,
                 unroll_factors=unroll_factors,
+                use_forall=use_forall,
             )
             transform.yield_()
         lh_transform.cleanup(named_seq.bodyTarget)

--- a/lighthouse/transform/tiling.py
+++ b/lighthouse/transform/tiling.py
@@ -63,9 +63,14 @@ def tile(
             use_forall=use_forall,
         ).results
     else:
-        tiled_op, *loops = structured.TileUsingForOp(
-            target, sizes=tile_sizes, interchange=tile_interchange
-        ).results
+        if use_forall:
+            tiled_op, *loops = structured.TileUsingForallOp(
+                target, tile_sizes=tile_sizes
+            ).results
+        else:
+            tiled_op, *loops = structured.TileUsingForOp(
+                target, sizes=tile_sizes, interchange=tile_interchange
+            ).results
 
     remainder_loops = [None] * len(loops)
     for idx in peel_loops:


### PR DESCRIPTION
Right now this is better than the standard schedule but about half of the (memory bound) perf expected due to using the inner product strategy and accumulating on scalar registers.

A better way to do this would be to change to a broadcast-outer product, so that both multiplication and accumulation are on full vector registers.

The Mat-scalar kernel is already good enough on the standard schedule (lower to loops), as LLVM does a good vectorization and reaches the memroy bandwidth that we expect.

At least now there's some variation on the schedules, which helps users prepare for more changes on other kernels.