### PR TITLE
[xegpu][examples] Add truncate-c option to matmul example

### DIFF
--- a/examples/xegpu/matmul.py
+++ b/examples/xegpu/matmul.py
@@ -6,6 +6,8 @@
 # RUN: %PYTHON %s --dump-kernel=xegpu-wg --relu | FileCheck %s
 # RUN: %PYTHON %s --dump-kernel=xegpu-wg --bias --relu | FileCheck %s
 # RUN: %PYTHON %s --dump-kernel=xegpu-wg --no-accumulate-c | FileCheck %s
+# RUN: %PYTHON %s --dump-kernel=xegpu-wg --truncate-c | FileCheck %s
+# RUN: %PYTHON %s --dump-kernel=xegpu-wg --bias --truncate-c | FileCheck %s
 # RUN: %PYTHON %s --dump-kernel=xegpu-wg --bias --relu --no-accumulate-c | FileCheck %s
 # CHECK: module attributes {gpu.container_module} {
 
@@ -68,8 +70,14 @@ class XeGPUMatMul:
 
     Computes C = A * B for input matrices A (M x K) and B (K x N).
 
-    Optionally adds a ReLU operation on the result C.
-    Optionally adds a bias term to C (not implemented yet).
+    If `accumulate_c` is True, computes C = A * B + C instead.
+
+    If `transpose_a` is True, treats A as transposed (i.e., K x M) and computes C = A^T * B.
+    If `transpose_b` is True, treats B as transposed (i.e., N x K) and computes C = A * B^T.
+
+    If `has_bias` is True, adds a bias term to the result.
+    If `has_relu` is True, applies ReLU activation to the result (after bias if any).
+    If `truncate_c` is True, truncates the C to A/B data type after accumulation.
     """
 
     payload_function_name: ClassVar[str] = "payload"
@@ -80,11 +88,13 @@ class XeGPUMatMul:
     K: int = 1024
     ab_type: ir.Type | str | None = None
     c_type: ir.Type | str | None = None
+    acc_type: ir.Type | str | None = None
     transpose_a: bool = False
     transpose_b: bool = False
     has_bias: bool = False
     has_relu: bool = False
     accumulate_c: bool = True
+    truncate_c: bool = False
     _input_arrays_cache: dict[bool, list[np.ndarray]] = field(
         default_factory=dict, init=False, repr=False
     )
@@ -94,14 +104,22 @@ class XeGPUMatMul:
             self.ab_type = get_mlir_elem_type(self.ab_type)
         if isinstance(self.c_type, str):
             self.c_type = get_mlir_elem_type(self.c_type)
+        if isinstance(self.acc_type, str):
+            self.acc_type = get_mlir_elem_type(self.acc_type)
         if self.ab_type is None:
             self.ab_type = ir.F16Type.get()
+        if self.acc_type is None:
+            self.acc_type = ir.F32Type.get()
         if self.c_type is None:
-            self.c_type = ir.F32Type.get()
+            self.c_type = self.ab_type if self.truncate_c else self.acc_type
         assert isinstance(self.ab_type, ir.F16Type), (
             "Only f16 type is supported for A and B"
         )
-        assert isinstance(self.c_type, ir.F32Type), "Only f32 type is supported for C"
+        assert isinstance(self.acc_type, ir.F32Type), "Only f32 type is supported for C"
+        if self.truncate_c:
+            assert self.c_type == self.ab_type, (
+                "C type must match A/B type when truncating"
+            )
         self.ab_dtype = mlir_to_numpy_dtype(self.ab_type)
         self.c_dtype = mlir_to_numpy_dtype(self.c_type)
         self.a_shape = (self.M, self.K) if not self.transpose_a else (self.K, self.M)
@@ -161,14 +179,15 @@ class XeGPUMatMul:
             N=self.N,
             K=self.K,
             ab_type=self.ab_type,
-            c_type=self.c_type,
+            c_type=self.acc_type,
+            result_type=self.c_type if not self.truncate_c else self.ab_type,
             transpose_a=self.transpose_a,
             transpose_b=self.transpose_b,
             has_bias=self.has_bias,
             has_relu=self.has_relu,
             accumulate_c=self.accumulate_c,
         )
-        ranks_and_types = [(2, self.ab_type), (2, self.c_type)]
+        ranks_and_types = list(set(((2, self.ab_type), (2, self.c_type))))
         if self.has_bias:
             ranks_and_types.append((1, self.c_type))
         self.memory_manager_class.emit_memory_management_funcs(
@@ -286,6 +305,11 @@ def cli_parser(description):
         "--no-accumulate-c",
         action="store_true",
         help="Compute plain matrix-multiply C=A*B instead of matrix-multiply-accumulate C+=A*B.",
+    )
+    parser.add_argument(
+        "--truncate-c",
+        action="store_true",
+        help="Truncate C to A,B data type after accumulation (e.g., float32 to float16).",
     )
     return parser
 
@@ -480,6 +504,7 @@ enabled via CLI arguments.
             has_bias=args.bias,
             has_relu=args.relu,
             accumulate_c=not args.no_accumulate_c,
+            truncate_c=args.truncate_c,
         )
 
         if args.check_result and not args.init_int:

--- a/examples/xegpu/tune_matmul_costmodel.py
+++ b/examples/xegpu/tune_matmul_costmodel.py
@@ -127,6 +127,7 @@ to three phases:
     has_bias = args.bias
     has_relu = args.relu
     accumulate_c = not args.no_accumulate_c
+    truncate_c = args.truncate_c
     ab_type = "f16"
     c_type = "f32"
 
@@ -157,6 +158,7 @@ to three phases:
     print(f"{has_bias=}")
     print(f"{has_relu=}")
     print(f"{accumulate_c=}")
+    print(f"{truncate_c=}")
     sys.stdout.flush()
 
     max_nb_configs = args.max_nb_configs
@@ -212,6 +214,7 @@ to three phases:
                 has_bias=has_bias,
                 has_relu=has_relu,
                 accumulate_c=accumulate_c,
+                truncate_c=truncate_c,
             )
             executed_configs.append((gflops, params))
 
@@ -305,10 +308,12 @@ to three phases:
     if args.n_dump_json > 0 and not args.dry_run:
         best_configs = [c for c in executed_configs[: args.n_dump_json]]
         sizes_str = "-".join(str(s) for s in sizes)
+        sizes_str = "-".join(str(s) for s in sizes)
         relu_str = "_relu" if has_relu else ""
         bias_str = "_bias" if has_bias else ""
         tra_str = "_tra" if transpose_a else ""
         trb_str = "_trb" if transpose_b else ""
         acc_str = "_acc" if accumulate_c else ""
-        prefix = f"matmul_params_{sizes_str}_{ab_type}-{c_type}{tra_str}{trb_str}{bias_str}{relu_str}{acc_str}"
+        trunc_str = "_trunc" if truncate_c else ""
+        prefix = f"matmul_params_{sizes_str}_{ab_type}-{c_type}{tra_str}{trb_str}{bias_str}{relu_str}{acc_str}{trunc_str}"
         dump_configs_json([p for _, p in best_configs], filename_prefix=prefix)

--- a/examples/xegpu/tune_matmul_gridsearch.py
+++ b/examples/xegpu/tune_matmul_gridsearch.py
@@ -36,6 +36,7 @@ def run_experiment(
     has_bias: bool = False,
     has_relu: bool = False,
     accumulate_c: bool = True,
+    truncate_c: bool = False,
     **params,
 ) -> tuple[float, float]:
     with ir.Context(), ir.Location.unknown():
@@ -46,12 +47,13 @@ def run_experiment(
             N=params["n"],
             K=params["k"],
             ab_type=ab_type,
-            c_type=c_type,
+            c_type=ab_type if truncate_c else c_type,
             transpose_a=params["transpose_a"],
             transpose_b=params["transpose_b"],
             has_bias=has_bias,
             has_relu=has_relu,
             accumulate_c=accumulate_c,
+            truncate_c=truncate_c,
         )
         pipeline = TransformDriver(wload.schedule_modules(parameters=params))
         payload = pipeline.apply(wload.payload_module())
@@ -214,6 +216,7 @@ if __name__ == "__main__":
     has_bias = args.bias
     has_relu = args.relu
     accumulate_c = not args.no_accumulate_c
+    truncate_c = not args.truncate_c
     ab_type = "f16"
     c_type = "f32"
 
@@ -248,6 +251,7 @@ if __name__ == "__main__":
     print(f"{has_bias=}")
     print(f"{has_relu=}")
     print(f"{accumulate_c=}")
+    print(f"{truncate_c=}")
     var_set.print()
     sys.stdout.flush()
 
@@ -278,6 +282,7 @@ if __name__ == "__main__":
             has_bias=has_bias,
             has_relu=has_relu,
             accumulate_c=accumulate_c,
+            truncate_c=truncate_c,
         )
         executed_configs.append((gflops, params))
 
@@ -297,5 +302,6 @@ if __name__ == "__main__":
         tra_str = "_tra" if transpose_a else ""
         trb_str = "_trb" if transpose_b else ""
         acc_str = "_acc" if accumulate_c else ""
-        prefix = f"matmul_params_{sizes_str}_{ab_type}-{c_type}{tra_str}{trb_str}{bias_str}{relu_str}{acc_str}"
+        trunc_str = "_trunc" if truncate_c else ""
+        prefix = f"matmul_params_{sizes_str}_{ab_type}-{c_type}{tra_str}{trb_str}{bias_str}{relu_str}{acc_str}{trunc_str}"
         dump_configs_json([p for _, p in best_configs], filename_prefix=prefix)

--- a/examples/xegpu/tune_utils.py
+++ b/examples/xegpu/tune_utils.py
@@ -60,6 +60,7 @@ def execute_and_log(
     has_bias: bool = False,
     has_relu: bool = False,
     accumulate_c: bool = True,
+    truncate_c: bool = False,
     timeout: int = 20,
 ) -> tuple[float, float]:
     entry = params.copy()
@@ -77,6 +78,7 @@ def execute_and_log(
             has_bias=has_bias,
             has_relu=has_relu,
             accumulate_c=accumulate_c,
+            truncate_c=truncate_c,
             **params,
         )
         duration = perf_counter() - tic

--- a/lighthouse/ingress/mlir_gen/gpu_matmul_payload.py
+++ b/lighthouse/ingress/mlir_gen/gpu_matmul_payload.py
@@ -14,6 +14,7 @@ def generate_gpu_matmul_payload(
     has_bias: bool,
     has_relu: bool,
     accumulate_c: bool,
+    result_type: ir.Type | None = None,
 ) -> ir.Module:
     """Generate payload function module for a matmul kernel."""
     return generate_gpu_mlp_payload(
@@ -24,8 +25,8 @@ def generate_gpu_matmul_payload(
         hidden_layer_sizes=[],
         ab_type=ab_type,
         acc_type=c_type,
-        bias_type=c_type,
-        result_type=c_type,
+        bias_type=c_type if result_type is None else result_type,
+        result_type=c_type if result_type is None else result_type,
         transpose_a=transpose_a,
         transpose_b=transpose_b,
         has_bias=has_bias,


### PR DESCRIPTION
- Adds `--truncate-c` option to cast result back to `float16`.
- Adds support for it in the cost model tuner.