### PR TITLE
[transform_ext][schedule] Tiling - optionally filter out non-tileable ops

### DIFF
--- a/examples/KernelBench/schedules/x86_64/element_wise/common.yaml
+++ b/examples/KernelBench/schedules/x86_64/element_wise/common.yaml
@@ -6,7 +6,8 @@ Pipeline:
   # Register tiling and unroll to fill the pipeline
   - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic
                                        tile_sizes=[1,$register_tile]
-                                       unroll_factors=[0,$unroll_factor]}"
+                                       unroll_factors=[0,$unroll_factor]
+                                       filter_ops=True}"
   # Tries to vectorize everything still at tensor level
   - schedule: vectorization.py[gen=vectorize_all]
 

--- a/examples/KernelBench/schedules/x86_64/matmul-like.yaml
+++ b/examples/KernelBench/schedules/x86_64/matmul-like.yaml
@@ -20,8 +20,8 @@ Pipeline:
                                                                     reg_unroll_n=$reg_unroll_n
                                                                     reg_unroll_k=$reg_unroll_k
                                                                   }"
-  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.fill tile_sizes=$fill_tiling}"
-  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic tile_sizes=$generic_tiling}"
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.fill tile_sizes=$fill_tiling filter_ops=True}"
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic tile_sizes=$generic_tiling filter_ops=True}"
 
   - include: vectorize.yaml
 

--- a/examples/KernelBench/schedules/x86_64/matvec/common.yaml
+++ b/examples/KernelBench/schedules/x86_64/matvec/common.yaml
@@ -4,18 +4,22 @@ Pipeline:
   # Pre-ops parallel 2D tiling
   - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.fill
                                        tile_sizes=[$cache_tile,$cache_tile]
-                                       use_forall=True}"
+                                       use_forall=True
+                                       filter_ops=True}"
   # Matvec outer parallel M tiling
   - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.matmul
                                        tile_sizes=[$cache_tile,1]
-                                       use_forall=True}"
+                                       use_forall=True
+                                       filter_ops=True}"
   # Matvec inner sequential K tiling
   - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.matmul
-                                       tile_sizes=[0,0,$cache_tile]}"
+                                       tile_sizes=[0,0,$cache_tile]
+                                       filter_ops=True}"
   # Register tiling and unroll to fill the pipeline
   - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.matmul
                                        tile_sizes=[1,1,$register_tile]
-                                       unroll_factors=[0,$unroll_factor]}"
+                                       unroll_factors=[0,$unroll_factor]
+                                       filter_ops=True}"
   # Tries to vectorize everything still at tensor level
   - schedule: vectorization.py[gen=vectorize_all]
 

--- a/lighthouse/dialects/transform/transform_ext/__init__.py
+++ b/lighthouse/dialects/transform/transform_ext/__init__.py
@@ -11,11 +11,13 @@ from .ops.get_tileable_consumers import get_tileable_consumers
 from .ops.get_tiling_sizes import get_tiling_sizes
 from .ops.update_address_space import update_address_space
 from .ops.replace_with_fused_attention import replace_with_fused_attention
