### PR TITLE
[ingress][torch] Add benchmark functionality to torch.compile backend

### DIFF
--- a/examples/xegpu/torch_matmul.py
+++ b/examples/xegpu/torch_matmul.py
@@ -8,7 +8,6 @@ import json
 from typing import Optional
 from functools import partial
 import os
-import time
 
 import torch
 import torch.nn as nn
@@ -20,6 +19,7 @@ from lighthouse import dialects as lh_dialects
 from lighthouse import schedule as lh_schedule
 from lighthouse.pipeline.driver import TransformDriver
 from lighthouse.utils.mlir import get_mlir_library_path
+from lighthouse.execution.runner import Runner
 from lighthouse.schedule.xegpu import (
     mlp_schedule,
     xegpu_to_binary,
@@ -48,7 +48,9 @@ def shared_libs() -> list[str]:
     return found_libs
 
 
-def schedule_modules(parameters: Optional[dict] = None) -> list[ir.Module]:
+def schedule_modules(
+    parameters: Optional[dict] = None, benchmark: bool = False, entry_func: str = "main"
+) -> list[ir.Module]:
     assert parameters is not None, "Schedule parameters must be provided"
     schedules = []
 
@@ -59,6 +61,8 @@ def schedule_modules(parameters: Optional[dict] = None) -> list[ir.Module]:
         )
         transform.yield_()
     schedules.append(sched)
