### PR TITLE
[schedule][transform][x86] AMX move data offsets to subviews

### DIFF
--- a/lighthouse/dialects/transform/transform_ext/__init__.py
+++ b/lighthouse/dialects/transform/transform_ext/__init__.py
@@ -12,6 +12,7 @@ from .ops.get_tiling_sizes import get_tiling_sizes
 from .ops.update_address_space import update_address_space
 from .ops.replace_with_fused_attention import replace_with_fused_attention
 from .ops.filter_num_loops import filter_num_loops
+from .ops.move_offsets_to_subview import move_offsets_to_subview
 
 __all__ = [
     "TransformExtensionDialect",
@@ -22,6 +23,7 @@ __all__ = [
     "get_named_attribute",
     "get_tileable_consumers",
     "get_tiling_sizes",
+    "move_offsets_to_subview",
     "param_cmp_eq",
     "register_and_load",
     "replace",

--- a/lighthouse/dialects/transform/transform_ext/ops/move_offsets_to_subview.py
+++ b/lighthouse/dialects/transform/transform_ext/ops/move_offsets_to_subview.py
@@ -1,0 +1,182 @@
+from mlir import ir
+from mlir.dialects import ext, transform, vector, memref, arith
+from mlir.dialects.transform import DiagnosedSilenceableFailure
+
+from lighthouse.dialects.transform.transform_ext import TransformExtensionDialect
+
+
+def get_base(op: ir.OpView) -> ir.Value:
+    assert isinstance(op, (vector.TransferReadOp, vector.TransferWriteOp)), (
+        "Expected vector transfer op"
+    )
+    return op.base
+
+
+def get_vector_type(op: ir.OpView) -> ir.VectorType:
+    if isinstance(op, vector.TransferReadOp):
+        return op.vector.type
+    elif isinstance(op, vector.TransferWriteOp):
+        return op.valueToStore.type
+    else:
+        raise NotImplementedError("Unsupported op")
+
+
+def get_indices(op: ir.OpView) -> ir.OpOperandList:
+    assert isinstance(op, (vector.TransferReadOp, vector.TransferWriteOp)), (
+        "Expected vector transfer op"
+    )
+    return op.indices
+
+
+def get_permutation_map(op: ir.OpView) -> ir.AffineMapAttr:
+    assert isinstance(op, (vector.TransferReadOp, vector.TransferWriteOp)), (
+        "Expected vector transfer op"
+    )
+    return op.permutation_map
+
+
+def get_in_bounds(op: ir.OpView) -> ir.ArrayAttr:
+    assert isinstance(op, (vector.TransferReadOp, vector.TransferWriteOp)), (
+        "Expected vector transfer op"
+    )
+    return op.in_bounds
+
+
+class MoveOffsetsToSubviewOp(
+    TransformExtensionDialect.Operation, name="move_offsets_to_subview"
+):
+    """
+    Outlines non-constant indicies from vector reads and writes to subviews.
+    A support rewrite to simplify offsets analysis.
+
+    Args:
+        target: Handle to target op
+    Returns:
+        Updated ops with offsets moved to subviews
+    """
+
+    target: ext.Operand[transform.AnyOpType]
+    updated_op: ext.Result[transform.AnyOpType[()]] = ext.infer_result()
+
+    @classmethod
+    def attach_interface_impls(cls, context=None):
+        cls.TransformOpInterfaceModel.attach(cls.OPERATION_NAME, context=context)
+        cls.MemoryEffectsOpInterfaceModel.attach(cls.OPERATION_NAME, context=context)
+
+    @staticmethod
+    def create_subview(target: ir.OpView) -> ir.OpView | None:
+        assert isinstance(target, (vector.TransferReadOp, vector.TransferWriteOp)), (
+            "Expected vector transfer op"
+        )
+
+        base_val = get_base(target)
+        assert isinstance(base_val.type, ir.MemRefType), (
+            "Expected memref type for base value"
+        )
+
+        memref_type: ir.MemRefType = base_val.type
+        vec_type: ir.VectorType = get_vector_type(target)
+
+        map_attr = get_permutation_map(target)
+        map: ir.AffineMap = map_attr.value
+        if map != ir.AffineMap.get_minor_identity(map.n_dims, len(map.results)):
+            return None
+
+        sizes = memref_type.shape
+        strides = [1] * memref_type.rank
+        indices = get_indices(target)
+
+        subview_offsets = []
+        zero_offset = arith.ConstantOp(ir.IndexType.get(), 0)
+        for offset in indices:
+            if not isinstance(offset.owner, arith.ConstantOp):
+                subview_offsets.append(offset)
+            else:
+                subview_offsets.append(zero_offset)
+
+        base_subview = memref.subview(
+            base_val,
+            subview_offsets,
+            sizes,
+            strides,
+        )
+
+        transfer_indices = []
+        for offset in indices:
+            if isinstance(offset.owner, arith.ConstantOp):
+                transfer_indices.append(offset)
+            else:
+                transfer_indices.append(zero_offset)
+        transfer_op = (
+            vector.transfer_read(
+                vec_type,
+                base_subview,
+                transfer_indices,
+                map_attr,
+                target.padding,
+                get_in_bounds(target),
+            ).owner
+            if isinstance(target, vector.TransferReadOp)
+            else vector.transfer_write(
+                None,
+                target.valueToStore,
+                base_subview,
+                transfer_indices,
+                map_attr,
+                get_in_bounds(target),
+            )
+        )
+
+        return transfer_op
+
+    class TransformOpInterfaceModel(transform.TransformOpInterface):
+        @staticmethod
+        def apply(
+            op: "MoveOffsetsToSubviewOp",
+            rewriter: transform.TransformRewriter,
+            results: transform.TransformResults,
+            state: transform.TransformState,
+        ) -> DiagnosedSilenceableFailure:
+            targets = state.get_payload_ops(op.target)
+            updated_ops = []
+
+            for target in targets:
+                if not isinstance(
+                    target, (vector.TransferReadOp, vector.TransferWriteOp)
+                ):
+                    return DiagnosedSilenceableFailure.SilenceableFailure
+
+                base_val = get_base(target)
+                if not isinstance(base_val.type, ir.MemRefType):
+                    return DiagnosedSilenceableFailure.SilenceableFailure
+
+                with ir.InsertionPoint(target), target.location:
+                    updated_op = MoveOffsetsToSubviewOp.create_subview(target)
+                    if updated_op is None:
+                        updated_op = target
+                    else:
+                        rewriter.replace_op(target, updated_op)
+                updated_ops.append(updated_op)
+
+            results.set_ops(op.updated_op, updated_ops)
+
+            return DiagnosedSilenceableFailure.Success
+
+        @staticmethod
+        def allow_repeated_handle_operands(_op: "MoveOffsetsToSubviewOp") -> bool:
+            return False
+
+    class MemoryEffectsOpInterfaceModel(ir.MemoryEffectsOpInterface):
+        @staticmethod
+        def get_effects(op: "MoveOffsetsToSubviewOp", effects):
+            transform.consumes_handle(op.op_operands, effects)
+            transform.produces_handle(op.results, effects)
+            transform.modifies_payload(effects)
+
+
+def move_offsets_to_subview(
+    target: ir.Value[transform.AnyOpType],
+) -> ir.Value[transform.AnyOpType]:
+    """snake_case wrapper to create a MoveOffsetsToSubviewOp."""
+    op = MoveOffsetsToSubviewOp(target=target)
+    return op.updated_op

--- a/lighthouse/schedule/x86/__init__.py
+++ b/lighthouse/schedule/x86/__init__.py
@@ -1,8 +1,10 @@
 from .cache_tiling import matmul_cache_tiling
 from .pack_lowering import lower_packs_unpacks
 from .register_tiling import matmul_register_tiling, matmul_register_unroll
+from .amx_move_offsets import amx_move_offsets
 
 __all__ = [
+    "amx_move_offsets",
     "lower_packs_unpacks",
     "matmul_cache_tiling",
     "matmul_register_tiling",

--- a/lighthouse/schedule/x86/amx_move_offsets.py
+++ b/lighthouse/schedule/x86/amx_move_offsets.py
@@ -1,0 +1,23 @@
+from mlir import ir
+from mlir.dialects import transform
+
+from lighthouse.dialects.transform import transform_ext
+from lighthouse.schedule.builders import schedule_boilerplate
+import lighthouse.transform as lh_transform
+
+
+def amx_move_offsets() -> ir.Module:
+    """
+    Moves non-constant indicies from AMX input reads to subviews.
+    This IR shapes helps AMX pattern to identify correct sub-graphs.
+
+    Returns:
+        Schedule module
+    """
+    with schedule_boilerplate() as (sched, named_seq):
+        ops = lh_transform.match_op(named_seq.bodyTarget, "vector.transfer_read")
+        transform_ext.move_offsets_to_subview(ops)
+        func = lh_transform.match_op(named_seq.bodyTarget, "func.func")
+        transform.apply_cse(func)
+        transform.yield_()
+    return sched

--- a/test/dialects/transform_ext_subview.py
+++ b/test/dialects/transform_ext_subview.py
@@ -1,0 +1,157 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+"""Tests for the lighthouse transform_ext dialect operations."""
+
+from mlir import ir
+from mlir.dialects import transform
+from mlir.dialects.transform import structured as transform_structured
+import lighthouse.dialects as lh_dialects
+from lighthouse.dialects.transform import transform_ext
+
+
+def run(payload_fn):
+    def decorator(f):
+        print("Test: ", f.__name__, flush=True)
+        with ir.Context(), ir.Location.unknown():
+            lh_dialects.register_and_load(
+                reload=True
+            )  # reload across @run-s to ensure interfaces are registered for new contexts
+
+            mod = ir.Module.create()
+            mod.operation.attributes["transform.with_named_sequence"] = (
+                ir.UnitAttr.get()
+            )
+            with ir.InsertionPoint(mod.body):
+                named_seq = transform.named_sequence(
+                    "main", [transform.AnyOpType.get()], []
+                )
+                any_op = transform.AnyOpType.get()
+                with ir.InsertionPoint(named_seq.body):
+                    func_funcs = transform_structured.structured_match(
+                        any_op, named_seq.bodyTarget, ops={"func.func"}
+                    )
+                    payload_handle = transform.get_parent_op(any_op, func_funcs)
+
+                    f(payload_handle)
+                    transform.yield_()
+
+                named_seq.verify()
+
+                try:
+                    payload_mod = payload_fn()
+                    named_seq.apply(payload_mod)
+                except Exception as e:
+                    print(f"Caught exception: {e}", flush=True)
+        return f
+
+    return decorator
+
+
+def payload_read():
+    mod = ir.Module.parse(
+        r"""
+func.func @move_read_offsets(%arg0: memref<20x4096x4096xbf16>) -> vector<32x32xbf16> {
+    %c8 = arith.constant 8 : index
+    %c16 = arith.constant 16 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %0 = vector.transfer_read %arg0[%c16, %c8, %c16], %cst
+        {in_bounds = [true, true],
+        permutation_map = affine_map<(d0, d1, d2) -> (d1, d2)>}
+        : memref<20x4096x4096xbf16>, vector<32x32xbf16>
+    return %0 : vector<32x32xbf16>
+}
+    """
+    )
+
+    return mod
+
+
+# CHECK-LABEL: Test: test_move_read_offsets
+@run(payload_read)
+def test_move_read_offsets(payload_handle):
+    any_op = transform.AnyOpType.get()
+    transfers = transform_structured.structured_match(
+        any_op, payload_handle, ops={"vector.transfer_read"}
+    )
+    transform_ext.move_offsets_to_subview(transfers)
+
+    # CHECK-LABEL: @move_read_offsets(
+    # CHECK-SAME: %[[ARG0:.+]]: memref<20x4096x4096xbf16>) -> vector<32x32xbf16> {
+    # CHECK-DAG: %[[C16:.+]] = arith.constant 16 : index
+    # CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
+    # CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+    # CHECK: %[[SUBVIEW:.+]] = memref.subview %[[ARG0]][%[[C0]], %[[C0]], %[[C0]]] [20, 4096, 4096] [1, 1, 1]
+    # CHECK: vector.transfer_read %[[SUBVIEW]][%[[C16]], %[[C8]], %[[C16]]]
+    transform.print_()
+
+
+def payload_write():
+    mod = ir.Module.parse(
+        r"""
+func.func @move_write_offsets(%arg0: memref<32x4096x4096xbf16>, %arg1: vector<32x32xbf16>) {
+    %c8 = arith.constant 8 : index
+    %c16 = arith.constant 16 : index
+    vector.transfer_write %arg1, %arg0[%c16, %c8, %c16]
+        {in_bounds = [true, true],
+        permutation_map = affine_map<(d0, d1, d2) -> (d1, d2)>}
+        : vector<32x32xbf16>, memref<32x4096x4096xbf16>
+    return
+}
+    """
+    )
+
+    return mod
+
+
+# CHECK-LABEL: Test: test_move_write_offsets
+@run(payload_write)
+def test_move_write_offsets(payload_handle):
+    any_op = transform.AnyOpType.get()
+    transfers = transform_structured.structured_match(
+        any_op, payload_handle, ops={"vector.transfer_write"}
+    )
+    transform_ext.move_offsets_to_subview(transfers)
+
+    # CHECK-LABEL: @move_write_offsets(
+    # CHECK-SAME: %[[ARG0:.+]]: memref<32x4096x4096xbf16>, %[[ARG1:.+]]: vector<32x32xbf16>) {
+    # CHECK-DAG: %[[C16:.+]] = arith.constant 16 : index
+    # CHECK-DAG: %[[C8:.+]] = arith.constant 8 : index
+    # CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+    # CHECK: %[[SUBVIEW:.+]] = memref.subview %[[ARG0]][%[[C0]], %[[C0]], %[[C0]]] [32, 4096, 4096] [1, 1, 1]
+    # CHECK: vector.transfer_write %[[ARG1]], %[[SUBVIEW]][%[[C16]], %[[C8]], %[[C16]]]
+    transform.print_()
+
+
+def payload_read_permutation():
+    mod = ir.Module.parse(
+        r"""
+func.func @negative_non_minor_identity(%arg0: memref<20x4096x4096xbf16>) -> vector<16x16xbf16> {
+    %c0 = arith.constant 0 : index
+    %c8 = arith.constant 8 : index
+    %c16 = arith.constant 16 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %0 = vector.transfer_read %arg0[%c0, %c8, %c16], %cst
+        {in_bounds = [true, true],
+        permutation_map = affine_map<(d0, d1, d2) -> (d2, d0)>}
+        : memref<20x4096x4096xbf16>, vector<16x16xbf16>
+    return %0 : vector<16x16xbf16>
+}
+    """
+    )
+
+    return mod
+
+
+# CHECK-LABEL: Test: test_negative_non_minor_identity
+@run(payload_read_permutation)
+def test_negative_non_minor_identity(payload_handle):
+    any_op = transform.AnyOpType.get()
+    transfers = transform_structured.structured_match(
+        any_op, payload_handle, ops={"vector.transfer_read"}
+    )
+    transform_ext.move_offsets_to_subview(transfers)
+
+    # CHECK-LABEL: @negative_non_minor_identity(
+    # CHECK-NOT: memref.subview
+    # CHECK: vector.transfer_read
+    transform.print_()


### PR DESCRIPTION
Adds a support transform and schedule that moves base memref offsets into a separate subview to align IR shape to AMX pattern expectations.