+from .ops.filter_num_loops import filter_num_loops
 
 __all__ = [
     "TransformExtensionDialect",
     "convert_func_results_to_args",
     "extract_handle",
+    "filter_num_loops",
     "get_named_attribute",
     "get_named_attribute",
     "get_tileable_consumers",

--- a/lighthouse/dialects/transform/transform_ext/ops/filter_num_loops.py
+++ b/lighthouse/dialects/transform/transform_ext/ops/filter_num_loops.py
@@ -1,0 +1,98 @@
+from mlir import ir
+from mlir.dialects import ext, transform, linalg
+from mlir.dialects.transform import DiagnosedSilenceableFailure
+
+from lighthouse.dialects.transform.transform_ext import TransformExtensionDialect
+
+
+class FilterNumLoopsOp(TransformExtensionDialect.Operation, name="filter_num_loops"):
+    """
+    Returns ops that have at least `num_loops` loops.
+    Supports Linalg operations only.
+
+    Unsupported ops or ops for which the number of loops cannot be determined
+    are ignored and not returned.
+
+    Args:
+        target: Handle to target op
+        num_loops: Number of loops to filter by
+    Returns:
+        Matching ops
+    """
+
+    target: ext.Operand[transform.AnyOpType]
+    num_loops: ext.Operand[transform.AnyParamType]
+    ops: ext.Result[transform.AnyOpType[()]] = ext.infer_result()
+
+    @classmethod
+    def attach_interface_impls(cls, ctx=None):
+        cls.TransformOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+        cls.MemoryEffectsOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+
+    class TransformOpInterfaceModel(transform.TransformOpInterface):
+        @staticmethod
+        def apply(
+            op: "FilterNumLoopsOp",
+            _rewriter: transform.TransformRewriter,
+            results: transform.TransformResults,
+            state: transform.TransformState,
+        ) -> DiagnosedSilenceableFailure:
+            targets = state.get_payload_ops(op.target)
+            num_loops_attr = state.get_params(op.num_loops)
+            if len(num_loops_attr) == 1 and isinstance(
+                num_loops_attr[0], ir.IntegerAttr
+            ):
+                num_loops = num_loops_attr[0].value
+            else:
+                return DiagnosedSilenceableFailure.SilenceableFailure
+
+            matching_ops = []
+            for target in targets:
+                if "linalg" not in target.name:
+                    continue
+                if hasattr(target, "indexing_maps"):
+                    map: ir.AffineMap = target.indexing_maps[0].value
+                    if map.n_dims >= num_loops:
+                        matching_ops.append(target)
+                elif hasattr(target, "iterator_types"):
+                    if len(target.iterator_types) >= num_loops:
+                        matching_ops.append(target)
+                elif isinstance(target.opview, linalg.FillOp):
+                    if target.outputs[0].type.rank >= num_loops:
+                        matching_ops.append(target)
+                else:
+                    continue
+
+            results.set_ops(op.ops, matching_ops)
+            return DiagnosedSilenceableFailure.Success
+
+        @staticmethod
+        def allow_repeated_handle_operands(_op: "FilterNumLoopsOp") -> bool:
+            return False
+
+    class MemoryEffectsOpInterfaceModel(ir.MemoryEffectsOpInterface):
+        @staticmethod
+        def get_effects(op: ir.Operation, effects):
+            transform.only_reads_handle(op.op_operands, effects)
+            transform.produces_handle(op.results, effects)
+            transform.only_reads_payload(effects)
+
+
+def filter_num_loops(
+    target: ir.Value[transform.AnyOpType],
+    num_loops: int | ir.Value[transform.AnyParamType],
+) -> ir.Value:
+    """
+    snake_case wrapper to create a FilterNumLoopsOp.
+
+    Args:
+        target: Handle to target op
+        num_loops: Number of loops to filter by
+    Returns:
+        List of matching ops that have at least `num_loops` loops.
+    """
+    if isinstance(num_loops, int):
+        param_attr = ir.IntegerAttr.get(ir.IntegerType.get_signless(64), num_loops)
+        num_loops = transform.ParamConstantOp(transform.AnyParamType.get(), param_attr)
+
+    return FilterNumLoopsOp(target=target, num_loops=num_loops).ops

--- a/lighthouse/schedule/tiling.py
+++ b/lighthouse/schedule/tiling.py
@@ -3,6 +3,7 @@ from mlir.dialects import transform
 from mlir.dialects.transform.structured import MatchInterfaceEnum
 
 from lighthouse.schedule.builders import schedule_boilerplate
+from lighthouse.dialects.transform import transform_ext
 import lighthouse.transform as lh_transform
 
 
@@ -14,6 +15,7 @@ def tile_ops(
     peel_loops: list[int] = [],
     unroll_factors: list[int] = [],
     use_forall: bool = False,
+    filter_ops: bool = False,
 ) -> ir.Module:
     """
     Tile all matching op.
@@ -37,11 +39,14 @@ def tile_ops(
         unroll_factors: Unroll factors for each loop.
             Unrolling is applied from the innermost loop.
             Skipped if None. Exclusive with peeling.
+        filter_ops: Whether to filter ops by number of tileable dimensions.
     Returns:
         Schedule
     """
     with schedule_boilerplate() as (schedule, named_seq):
         ops = lh_transform.match_op(named_seq.bodyTarget, target_op)
+        if filter_ops:
+            ops = transform_ext.filter_num_loops(ops, len(tile_sizes))
         with lh_transform.foreach(ops) as op:
             lh_transform.tile(
                 op,

--- a/lighthouse/schedule/x86/register_tiling.py
+++ b/lighthouse/schedule/x86/register_tiling.py
@@ -47,6 +47,7 @@ def matmul_register_tiling(
         tile_sizes=tile_sizes,
         tile_interchange=tile_interchange,
         peel_loops=reg_peel_loops,
+        filter_ops=True,
     )
 
 
@@ -92,4 +93,5 @@ def matmul_register_unroll(
         target_op=target,
         tile_sizes=tile_sizes,
         unroll_factors=reg_unroll_factors,
+        filter_ops=True,
     )


### PR DESCRIPTION
Adds a utility transform op that filters out Linalg operations that have fewer number of loops than specified.
The transform supplements tiling schedule which normally fails when too many tile sizes are provided.

This way the tiling schedule can be applied more aggressively without halting lowering due to application failures when an op cannot be tiled anyway.