### PR TITLE
[utils] Enable OS AMX support

### DIFF
--- a/examples/KernelBench/test-kernel-bench.py
+++ b/examples/KernelBench/test-kernel-bench.py
@@ -188,7 +188,7 @@ if __name__ == "__main__":
         exit(0)
 
     target_info = TargetInfo(args.target, args.feature)
-    enable_amx = target_info.feature.get("amx", False)
+    enable_amx = target_info.feature and "amx" in target_info.feature
 
     for test in tests:
         kb_kernel = kb_path / test["kernel"]

--- a/examples/KernelBench/test-kernel-bench.py
+++ b/examples/KernelBench/test-kernel-bench.py
@@ -187,6 +187,9 @@ if __name__ == "__main__":
             print("No tests to run. Please check your arguments.")
         exit(0)
 
+    target_info = TargetInfo(args.target, args.feature)
+    enable_amx = target_info.feature.get("amx", False)
+
     for test in tests:
         kb_kernel = kb_path / test["kernel"]
         command_line = []
@@ -204,6 +207,9 @@ if __name__ == "__main__":
             "--dtype",
             args.dtype,
         ]
+
+        if enable_amx:
+            command_line += ["--enable-amx"]
 
         # Benchmark mode.
         if args.benchmark:

--- a/examples/KernelBench/test-kernel-bench.py
+++ b/examples/KernelBench/test-kernel-bench.py
@@ -205,11 +205,13 @@ if __name__ == "__main__":
             test["pipeline"],
             "--dtype",
             args.dtype,
-            "--target",
-            target_info.arch,
-            "--feature",
-            target_info.feature if target_info.feature else "",
         ]
+
+        if target_info.arch:
+            command_line += ["--target", target_info.arch]
+
+        if target_info.feature:
+            command_line += ["--feature", target_info.feature]
 
         # Benchmark mode.
         if args.benchmark:

--- a/examples/KernelBench/test-kernel-bench.py
+++ b/examples/KernelBench/test-kernel-bench.py
@@ -188,7 +188,6 @@ if __name__ == "__main__":
         exit(0)
 
     target_info = TargetInfo(args.target, args.feature)
-    enable_amx = target_info.feature and "amx" in target_info.feature
 
     for test in tests:
         kb_kernel = kb_path / test["kernel"]
@@ -206,10 +205,11 @@ if __name__ == "__main__":
             test["pipeline"],
             "--dtype",
             args.dtype,
+            "--target",
+            target_info.arch,
+            "--feature",
+            target_info.feature if target_info.feature else "",
         ]
-
-        if enable_amx:
-            command_line += ["--enable-amx"]
 
         # Benchmark mode.
         if args.benchmark:

--- a/lighthouse/utils/sys_config.py
+++ b/lighthouse/utils/sys_config.py
@@ -1,0 +1,22 @@
+import ctypes
+import ctypes.util
+
+SYS_ARCH_PRCTL = 158
+ARCH_REQ_XCOMP_PERM = 0x1023
+XFEATURE_XTILEDATA = 18
+
+
+def enable_amx():
+    """
+    Enable AMX support on the current thread.
+
+    Raises:
+        OSError: If the syscall fails
+    """
+    libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+    ret = libc.syscall(SYS_ARCH_PRCTL, ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA)
+    if ret != 0:
+        raise OSError(
+            ctypes.get_errno(),
+            "arch_prctl failed: AMX not supported or permission denied",
+        )

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -21,6 +21,7 @@ from lighthouse.utils.mlir import get_mlir_library_path
 import os
 
 from lighthouse.utils.types import string_to_type
+from lighthouse.utils.sys_config import enable_amx
 
 lib_dir = get_mlir_library_path()
 c_runner_lib = os.path.join(lib_dir, "libmlir_c_runner_utils.so")
@@ -430,6 +431,11 @@ if __name__ == "__main__":
         action=argparse.BooleanOptionalAction,
         help="Whether to dump the assembly of the compiled object file to a .s file. Default is False.",
     )
+    Parser.add_argument(
+        "--enable-amx",
+        action=argparse.BooleanOptionalAction,
+        help="Whether to enable AMX support. Default is False.",
+    )
     args = Parser.parse_args()
 
     # Initialize the random seed, for stable tests
@@ -445,6 +451,11 @@ if __name__ == "__main__":
         raise ValueError(
             "--input-shapes and --output-shape must be provided together for non-torch-compile mode."
         )
+
+    # Enable AMX support if requested
+    # TODO: This should be handled by the runner.
+    if args.enable_amx:
+        enable_amx()
 
     # Validate data type argument
     model_datatype = get_torch_data_type(args.dtype)

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -459,7 +459,7 @@ if __name__ == "__main__":
 
     # Enable AMX support if requested
     # TODO: This should be handled by the runner.
-    if "amx" in args.feature:
+    if args.feature and "amx" in args.feature:
         enable_amx()
 
     # Validate data type argument

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -432,9 +432,14 @@ if __name__ == "__main__":
         help="Whether to dump the assembly of the compiled object file to a .s file. Default is False.",
     )
     Parser.add_argument(
-        "--enable-amx",
-        action=argparse.BooleanOptionalAction,
-        help="Whether to enable AMX support. Default is False.",
+        "--target",
+        type=str,
+        help="Specify a particular target architecture (x86_64, arm64, etc.). Default is to auto-detect.",
+    )
+    Parser.add_argument(
+        "--feature",
+        type=str,
+        help="Specify a particular target feature (amx, avx512, etc.).",
     )
     args = Parser.parse_args()
 
@@ -454,7 +459,7 @@ if __name__ == "__main__":
 
     # Enable AMX support if requested
     # TODO: This should be handled by the runner.
-    if args.enable_amx:
+    if "amx" in args.feature:
         enable_amx()
 
     # Validate data type argument


### PR DESCRIPTION
Adds utility function that enables AMX registers in OS.

Explicit AMX register config is required before AMX instructions can be executed.