+    if benchmark:
+        schedules.append(Runner.get_bench_wrapper_schedule(entry_func))
 
     schedules.append(
         mlp_schedule(
@@ -71,8 +75,17 @@ def schedule_modules(parameters: Optional[dict] = None) -> list[ir.Module]:
     return schedules
 
 
-def lower_to_llvm(module: ir.Module, parameters: Optional[dict] = None) -> ir.Module:
-    pipeline = TransformDriver(schedule_modules(parameters=parameters))
+def lower_to_llvm(
+    module: ir.Module,
+    parameters: Optional[dict] = None,
+    benchmark: bool = False,
+    entry_func: str = "main",
+) -> ir.Module:
+    pipeline = TransformDriver(
+        schedule_modules(
+            parameters=parameters, benchmark=benchmark, entry_func=entry_func
+        )
+    )
     payload = pipeline.apply(module)
     return payload
 
@@ -244,16 +257,18 @@ enabled via CLI arguments.
         out_ref = model(a, b)
         torch.xpu.synchronize()
 
-        fn_compile = partial(lower_to_llvm, parameters=params)
+        benchmark = args.nruns > 0
+        fn_compile = partial(lower_to_llvm, parameters=params, benchmark=benchmark)
+        backend = gpu_backend(
+            fn_compile,
+            device=xpu_device,
+            dialect=TargetDialect.LINALG_ON_TENSORS,
+            ir_context=ctx,
+            shared_libs=shared_libs(),
+        )
         model.compile(
             dynamic=False,
-            backend=gpu_backend(
-                fn_compile,
-                device=xpu_device,
-                dialect=TargetDialect.LINALG_ON_TENSORS,
-                ir_context=ctx,
-                shared_libs=shared_libs(),
-            ),
+            backend=backend,
         )
         out = model(a, b)
         torch.xpu.synchronize()
@@ -263,20 +278,12 @@ enabled via CLI arguments.
         # CHECK: Compile function - result match: True
         print(f"Compile function - result match: {is_match}")
 
-        if args.nruns > 0:
-            # Warmup
-            for _ in range(args.nwarmup):
-                model(a, b)
+        if benchmark:
+            times = backend.jit_function.benchmark(
+                a, b, nruns=args.nruns, nwarmup=args.nwarmup
+            )
 
-            # Benchmark loop.
-            start = time.perf_counter_ns()
-            for i in range(args.nruns):
-                # MLIR synchronizes internally.
-                # No need for extra synchronization here.
-                model(a, b)
-            end = time.perf_counter_ns()
-
-            elapsed = (end - start) / args.nruns / 1e3  # Convert to us
+            elapsed = times.mean() * 1e6  # convert to us
             flop_count = 2 * m * n * k
             gflops = flop_count / (elapsed * 1e-6) / 1e9
 

--- a/lighthouse/ingress/torch/compile.py
+++ b/lighthouse/ingress/torch/compile.py
@@ -12,6 +12,7 @@ from mlir import ir
 from mlir.dialects import bufferization
 from mlir.dialects import func
 import torch
+import numpy as np
 
 
 class TargetDialect(Enum):
@@ -82,6 +83,27 @@ class JITFunction:
         self.results = results
         self.n_outputs = n_outputs if n_outputs is not None else len(results)
 
+    def _generate_input_args(
+        self, *args: torch.Tensor
+    ) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+        """
+        Generate input arguments for the MLIR function.
+
+        Args:
+            args: Input tensors.
+        """
+        # Allocate empty buffers to store results.
+        outs = [
+            torch.empty(res.shape, dtype=res.dtype, device=res.device)
+            for res in self.results
+        ]
+
+        # Prepare arguments according to MLIR backend's calling convention:
+        # input data followed by output storage buffers.
+        all_tensors = [arg.detach() for arg in args]
+        all_tensors.extend(outs)
+        return all_tensors, outs
+
     def __call__(
         self,
         *args: torch.Tensor,
@@ -95,23 +117,32 @@ class JITFunction:
         Returns:
             Result tensors.
         """
-        # Allocate empty buffers to store results.
-        outs = [
-            torch.empty(res.shape, dtype=res.dtype, device=res.device)
-            for res in self.results
-        ]
+        all_tensors, output_tensors = self._generate_input_args(*args)
 
-        # Prepare arguments according to MLIR backend's calling convention:
-        # input data followed by output storage buffers.
-        all_tensors = [arg.detach() for arg in args]
-        all_tensors.extend(outs)
         self.runner.execute(self.entry_func, all_tensors)
 
         # Return only the outputs corresponding to the FX graph's actual return
         # values. torch-mlir may prepend extra results for in-place state
         # mutations (e.g. BatchNorm running statistics), which Dynamo does not
         # expect in the backend callable's return value.
-        return outs[len(self.results) - self.n_outputs :]
+        return output_tensors[len(self.results) - self.n_outputs :]
+
+    def benchmark(
+        self, *args: torch.Tensor, nruns: int = 500, nwarmup: int = 500
+    ) -> np.ndarray:
+        """
+        Benchmark the jitted function.
+
+        Args:
+            args: Input tensors.
+            nruns: Number of benchmark runs.
+            nwarmup: Number of warmup runs.
+
+        Returns:
+            Array of execution times in seconds.
+        """
+        all_tensors, _ = self._generate_input_args(*args)
+        return self.runner.benchmark(all_tensors, nruns=nruns, nwarmup=nwarmup)
 
 
 class MLIRBackend:
@@ -158,6 +189,24 @@ class MLIRBackend:
         self.shared_libs = list(shared_libs)
         self.entry_func = entry_func
         self.dump_obj_file = dump_obj_file
+        self._last_jit_function: JITFunction | None = None
+
+    @property
+    def jit_function(self) -> JITFunction:
+        """
+        Access the last created JITFunction.
+
+        Returns:
+            JITFunction object.
+
+        Raises:
+            ValueError: If no model has been compiled yet.
+        """
+        if self._last_jit_function is None:
+            raise ValueError(
+                "The backend does not have a JITFunction available. Compile the torch model first."
+            )
+        return self._last_jit_function
 
     def get_entry_func(self, module: ir.Module) -> func.FuncOp | None:
         """
@@ -342,7 +391,7 @@ class MLIRBackend:
 
         mlir_mod = self.compile_mlir(mlir_mod)
 
-        return JITFunction(
+        jit_fn = JITFunction(
             mlir_mod,
             results,
             shared_libs=self.shared_libs,
@@ -350,6 +399,8 @@ class MLIRBackend:
             n_outputs=n_fx_outputs,
             dump_obj_file=self.dump_obj_file,
         )
+        self._last_jit_function = jit_fn
+        return jit_fn
 
 
 def cpu_backend(


### PR DESCRIPTION
- `JITFunction` now has a `benchmark(*args, nwarmup, nruns)` function that can be used to time the kernel.
- `MLIRBackend.jit_function` holds a reference to the latest compiled `JITFunction`.
- Updated xegpu `torch_matmul.py` example to use this benchmark method.

Basic usage:

```python
model = ... # create torch model
backend = gpu_backend(...)
model.compile(backend=backend)
outputs = model(input_a, input_b)
# accessing backend.jit_function raises an error if a model has not been compiled yet
times = backend.jit_function.benchmark(input_a, input_b, nwarmup=500, nruns=500)
avg_time = times.mean() * 1e6  # microseconds
```
