### PR TITLE
[xegpu] Elementwise schedule and refactoring

### DIFF
--- a/examples/xegpu/matmul.py
+++ b/examples/xegpu/matmul.py
@@ -209,6 +209,7 @@ class XeGPUMatMul:
 
         schedules.append(
             mlp_schedule(
+                payload_func_name=self.payload_function_name,
                 stop_at_stage=stop_at_stage,
                 params=[parameters],
             )

--- a/examples/xegpu/mlp.py
+++ b/examples/xegpu/mlp.py
@@ -252,6 +252,7 @@ class XeGPUMLP:
 
         schedules.append(
             mlp_schedule(
+                payload_func_name=self.payload_function_name,
                 stop_at_stage=stop_at_stage,
                 params=parameters,
             )

--- a/examples/xegpu/torch_matmul.py
+++ b/examples/xegpu/torch_matmul.py
@@ -66,6 +66,7 @@ def schedule_modules(
 
     schedules.append(
         mlp_schedule(
+            payload_func_name="main",
             params=[parameters],
         )
     )

--- a/lighthouse/schedule/xegpu/__init__.py
+++ b/lighthouse/schedule/xegpu/__init__.py
@@ -1,5 +1,6 @@
 from .xegpu_to_binary import xegpu_to_binary
 from .mlp_schedule import mlp_schedule
+from .elemwise_schedule import elemwise_schedule
 from .softmax_schedule import softmax_schedule
 from .layer_norm_schedule import layer_norm_schedule
 from .fused_attention_schedule import fused_attention_schedule
@@ -11,6 +12,7 @@ __all__ = [
     "XeGPUParameterSelector",
     "XeGPUSpecs",
     "check_constraints",
+    "elemwise_schedule",
     "fused_attention_schedule",
     "layer_norm_schedule",
     "mlp_schedule",

--- a/lighthouse/schedule/xegpu/__init__.py
+++ b/lighthouse/schedule/xegpu/__init__.py
@@ -7,15 +7,29 @@ from .fused_attention_schedule import fused_attention_schedule
 from .xegpu_parameter_selector import XeGPUParameterSelector
 from .matmul_constraints import check_constraints
 from .xegpu_specs import XeGPUSpecs
+from .lowering_common import (
+    bufferize,
+    convert_to_gpu_launch,
+    convert_vector_to_xegpu,
+    outline_gpu_function,
+    vectorize,
+    vectorize_bufferize_and_outline_gpu_func,
+)
 
 __all__ = [
     "XeGPUParameterSelector",
     "XeGPUSpecs",
+    "bufferize",
     "check_constraints",
+    "convert_to_gpu_launch",
+    "convert_vector_to_xegpu",
     "elemwise_schedule",
     "fused_attention_schedule",
     "layer_norm_schedule",
     "mlp_schedule",
+    "outline_gpu_function",
     "softmax_schedule",
+    "vectorize",
+    "vectorize_bufferize_and_outline_gpu_func",
     "xegpu_to_binary",
 ]

--- a/lighthouse/schedule/xegpu/elemwise_schedule.py
+++ b/lighthouse/schedule/xegpu/elemwise_schedule.py
@@ -1,10 +1,6 @@
 from mlir import ir
-from mlir.dialects.transform import loop
-from mlir.dialects.transform import bufferization
 from mlir.dialects.transform import xegpu
-from mlir.dialects.bufferization import LayoutMapOption
 from mlir.dialects import transform
-from mlir.dialects.transform import structured
 import lighthouse.transform as lh_transform
 from lighthouse.pipeline.helper import (
     apply_registered_pass,
@@ -20,11 +16,13 @@ from lighthouse.dialects.transform import smt_ext as td_smt_ext
 from lighthouse.dialects.transform.tune_ext import KnobValue
 from .xegpu_specs import XeGPUSpecs
 from .xegpu_parameter_selector import XeGPUParameterSelector
+from .lowering_common import (
+    vectorize_bufferize_and_outline_gpu_func,
+    convert_vector_to_xegpu,
+)
 from .matmul_constraints import (
-    NB_WORKITEMS,
     LOAD_MAX_ROWS,
     LOAD_MAX_COLS,
-    MIN_NB_THREADS,
 )
 
 
@@ -71,7 +69,7 @@ def bundle_xegpu_elemwise_schedule(
     params: list[dict[str, int | KnobValue]],
     stop_at_stage: str = "",
 ) -> ir.Value[transform.AnyOpType]:
-    """Schedule for lowering MLP-like payload to xegpu wg level."""
+    """Schedule for lowering elemwise-like payload to xegpu wg level."""
     nlayers = len(params)
 
     if stop_at_stage == "initial":
@@ -79,11 +77,11 @@ def bundle_xegpu_elemwise_schedule(
 
     anytype = transform.AnyOpType.get()
 
-    # fuse all elementwise ops
+    # fuse all elementwise ops first
     mod = apply_registered_pass(mod, "linalg-fuse-elementwise-ops")
 
+    # tile each layer separately
     generic_ops = match_and_split(mod, ops={"linalg.generic"}, nhandles=nlayers)
-
     for generic_op, layer_params in zip(generic_ops, params):
         # wg tiling
         wg_tile = [layer_params["wg_m"], layer_params["wg_n"]]
@@ -102,113 +100,22 @@ def bundle_xegpu_elemwise_schedule(
         deduplicate=True,
     )
     lh_transform.cleanup(func)
-
     if stop_at_stage == "tiled":
         raise PipelineInterrupt()
 
-    # vectorize
-    func = structured.structured_vectorize_children_and_apply_patterns(
-        transform.any_op_t(),
+    mod = vectorize_bufferize_and_outline_gpu_func(
+        mod,
         func,
-        fold_type_extensions_into_contract=True,
+        nlayers=nlayers,
+        gpu_specs=gpu_specs,
+        params=params,
+        stop_at_stage=stop_at_stage,
     )
-
-    if stop_at_stage == "vectorized":
-        raise PipelineInterrupt()
-
-    # bufferize
-
-    # eliminate empty tensors to avoid emitting extra copy ops
-    mod = apply_registered_pass(mod, "eliminate-empty-tensors")
-    identity_layout = LayoutMapOption.IdentityLayoutMap
-    mod = bufferization.OneShotBufferizeOp(
-        mod,
-        allow_return_allocs_from_loops=True,
-        bufferize_function_boundaries=True,
-        function_boundary_type_conversion=identity_layout,
-    ).result
-    # fold memref.subviews into vector.transfer_read/write ops
-    mod = apply_registered_pass(mod, "fold-memref-alias-ops")
-    transform.apply_cse(mod)
-    canonicalize(mod)
-
-    if stop_at_stage == "bufferized":
-        raise PipelineInterrupt()
-
-    # convert forall to parallel
-    wg_loops = match_and_split(mod, ops={"scf.forall"}, nhandles=nlayers)
-    for wg_loop in wg_loops:
-        wg_loop = loop.loop_forall_to_parallel([anytype], wg_loop)
-    func = transform.get_parent_op(anytype, wg_loop)
-
-    # convert to scf.parallel to gpu.launch
-    func = apply_registered_pass(func, "gpu-map-parallel-loops")
-    func = apply_registered_pass(func, "convert-parallel-loops-to-gpu")
-    func = apply_registered_pass(func, "lower-affine")
-    transform.apply_cse(func)
-    canonicalize(func)
-
-    # set correct number of gpu threads
-    launch_ops = match_and_split(mod, ops={"gpu.launch"}, nhandles=nlayers)
-    assert len(launch_ops) == nlayers
-    for launch_op, layer_params in zip(launch_ops, params):
-        # tunable parameters
-        wg_m, wg_n = layer_params["wg_m"], layer_params["wg_n"]
-        sg_m, sg_n = layer_params["sg_m"], layer_params["sg_n"]
-
-        @td_smt_ext.constrain_params(wg_m, wg_n, sg_m, sg_n)
-        def constrain_wg_sg_and_calc_nb_threads(
-            WG_M: int | smt_ext.SMTIntValue,
-            WG_N: int | smt_ext.SMTIntValue,
-            SG_M: int | smt_ext.SMTIntValue,
-            SG_N: int | smt_ext.SMTIntValue,
-        ):
-            # NB: normal asserts in case of concrete values, SMT assert ops for symbolic values.
-            smt_ext.assert_(WG_M % SG_M == 0)
-            smt_ext.assert_(WG_N % SG_N == 0)
-
-            # NB: normal ints in case of concrete values, SMT int values for symbolic values.
-            sg_m_threads = WG_M // SG_M
-            sg_n_threads = WG_N // SG_N
-            sg_threads = sg_m_threads * sg_n_threads
-            smt_ext.assert_(
-                sg_threads <= gpu_specs.max_nb_threads, "too many SG threads"
-            )
-            smt_ext.assert_(sg_threads >= MIN_NB_THREADS, "too few SG threads")
-
-            # number of threads collapsed to 1d layout
-            return sg_threads * NB_WORKITEMS
-
-        nb_threads: int | transform.AnyParamType = (
-            constrain_wg_sg_and_calc_nb_threads.results
-        )
-
-        xegpu.set_gpu_launch_threads(launch_op, threads=[nb_threads, 1, 1])
-
-    # outline gpu func
-    func = apply_registered_pass(func, "lower-affine")
-    canonicalize(func)
-    func = apply_registered_pass(func, "gpu-launch-sink-index-computations")
-    mod = apply_registered_pass(mod, "gpu-kernel-outlining")
-    transform.apply_cse(mod)
-
-    # set xevm target
-    mod = apply_registered_pass(
-        mod,
-        "xevm-attach-target",
-        options={"O": "3", "chip": "bmg"},
-    )
-
-    # convert vector to xegpu
-    gpu_mod_ops = match_and_split(mod, ops={"gpu.module"}, nhandles=nlayers)
-    for gpu_mod in gpu_mod_ops:
-        gpu_func = match(gpu_mod, ops={"gpu.func"})
-        gpu_func = apply_registered_pass(gpu_func, "convert-vector-to-xegpu")
-        transform.apply_cse(gpu_func)
-
+    mod = convert_vector_to_xegpu(mod, nlayers=nlayers)
     if stop_at_stage == "xegpu-initial":
         raise PipelineInterrupt()
 
+    gpu_mod_ops = match_and_split(mod, ops={"gpu.module"}, nhandles=nlayers)
     for gpu_mod, layer_params in zip(gpu_mod_ops, params):
         gpu_func = match(gpu_mod, ops={"gpu.func"})
         xegpu_wg_annotation_for_elemwise_layer(

--- a/lighthouse/schedule/xegpu/elemwise_schedule.py
+++ b/lighthouse/schedule/xegpu/elemwise_schedule.py
@@ -19,6 +19,7 @@ from .xegpu_parameter_selector import XeGPUParameterSelector
 from .lowering_common import (
     vectorize_bufferize_and_outline_gpu_func,
     convert_vector_to_xegpu,
+    get_named_func,
 )
 from .matmul_constraints import (
     LOAD_MAX_ROWS,
@@ -28,6 +29,7 @@ from .matmul_constraints import (
 
 def elemwise_schedule(
     params: list[dict[str, int | None]],
+    payload_func_name: str = "payload",
     stop_at_stage: str = "",
 ) -> ir.Module:
     """Generate transform schedule module for elemwise payload."""
@@ -41,7 +43,7 @@ def elemwise_schedule(
     with schedule_boilerplate() as (schedule, named_seq):
         # match the payload module
         anytype = transform.AnyOpType.get()
-        func = match(named_seq.bodyTarget, ops={"func.func"})
+        func = get_named_func(named_seq.bodyTarget, payload_func_name)
         payload_mod = transform.get_parent_op(
             anytype,
             func,
@@ -51,6 +53,7 @@ def elemwise_schedule(
         try:
             bundle_xegpu_elemwise_schedule(
                 payload_mod,
+                payload_func_name=payload_func_name,
                 gpu_specs=gpu_specs,
                 params=params,
                 stop_at_stage=stop_at_stage,
@@ -65,6 +68,7 @@ def elemwise_schedule(
 
 def bundle_xegpu_elemwise_schedule(
     mod: ir.Value[transform.AnyOpType],
+    payload_func_name: str,
     gpu_specs: XeGPUSpecs,
     params: list[dict[str, int | KnobValue]],
     stop_at_stage: str = "",
@@ -75,13 +79,12 @@ def bundle_xegpu_elemwise_schedule(
     if stop_at_stage == "initial":
         raise PipelineInterrupt()
 
-    anytype = transform.AnyOpType.get()
-
     # fuse all elementwise ops first
-    mod = apply_registered_pass(mod, "linalg-fuse-elementwise-ops")
+    func = get_named_func(mod, payload_func_name)
+    func = apply_registered_pass(func, "linalg-fuse-elementwise-ops")
 
     # tile each layer separately
-    generic_ops = match_and_split(mod, ops={"linalg.generic"}, nhandles=nlayers)
+    generic_ops = match_and_split(func, ops={"linalg.generic"}, nhandles=nlayers)
     for generic_op, layer_params in zip(generic_ops, params):
         # wg tiling
         wg_tile = [layer_params["wg_m"], layer_params["wg_n"]]
@@ -93,19 +96,13 @@ def bundle_xegpu_elemwise_schedule(
             apply_cleanup=False,
         )
 
-    func = transform.get_parent_op(
-        anytype,
-        wg_loop,
-        op_name="func.func",
-        deduplicate=True,
-    )
     lh_transform.cleanup(func)
     if stop_at_stage == "tiled":
         raise PipelineInterrupt()
 
     mod = vectorize_bufferize_and_outline_gpu_func(
         mod,
-        func,
+        payload_func_name=payload_func_name,
         nlayers=nlayers,
         gpu_specs=gpu_specs,
         params=params,

--- a/lighthouse/schedule/xegpu/elemwise_schedule.py
+++ b/lighthouse/schedule/xegpu/elemwise_schedule.py
@@ -1,0 +1,293 @@
+from mlir import ir
+from mlir.dialects.transform import loop
+from mlir.dialects.transform import bufferization
+from mlir.dialects.transform import xegpu
+from mlir.dialects.bufferization import LayoutMapOption
+from mlir.dialects import transform
+from mlir.dialects.transform import structured
+import lighthouse.transform as lh_transform
+from lighthouse.pipeline.helper import (
+    apply_registered_pass,
+    canonicalize,
+    match,
+    match_and_split,
+    PipelineInterrupt,
+)
+
+from lighthouse.schedule import schedule_boilerplate
+from lighthouse.dialects import smt_ext
+from lighthouse.dialects.transform import smt_ext as td_smt_ext
+from lighthouse.dialects.transform.tune_ext import KnobValue
+from .xegpu_specs import XeGPUSpecs
+from .xegpu_parameter_selector import XeGPUParameterSelector
+from .matmul_constraints import (
+    NB_WORKITEMS,
+    LOAD_MAX_ROWS,
+    LOAD_MAX_COLS,
+    MIN_NB_THREADS,
+)
+
+
+def elemwise_schedule(
+    params: list[dict[str, int | None]],
+    stop_at_stage: str = "",
+) -> ir.Module:
+    """Generate transform schedule module for elemwise payload."""
+    assert params is not None and len(params) > 0, "params must be provided."
+    devices = {p.get("device") for p in params if "device" in p}
+    assert len(devices) <= 1, f"Multiple devices specified in params list: {devices}"
+    device = devices.pop() if devices else None
+    param_selector = XeGPUParameterSelector(device=device)
+    gpu_specs = param_selector.gpu_specs
+
+    with schedule_boilerplate() as (schedule, named_seq):
+        # match the payload module
+        anytype = transform.AnyOpType.get()
+        func = match(named_seq.bodyTarget, ops={"func.func"})
+        payload_mod = transform.get_parent_op(
+            anytype,
+            func,
+            op_name="builtin.module",
+            deduplicate=True,
+        )
+        try:
+            bundle_xegpu_elemwise_schedule(
+                payload_mod,
+                gpu_specs=gpu_specs,
+                params=params,
+                stop_at_stage=stop_at_stage,
+            )
+        except PipelineInterrupt:
+            pass
+        finally:
+            transform.yield_()
+
+    return schedule
+
+
+def bundle_xegpu_elemwise_schedule(
+    mod: ir.Value[transform.AnyOpType],
+    gpu_specs: XeGPUSpecs,
+    params: list[dict[str, int | KnobValue]],
+    stop_at_stage: str = "",
+) -> ir.Value[transform.AnyOpType]:
+    """Schedule for lowering MLP-like payload to xegpu wg level."""
+    nlayers = len(params)
+
+    if stop_at_stage == "initial":
+        raise PipelineInterrupt()
+
+    anytype = transform.AnyOpType.get()
+
+    # fuse all elementwise ops
+    mod = apply_registered_pass(mod, "linalg-fuse-elementwise-ops")
+
+    generic_ops = match_and_split(mod, ops={"linalg.generic"}, nhandles=nlayers)
+
+    for generic_op, layer_params in zip(generic_ops, params):
+        # wg tiling
+        wg_tile = [layer_params["wg_m"], layer_params["wg_n"]]
+        _, [wg_loop], _ = lh_transform.tile(
+            generic_op,
+            tile_sizes=wg_tile,
+            fuse_producers=True,
+            use_forall=True,
+            apply_cleanup=False,
+        )
+
+    func = transform.get_parent_op(
+        anytype,
+        wg_loop,
+        op_name="func.func",
+        deduplicate=True,
+    )
+    lh_transform.cleanup(func)
+
+    if stop_at_stage == "tiled":
+        raise PipelineInterrupt()
+
+    # vectorize
+    func = structured.structured_vectorize_children_and_apply_patterns(
+        transform.any_op_t(),
+        func,
+        fold_type_extensions_into_contract=True,
+    )
+
+    if stop_at_stage == "vectorized":
+        raise PipelineInterrupt()
+
+    # bufferize
+
+    # eliminate empty tensors to avoid emitting extra copy ops
+    mod = apply_registered_pass(mod, "eliminate-empty-tensors")
+    identity_layout = LayoutMapOption.IdentityLayoutMap
+    mod = bufferization.OneShotBufferizeOp(
+        mod,
+        allow_return_allocs_from_loops=True,
+        bufferize_function_boundaries=True,
+        function_boundary_type_conversion=identity_layout,
+    ).result
+    # fold memref.subviews into vector.transfer_read/write ops
+    mod = apply_registered_pass(mod, "fold-memref-alias-ops")
+    transform.apply_cse(mod)
+    canonicalize(mod)
+
+    if stop_at_stage == "bufferized":
+        raise PipelineInterrupt()
+
+    # convert forall to parallel
+    wg_loops = match_and_split(mod, ops={"scf.forall"}, nhandles=nlayers)
+    for wg_loop in wg_loops:
+        wg_loop = loop.loop_forall_to_parallel([anytype], wg_loop)
+    func = transform.get_parent_op(anytype, wg_loop)
+
+    # convert to scf.parallel to gpu.launch
+    func = apply_registered_pass(func, "gpu-map-parallel-loops")
+    func = apply_registered_pass(func, "convert-parallel-loops-to-gpu")
+    func = apply_registered_pass(func, "lower-affine")
+    transform.apply_cse(func)
+    canonicalize(func)
+
+    # set correct number of gpu threads
+    launch_ops = match_and_split(mod, ops={"gpu.launch"}, nhandles=nlayers)
+    assert len(launch_ops) == nlayers
+    for launch_op, layer_params in zip(launch_ops, params):
+        # tunable parameters
+        wg_m, wg_n = layer_params["wg_m"], layer_params["wg_n"]
+        sg_m, sg_n = layer_params["sg_m"], layer_params["sg_n"]
+
+        @td_smt_ext.constrain_params(wg_m, wg_n, sg_m, sg_n)
+        def constrain_wg_sg_and_calc_nb_threads(
+            WG_M: int | smt_ext.SMTIntValue,
+            WG_N: int | smt_ext.SMTIntValue,
+            SG_M: int | smt_ext.SMTIntValue,
+            SG_N: int | smt_ext.SMTIntValue,
+        ):
+            # NB: normal asserts in case of concrete values, SMT assert ops for symbolic values.
+            smt_ext.assert_(WG_M % SG_M == 0)
+            smt_ext.assert_(WG_N % SG_N == 0)
+
+            # NB: normal ints in case of concrete values, SMT int values for symbolic values.
+            sg_m_threads = WG_M // SG_M
+            sg_n_threads = WG_N // SG_N
+            sg_threads = sg_m_threads * sg_n_threads
+            smt_ext.assert_(
+                sg_threads <= gpu_specs.max_nb_threads, "too many SG threads"
+            )
+            smt_ext.assert_(sg_threads >= MIN_NB_THREADS, "too few SG threads")
+
+            # number of threads collapsed to 1d layout
+            return sg_threads * NB_WORKITEMS
+
+        nb_threads: int | transform.AnyParamType = (
+            constrain_wg_sg_and_calc_nb_threads.results
+        )
+
+        xegpu.set_gpu_launch_threads(launch_op, threads=[nb_threads, 1, 1])
+
+    # outline gpu func
+    func = apply_registered_pass(func, "lower-affine")
+    canonicalize(func)
+    func = apply_registered_pass(func, "gpu-launch-sink-index-computations")
+    mod = apply_registered_pass(mod, "gpu-kernel-outlining")
+    transform.apply_cse(mod)
+
+    # set xevm target
+    mod = apply_registered_pass(
+        mod,
+        "xevm-attach-target",
+        options={"O": "3", "chip": "bmg"},
+    )
+
+    # convert vector to xegpu
+    gpu_mod_ops = match_and_split(mod, ops={"gpu.module"}, nhandles=nlayers)
+    for gpu_mod in gpu_mod_ops:
+        gpu_func = match(gpu_mod, ops={"gpu.func"})
+        gpu_func = apply_registered_pass(gpu_func, "convert-vector-to-xegpu")
+        transform.apply_cse(gpu_func)
+
+    if stop_at_stage == "xegpu-initial":
+        raise PipelineInterrupt()
+
+    for gpu_mod, layer_params in zip(gpu_mod_ops, params):
+        gpu_func = match(gpu_mod, ops={"gpu.func"})
+        xegpu_wg_annotation_for_elemwise_layer(
+            gpu_func, gpu_specs=gpu_specs, **layer_params
+        )
+
+    if stop_at_stage == "xegpu-wg":
+        raise PipelineInterrupt()
+
+    return mod
+
+
+def xegpu_wg_annotation_for_elemwise_layer(
+    gpu_func: ir.Value,
+    gpu_specs: XeGPUSpecs,
+    *,
+    wg_m: int | KnobValue,
+    wg_n: int | KnobValue,
+    sg_m: int | KnobValue,
+    sg_n: int | KnobValue,
+    load_m: int | KnobValue,
+    load_n: int | KnobValue,
+    **_catch_all,
+):
+    """
+    Adds XeGPU anchor layout annotations for an elementwise layer.
+
+    Should be applied after the payload has been converted to XeGPU using
+    the convert-vector-to-xegpu pass.
+    """
+    anyvalue = transform.AnyValueType.get()
+
+    @td_smt_ext.constrain_params(wg_m, wg_n, sg_m, sg_n, load_m, load_n)
+    def calc_sg_layout(WG_M, WG_N, SG_M, SG_N, LD_M, LD_N):
+        smt_ext.assert_(WG_M % SG_M == 0)
+        smt_ext.assert_(WG_N % SG_N == 0)
+        smt_ext.assert_(SG_M % LD_M == 0)
+        smt_ext.assert_(SG_N % LD_N == 0)
+        smt_ext.assert_(LD_M <= LOAD_MAX_ROWS)
+        smt_ext.assert_(LD_N <= LOAD_MAX_COLS)
+        return WG_M // SG_M, WG_N // SG_N
+
+    sg_layout = calc_sg_layout.results
+
+    sg_tile = [sg_m, sg_n]
+    load_tile = [load_m, load_n]
+
+    # add layouts to load ops
+    load_ops = match(gpu_func, ops={"xegpu.load_nd"})
+
+    def add_load_layout(load_ops, layout_load, layout_dpas):
+        xegpu.set_anchor_layout(load_ops, **layout_load)
+        result_tile = transform.get_result(anyvalue, load_ops, [0])
+        xegpu.convert_layout(
+            result_tile,
+            input_sg_layout=layout_load["sg_layout"],
+            input_sg_data=layout_load["sg_data"],
+            input_inst_data=layout_load["inst_data"],
+            target_sg_layout=layout_dpas["sg_layout"],
+            target_sg_data=layout_dpas["sg_data"],
+            target_inst_data=layout_dpas["inst_data"],
+        )
+
+    # load layout
+    layout_load = {
+        "sg_layout": sg_layout,
+        "sg_data": sg_tile,
+        "inst_data": load_tile,
+    }
+    # inst layout
+    layout_dpas = layout_load.copy()
+    add_load_layout(
+        load_ops,
+        layout_load,
+        layout_dpas,
+    )
+    # add layout to store ops
+    store_ops = match(gpu_func, ops={"xegpu.store_nd"})
+    xegpu.set_anchor_layout(store_ops, **layout_load)
+
+    transform.apply_cse(gpu_func)
+    canonicalize(gpu_func)

--- a/lighthouse/schedule/xegpu/lowering_common.py
+++ b/lighthouse/schedule/xegpu/lowering_common.py
@@ -1,3 +1,4 @@
+from mlir import ir
 from mlir.dialects import transform
 from mlir.dialects.bufferization import LayoutMapOption
 from mlir.dialects.transform import bufferization
@@ -23,45 +24,56 @@ from .xegpu_specs import XeGPUSpecs
 from .matmul_constraints import NB_WORKITEMS, MIN_NB_THREADS
 
 
+def get_named_func(
+    mod: transform.AnyOpType,
+    func_name: str,
+) -> transform.AnyOpType:
+    """
+    Get the function with the given name from the module.
+
+    Produces a silenceable failure if the function is not found.
+    """
+    return match_and_split(
+        mod,
+        ops={"func.func"},
+        op_attrs={"sym_name": ir.StringAttr.get(func_name)},
+        nhandles=1,
+    )[0]
+
+
 def vectorize_bufferize_and_outline_gpu_func(
     mod: transform.AnyOpType,
-    func: transform.AnyOpType,
+    payload_func_name: str,
     *,
     nlayers: int,
     gpu_specs: XeGPUSpecs,
     params: list[dict[str, int | KnobValue]],
     stop_at_stage: str = "",
 ) -> transform.AnyOpType:
-    """Vectorize, bufferize, emit gpu.launch, and outline to gpu.func."""
-
-    func = vectorize(func)
+    """Vectorizes and bufferizes the payload function and outlines it to gpu.func."""
+    vectorize(mod, payload_func_name=payload_func_name)
     if stop_at_stage == "vectorized":
         raise PipelineInterrupt()
 
     mod = bufferize(mod)
-
-    # match payload function
-    anytype = transform.AnyOpType.get()
-    wg_loops = match(mod, ops={"scf.forall"})
-    func = transform.get_parent_op(
-        anytype, wg_loops, op_name="func.func", deduplicate=True
-    )
-    func = convert_allocs_to_gpu(func)
+    convert_allocs_to_gpu(mod, payload_func_name)
     if stop_at_stage == "bufferized":
         raise PipelineInterrupt()
 
-    func = convert_to_gpu_launch(func, nlayers=nlayers)
-    mod = outline_gpu_function(mod, func, gpu_specs=gpu_specs, params=params)
+    convert_to_gpu_launch(mod, payload_func_name, nlayers=nlayers)
+    mod = outline_gpu_function(
+        mod, payload_func_name, gpu_specs=gpu_specs, params=params
+    )
 
     return mod
 
 
 def vectorize(
-    func: transform.AnyOpType,
+    mod: transform.AnyOpType,
+    payload_func_name: str,
 ) -> transform.AnyOpType:
     """Vectorize and run loop-hoisting cleanup for the payload function."""
-
-    # vectorize
+    func = get_named_func(mod, payload_func_name)
     func = structured.structured_vectorize_children_and_apply_patterns(
         transform.any_op_t(),
         func,
@@ -99,10 +111,12 @@ def bufferize(
 
 
 def convert_allocs_to_gpu(
-    func: transform.AnyOpType,
+    mod: transform.AnyOpType,
+    payload_func_name: str,
 ) -> transform.AnyOpType:
     """Insert deallocs and convert memref alloc/dealloc ops to GPU variants."""
 
+    func = get_named_func(mod, payload_func_name)
     func = apply_registered_pass(func, "buffer-deallocation-pipeline")
     alloc_ops = match(func, ops={"memref.alloc"})
     transform_ext.replace(alloc_ops, "gpu.alloc")
@@ -113,18 +127,18 @@ def convert_allocs_to_gpu(
 
 
 def convert_to_gpu_launch(
-    func: transform.AnyOpType,
+    mod: transform.AnyOpType,
+    payload_func_name: str,
     *,
     nlayers: int,
 ) -> transform.AnyOpType:
     """Convert scf.forall/scf.parallel structure to gpu.launch."""
 
-    anytype = transform.AnyOpType.get()
-
     # convert forall to parallel
+    func = get_named_func(mod, payload_func_name)
     wg_loops = match_and_split(func, ops={"scf.forall"}, nhandles=nlayers)
     for wg_loop in wg_loops:
-        wg_loop = loop.loop_forall_to_parallel([anytype], wg_loop)
+        wg_loop = loop.loop_forall_to_parallel([transform.any_op_t()], wg_loop)
 
     # convert scf.parallel to gpu.launch
     func = apply_registered_pass(func, "gpu-map-parallel-loops")
@@ -138,7 +152,7 @@ def convert_to_gpu_launch(
 
 def outline_gpu_function(
     mod: transform.AnyOpType,
-    func: transform.AnyOpType,
+    payload_func_name: str,
     *,
     gpu_specs: XeGPUSpecs,
     params: list[dict[str, int | KnobValue]],
@@ -187,6 +201,7 @@ def outline_gpu_function(
         xegpu.set_gpu_launch_threads(launch_op, threads=[nb_threads, 1, 1])
 
     # outline gpu func
+    func = get_named_func(mod, payload_func_name)
     func = apply_registered_pass(func, "lower-affine")
     canonicalize(func)
     func = apply_registered_pass(func, "gpu-launch-sink-index-computations")

--- a/lighthouse/schedule/xegpu/lowering_common.py
+++ b/lighthouse/schedule/xegpu/lowering_common.py
@@ -1,0 +1,218 @@
+from mlir.dialects import transform
+from mlir.dialects.bufferization import LayoutMapOption
+from mlir.dialects.transform import bufferization
+from mlir.dialects.transform import loop
+from mlir.dialects.transform import structured
+from mlir.dialects.transform import xegpu
+from mlir.dialects.transform import memref
+import lighthouse.transform as lh_transform
+
+from lighthouse.dialects.transform import transform_ext
+from lighthouse.dialects import smt_ext
+from lighthouse.dialects.transform import smt_ext as td_smt_ext
+from lighthouse.dialects.transform.tune_ext import KnobValue
+
+from lighthouse.pipeline.helper import (
+    PipelineInterrupt,
+    apply_registered_pass,
+    canonicalize,
+    match,
+    match_and_split,
+)
+from .xegpu_specs import XeGPUSpecs
+from .matmul_constraints import NB_WORKITEMS, MIN_NB_THREADS
+
+
+def vectorize_bufferize_and_outline_gpu_func(
+    mod: transform.AnyOpType,
+    func: transform.AnyOpType,
+    *,
+    nlayers: int,
+    gpu_specs: XeGPUSpecs,
+    params: list[dict[str, int | KnobValue]],
+    stop_at_stage: str = "",
+) -> transform.AnyOpType:
+    """Vectorize, bufferize, emit gpu.launch, and outline to gpu.func."""
+
+    func = vectorize(func)
+    if stop_at_stage == "vectorized":
+        raise PipelineInterrupt()
+
+    mod = bufferize(mod)
+
+    # match payload function
+    anytype = transform.AnyOpType.get()
+    wg_loops = match(mod, ops={"scf.forall"})
+    func = transform.get_parent_op(
+        anytype, wg_loops, op_name="func.func", deduplicate=True
+    )
+    func = convert_allocs_to_gpu(func)
+    if stop_at_stage == "bufferized":
+        raise PipelineInterrupt()
+
+    func = convert_to_gpu_launch(func, nlayers=nlayers)
+    mod = outline_gpu_function(mod, func, gpu_specs=gpu_specs, params=params)
+
+    return mod
+
+
+def vectorize(
+    func: transform.AnyOpType,
+) -> transform.AnyOpType:
+    """Vectorize and run loop-hoisting cleanup for the payload function."""
+
+    # vectorize
+    func = structured.structured_vectorize_children_and_apply_patterns(
+        transform.any_op_t(),
+        func,
+        fold_type_extensions_into_contract=True,
+    )
+    # Hoist loop-invariant vector read/store ops if present.
+    k_loop = match(func, ops={"scf.for"})
+    lh_transform.loop_hoisting(k_loop)
+    lh_transform.cleanup(func)
+
+    return func
+
+
+def bufferize(
+    mod: transform.AnyOpType,
+) -> transform.AnyOpType:
+    """Apply one-shot bufferization."""
+
+    # bufferize
+    bufferization.bufferization_eliminate_empty_tensors(mod)
+    mod = bufferization.bufferization_one_shot_bufferize(
+        transform.any_op_t(),
+        mod,
+        function_boundary_type_conversion=LayoutMapOption.IdentityLayoutMap,
+        bufferize_function_boundaries=True,
+    )
+    # fold memref.subviews into vector.transfer_read/write ops
+    with ir.InsertionPoint(transform.apply_patterns(mod).patterns):
+        memref.apply_patterns_memref_fold_memref_alias_ops()
+
+    transform.apply_cse(mod)
+    canonicalize(mod)
+
+    return mod
+
+
+def convert_allocs_to_gpu(
+    func: transform.AnyOpType,
+) -> transform.AnyOpType:
+    """Insert deallocs and convert memref alloc/dealloc ops to GPU variants."""
+
+    func = apply_registered_pass(func, "buffer-deallocation-pipeline")
+    alloc_ops = match(func, ops={"memref.alloc"})
+    transform_ext.replace(alloc_ops, "gpu.alloc")
+    alloc_ops = match(func, ops={"memref.dealloc"})
+    transform_ext.replace(alloc_ops, "gpu.dealloc")
+
+    return func
+
+
+def convert_to_gpu_launch(
+    func: transform.AnyOpType,
+    *,
+    nlayers: int,
+) -> transform.AnyOpType:
+    """Convert scf.forall/scf.parallel structure to gpu.launch."""
+
+    anytype = transform.AnyOpType.get()
+
+    # convert forall to parallel
+    wg_loops = match_and_split(func, ops={"scf.forall"}, nhandles=nlayers)
+    for wg_loop in wg_loops:
+        wg_loop = loop.loop_forall_to_parallel([anytype], wg_loop)
+
+    # convert scf.parallel to gpu.launch
+    func = apply_registered_pass(func, "gpu-map-parallel-loops")
+    func = apply_registered_pass(func, "convert-parallel-loops-to-gpu")
+    func = apply_registered_pass(func, "lower-affine")
+    transform.apply_cse(func)
+    canonicalize(func)
+
+    return func
+
+
+def outline_gpu_function(
+    mod: transform.AnyOpType,
+    func: transform.AnyOpType,
+    *,
+    gpu_specs: XeGPUSpecs,
+    params: list[dict[str, int | KnobValue]],
+) -> transform.AnyOpType:
+    """Set gpu.launch threads and outline the payload to gpu.func."""
+    nlayers = len(params)
+
+    # set correct number of gpu threads
+    launch_ops = match_and_split(mod, ops={"gpu.launch"}, nhandles=nlayers)
+    assert len(launch_ops) == nlayers
+    for launch_op, layer_params in zip(launch_ops, params):
+        # tunable parameters
+        wg_m, wg_n = layer_params["wg_m"], layer_params["wg_n"]
+        sg_m, sg_n = layer_params["sg_m"], layer_params["sg_n"]
+
+        @td_smt_ext.constrain_params(wg_m, wg_n, sg_m, sg_n)
+        def constrain_wg_sg_and_calc_nb_threads(
+            WG_M: int | smt_ext.SMTIntValue,
+            WG_N: int | smt_ext.SMTIntValue,
+            SG_M: int | smt_ext.SMTIntValue,
+            SG_N: int | smt_ext.SMTIntValue,
+        ):
+            # NB: normal asserts in case of concrete values, SMT assert ops for symbolic values.
+            smt_ext.assert_(WG_M % SG_M == 0)
+            smt_ext.assert_(WG_N % SG_N == 0)
+
+            # NB: normal ints in case of concrete values, SMT int values for symbolic values.
+            sg_m_threads = WG_M // SG_M
+            sg_n_threads = WG_N // SG_N
+            sg_threads = sg_m_threads * sg_n_threads
+            smt_ext.assert_(
+                sg_threads <= gpu_specs.max_nb_threads, "too many SG threads"
+            )
+            smt_ext.assert_(
+                sg_threads >= MIN_NB_THREADS,
+                f"too few SG threads: {sg_threads} {WG_M}/{SG_M}*{WG_N}/{SG_N}",
+            )
+
+            # number of threads collapsed to 1d layout
+            return sg_threads * NB_WORKITEMS
+
+        nb_threads: int | transform.AnyParamType = (
+            constrain_wg_sg_and_calc_nb_threads.results
+        )
+
+        xegpu.set_gpu_launch_threads(launch_op, threads=[nb_threads, 1, 1])
+
+    # outline gpu func
+    func = apply_registered_pass(func, "lower-affine")
+    canonicalize(func)
+    func = apply_registered_pass(func, "gpu-launch-sink-index-computations")
+    mod = apply_registered_pass(mod, "gpu-kernel-outlining")
+    transform.apply_cse(mod)
+
+    return mod
+
+
+def convert_vector_to_xegpu(
+    mod: transform.AnyOpType, *, nlayers: int
+) -> transform.AnyOpType:
+    """Attach xevm target and convert vector ops to xegpu in all gpu.module ops."""
+
+    # set xevm target
+    mod = apply_registered_pass(
+        mod,
+        "xevm-attach-target",
+        options={"O": "3", "chip": "bmg"},
+    )
+
+    # convert vector to xegpu
+    gpu_mod_ops = match_and_split(mod, ops={"gpu.module"}, nhandles=nlayers)
+    for gpu_mod in gpu_mod_ops:
+        gpu_func = match(gpu_mod, ops={"gpu.func"})
+        gpu_func = apply_registered_pass(gpu_func, "convert-vector-to-xegpu")
+        transform.apply_cse(gpu_func)
+
+    return mod

--- a/lighthouse/schedule/xegpu/mlp_schedule.py
+++ b/lighthouse/schedule/xegpu/mlp_schedule.py
@@ -1,8 +1,5 @@
 from mlir import ir
-from mlir.dialects.transform import loop
-from mlir.dialects.transform import bufferization
 from mlir.dialects.transform import xegpu
-from mlir.dialects.bufferization import LayoutMapOption
 from mlir.dialects import transform
 from mlir.dialects.transform import structured
 import lighthouse.transform as lh_transform
@@ -21,10 +18,13 @@ from lighthouse.dialects.transform import smt_ext as td_smt_ext
 from lighthouse.dialects.transform.tune_ext import knob, KnobValue
 from .xegpu_specs import XeGPUSpecs
 from .xegpu_parameter_selector import XeGPUParameterSelector
+from .lowering_common import (
+    vectorize_bufferize_and_outline_gpu_func,
+    convert_vector_to_xegpu,
+)
 from .matmul_constraints import (
     DPAS,
     PREFETCH_INST_DATA,
-    NB_WORKITEMS,
     LOAD_MAX_ROWS,
     LOAD_MAX_COLS,
     PFETCH_MIN_ROWS,
@@ -200,9 +200,8 @@ def bundle_xegpu_mlp_schedule(
     # fuse all elementwise ops first
     mod = apply_registered_pass(mod, "linalg-fuse-elementwise-ops")
 
-    matmul_ops = match_and_split(mod, ops={"linalg.matmul"}, nhandles=nlayers)
-
     # tile each layer separately
+    matmul_ops = match_and_split(mod, ops={"linalg.matmul"}, nhandles=nlayers)
     for matmul_op, layer_params in zip(matmul_ops, params):
         # tunable parameters: wg and k tiling
         wg_tile = [layer_params["wg_m"], layer_params["wg_n"]]
@@ -238,136 +237,22 @@ def bundle_xegpu_mlp_schedule(
         deduplicate=True,
     )
     lh_transform.cleanup(func)
-
     if stop_at_stage == "tiled":
         raise PipelineInterrupt()
 
-    # vectorize
-    func = structured.structured_vectorize_children_and_apply_patterns(
-        transform.any_op_t(),
+    mod = vectorize_bufferize_and_outline_gpu_func(
+        mod,
         func,
-        fold_type_extensions_into_contract=True,
+        nlayers=nlayers,
+        gpu_specs=gpu_specs,
+        params=params,
+        stop_at_stage=stop_at_stage,
     )
-
-    # hoist loop invariant vector read/store ops
-    k_loop = match(func, ops={"scf.for"})
-    lh_transform.loop_hoisting(k_loop)
-    lh_transform.cleanup(func)
-
-    if stop_at_stage == "vectorized":
-        raise PipelineInterrupt()
-
-    # bufferize
-
-    # eliminate empty tensors to avoid emitting extra copy ops
-    mod = apply_registered_pass(mod, "eliminate-empty-tensors")
-    identity_layout = LayoutMapOption.IdentityLayoutMap
-    mod = bufferization.OneShotBufferizeOp(
-        mod,
-        allow_return_allocs_from_loops=True,
-        bufferize_function_boundaries=True,
-        function_boundary_type_conversion=identity_layout,
-    ).result
-    # fold memref.subviews into vector.transfer_read/write ops
-    mod = apply_registered_pass(mod, "fold-memref-alias-ops")
-    # match payload function
-    wg_loops = match(mod, ops={"scf.forall"})
-    func = transform.get_parent_op(
-        anytype, wg_loops, op_name="func.func", deduplicate=True
-    )
-    # insert dealloc ops
-    func = apply_registered_pass(func, "buffer-deallocation-pipeline")
-    # convert to gpu.alloc and gpu.dealloc ops
-    alloc_ops = match(func, ops={"memref.alloc"})
-    transform_ext.replace(alloc_ops, "gpu.alloc")
-    alloc_ops = match(func, ops={"memref.dealloc"})
-    transform_ext.replace(alloc_ops, "gpu.dealloc")
-    transform.apply_cse(mod)
-    canonicalize(mod)
-
-    if stop_at_stage == "bufferized":
-        raise PipelineInterrupt()
-
-    # convert forall to parallel
-    wg_loops = match_and_split(mod, ops={"scf.forall"}, nhandles=nlayers)
-    for wg_loop in wg_loops:
-        wg_loop = loop.loop_forall_to_parallel([anytype], wg_loop)
-    func = transform.get_parent_op(anytype, wg_loop)
-
-    # convert to scf.parallel to gpu.launch
-    func = apply_registered_pass(func, "gpu-map-parallel-loops")
-    func = apply_registered_pass(func, "convert-parallel-loops-to-gpu")
-    func = apply_registered_pass(func, "lower-affine")
-    transform.apply_cse(func)
-    canonicalize(func)
-
-    # set correct number of gpu threads
-    launch_ops = match_and_split(mod, ops={"gpu.launch"}, nhandles=nlayers)
-    assert len(launch_ops) == nlayers
-    for launch_op, layer_params in zip(launch_ops, params):
-        # tunable parameters
-        wg_m, wg_n = layer_params["wg_m"], layer_params["wg_n"]
-        sg_m, sg_n = layer_params["sg_m"], layer_params["sg_n"]
-
-        @td_smt_ext.constrain_params(wg_m, wg_n, sg_m, sg_n)
-        def constrain_wg_sg_and_calc_nb_threads(
-            WG_M: int | smt_ext.SMTIntValue,
-            WG_N: int | smt_ext.SMTIntValue,
-            SG_M: int | smt_ext.SMTIntValue,
-            SG_N: int | smt_ext.SMTIntValue,
-        ):
-            # NB: normal asserts in case of concrete values, SMT assert ops for symbolic values.
-            smt_ext.assert_(WG_M % SG_M == 0)
-            smt_ext.assert_(WG_N % SG_N == 0)
-
-            # NB: normal ints in case of concrete values, SMT int values for symbolic values.
-            sg_m_threads = WG_M // SG_M
-            sg_n_threads = WG_N // SG_N
-            sg_threads = sg_m_threads * sg_n_threads
-            smt_ext.assert_(
-                sg_threads <= gpu_specs.max_nb_threads, "too many SG threads"
-            )
-            smt_ext.assert_(
-                sg_threads >= MIN_NB_THREADS,
-                f"too few SG threads: {sg_threads} {WG_M}/{SG_M}*{WG_N}/{SG_N}",
-            )
-
-            # number of threads collapsed to 1d layout
-            return sg_threads * NB_WORKITEMS
-
-        nb_threads: int | transform.AnyParamType = (
-            constrain_wg_sg_and_calc_nb_threads.results
-        )
-
-        xegpu.set_gpu_launch_threads(launch_op, threads=[nb_threads, 1, 1])
-
-    # outline gpu func
-    func = apply_registered_pass(func, "lower-affine")
-    canonicalize(func)
-    func = apply_registered_pass(func, "gpu-launch-sink-index-computations")
-    mod = apply_registered_pass(mod, "gpu-kernel-outlining")
-    transform.apply_cse(mod)
-
-    # set xevm target
-    mod = apply_registered_pass(
-        mod,
-        "xevm-attach-target",
-        options={"O": "3", "chip": "bmg"},
-    )
-
-    # convert vector to xegpu
-    gpu_mod_ops = match_and_split(mod, ops={"gpu.module"}, nhandles=nlayers)
-    for gpu_mod in gpu_mod_ops:
-        gpu_func = match(gpu_mod, ops={"gpu.func"})
-        gpu_func = apply_registered_pass(gpu_func, "convert-vector-to-xegpu")
-        transform.apply_cse(gpu_func)
-
+    mod = convert_vector_to_xegpu(mod, nlayers=nlayers)
     if stop_at_stage == "xegpu-initial":
         raise PipelineInterrupt()
 
-    assert len(gpu_mod_ops) == nlayers, (
-        "Expected one gpu.module per MLP layer after outlining"
-    )
+    gpu_mod_ops = match_and_split(mod, ops={"gpu.module"}, nhandles=nlayers)
     for gpu_mod, layer_params in zip(gpu_mod_ops, params):
         gpu_func = match(gpu_mod, ops={"gpu.func"})
         xegpu_wg_annotation_for_mlp_layer(gpu_func, gpu_specs=gpu_specs, **layer_params)

--- a/lighthouse/schedule/xegpu/mlp_schedule.py
+++ b/lighthouse/schedule/xegpu/mlp_schedule.py
@@ -21,6 +21,7 @@ from .xegpu_parameter_selector import XeGPUParameterSelector
 from .lowering_common import (
     vectorize_bufferize_and_outline_gpu_func,
     convert_vector_to_xegpu,
+    get_named_func,
 )
 from .matmul_constraints import (
     DPAS,
@@ -106,6 +107,7 @@ def params_with_constraints_imposed(
 
 def mlp_schedule(
     params: list[dict[str, int | None]],
+    payload_func_name: str = "payload",
     stop_at_stage: str = "",
 ) -> ir.Module:
     """Generate transform schedule module for MLP payload."""
@@ -119,7 +121,7 @@ def mlp_schedule(
     with schedule_boilerplate() as (schedule, named_seq):
         # match the payload module
         anytype = transform.AnyOpType.get()
-        func = match(named_seq.bodyTarget, ops={"func.func"})
+        func = get_named_func(named_seq.bodyTarget, payload_func_name)
         payload_mod = transform.get_parent_op(
             anytype,
             func,
@@ -171,6 +173,7 @@ def mlp_schedule(
         try:
             bundle_xegpu_mlp_schedule(
                 payload_mod,
+                payload_func_name=payload_func_name,
                 gpu_specs=gpu_specs,
                 params=params,
                 stop_at_stage=stop_at_stage,
@@ -185,6 +188,7 @@ def mlp_schedule(
 
 def bundle_xegpu_mlp_schedule(
     mod: ir.Value[transform.AnyOpType],
+    payload_func_name: str,
     gpu_specs: XeGPUSpecs,
     params: list[dict[str, int | KnobValue]],
     stop_at_stage: str = "",
@@ -198,10 +202,11 @@ def bundle_xegpu_mlp_schedule(
     anytype = transform.AnyOpType.get()
 
     # fuse all elementwise ops first
-    mod = apply_registered_pass(mod, "linalg-fuse-elementwise-ops")
+    func = get_named_func(mod, payload_func_name)
+    func = apply_registered_pass(func, "linalg-fuse-elementwise-ops")
 
     # tile each layer separately
-    matmul_ops = match_and_split(mod, ops={"linalg.matmul"}, nhandles=nlayers)
+    matmul_ops = match_and_split(func, ops={"linalg.matmul"}, nhandles=nlayers)
     for matmul_op, layer_params in zip(matmul_ops, params):
         # tunable parameters: wg and k tiling
         wg_tile = [layer_params["wg_m"], layer_params["wg_n"]]
@@ -230,19 +235,13 @@ def bundle_xegpu_mlp_schedule(
             anytype, anytype, transpose_op, k_loop
         )
 
-    func = transform.get_parent_op(
-        anytype,
-        k_loop,
-        op_name="func.func",
-        deduplicate=True,
-    )
     lh_transform.cleanup(func)
     if stop_at_stage == "tiled":
         raise PipelineInterrupt()
 
     mod = vectorize_bufferize_and_outline_gpu_func(
         mod,
-        func,
+        payload_func_name=payload_func_name,
         nlayers=nlayers,
         gpu_specs=gpu_specs,
         params=params,


### PR DESCRIPTION
- Adds a simple linalg-to-binary schedule for elementwise kernels.
- Refactors common parts with the mlp schedule to sub-schedules (python functions in `lowering_common.py`).
  - These sub-schedules could be outlined into separate schedules if needed.
- The mlp and elementwise schedules now take the payload function name for more robust matching.
  - GPU specific transformations should not be applied to the entire module nor all functions.