### PR TITLE
[KernelBench] Add XeGPU support in kernel bench tool

### DIFF
--- a/examples/KernelBench/schedules/xegpu/matmul/bf16.yaml
+++ b/examples/KernelBench/schedules/xegpu/matmul/bf16.yaml
@@ -1,0 +1,29 @@
+# XeGPU pipeline for level1-1 benchmark (4k matmul)
+Pipeline:
+  - schedule: "xegpu/mlp_schedule.py[gen=matmul_schedule] {
+                                                        payload_func_name=main
+                                                        m=4096
+                                                        n=4096
+                                                        k=4096
+                                                        wg_m=256
+                                                        wg_n=256
+                                                        sg_m=32
+                                                        sg_n=64
+                                                        k_tile=32
+                                                        load_a_m=32
+                                                        load_a_k=32
+                                                        load_b_k=16
+                                                        load_b_n=32
+                                                        prefetch_a_m=16
+                                                        prefetch_a_k=16
+                                                        prefetch_b_k=16
+                                                        prefetch_b_n=16
+                                                        prefetch_a_nb=1
+                                                        prefetch_b_nb=2
+                                                        transpose_a=false
+                                                        transpose_b=false
+                                                       }"
+  - schedule: "xegpu/xegpu_to_binary.py[gen=xegpu_to_binary] {
+                                                         xegpu_op_level=workgroup
+                                                         large_register_file=true
+                                                       }"

--- a/examples/KernelBench/test-kernel-bench.py
+++ b/examples/KernelBench/test-kernel-bench.py
@@ -85,6 +85,16 @@ def get_tests(args: argparse.Namespace) -> list[dict]:
         if args.smoke_test:
             test["pipeline"] = str(kb_default_pipeline)
 
+        if args.pipeline:
+            pipeline = args.pipeline
+        else:
+            pipeline = str(
+                get_pipeline_file(
+                    test.get("pipeline", ""),
+                    args.dtype,
+                    TargetInfo(args.target, args.feature),
+                )
+            )
         test_list.append(
             {
                 "kernel": test["kernel"],
@@ -99,13 +109,7 @@ def get_tests(args: argparse.Namespace) -> list[dict]:
                 "gflops": eval(test["gflops"])
                 if "gflops" in test and args.benchmark
                 else None,
-                "pipeline": str(
-                    get_pipeline_file(
-                        test.get("pipeline", ""),
-                        args.dtype,
-                        TargetInfo(args.target, args.feature),
-                    )
-                ),
+                "pipeline": pipeline,
                 "warning": test.get("warning", None),
             }
         )
@@ -130,6 +134,11 @@ if __name__ == "__main__":
         type=str,
         default="f32",
         help="Data type. Default f32.",
+    )
+    Parser.add_argument(
+        "--pipeline",
+        type=str,
+        help="A descriptor file (YAML) with the pipeline stages to apply.",
     )
     Parser.add_argument(
         "--benchmark",

--- a/examples/KernelBench/test-kernel-bench.py
+++ b/examples/KernelBench/test-kernel-bench.py
@@ -83,9 +83,8 @@ def get_tests(args: argparse.Namespace) -> list[dict]:
             continue
         # Smoke tests run on the simplest lowering
         if args.smoke_test:
-            test["pipeline"] = str(kb_default_pipeline)
-
-        if args.pipeline:
+            pipeline = str(kb_default_pipeline)
+        elif args.pipeline:
             pipeline = args.pipeline
         else:
             pipeline = str(

--- a/lighthouse/schedule/xegpu/__init__.py
+++ b/lighthouse/schedule/xegpu/__init__.py
@@ -1,5 +1,5 @@
 from .xegpu_to_binary import xegpu_to_binary
-from .mlp_schedule import mlp_schedule
+from .mlp_schedule import mlp_schedule, matmul_schedule
 from .elemwise_schedule import elemwise_schedule
 from .softmax_schedule import softmax_schedule
 from .layer_norm_schedule import layer_norm_schedule
@@ -26,6 +26,7 @@ __all__ = [
     "elemwise_schedule",
     "fused_attention_schedule",
     "layer_norm_schedule",
+    "matmul_schedule",
     "mlp_schedule",
     "outline_gpu_function",
     "softmax_schedule",

--- a/lighthouse/schedule/xegpu/mlp_schedule.py
+++ b/lighthouse/schedule/xegpu/mlp_schedule.py
@@ -105,13 +105,28 @@ def params_with_constraints_imposed(
     }
 
 
+def matmul_schedule(
+    payload_func_name: str = "payload",
+    stop_at_stage: str = "",
+    **layer_params,
+) -> ir.Module:
+    """Generate transform schedule module for a single matmul layer."""
+    return mlp_schedule(
+        params=[layer_params],
+        payload_func_name=payload_func_name,
+        stop_at_stage=stop_at_stage,
+    )
+
+
 def mlp_schedule(
     params: list[dict[str, int | None]],
     payload_func_name: str = "payload",
     stop_at_stage: str = "",
 ) -> ir.Module:
     """Generate transform schedule module for MLP payload."""
-    assert params is not None and len(params) > 0, "params must be provided."
+    assert params is not None and isinstance(params, list) and len(params) > 0, (
+        "params must be provided."
+    )
     devices = {p.get("device") for p in params if "device" in p}
     assert len(devices) <= 1, f"Multiple devices specified in params list: {devices}"
     device = devices.pop() if devices else None

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -5,6 +5,7 @@ import subprocess
 from datetime import datetime
 import sys
 import numpy as np
+import ml_dtypes
 from pathlib import Path
 import torch
 
@@ -35,7 +36,7 @@ def from_numpy(buf):
     """
     return (
         torch.from_numpy(buf.view(np.uint16)).view(torch.bfloat16)
-        if buf.dtype == torch.bfloat16
+        if buf.dtype in [ml_dtypes.bfloat16, torch.bfloat16]
         else torch.from_numpy(buf)
     )
 
@@ -174,10 +175,11 @@ def parse_module_arguments(
     # Parse input shapes first, to create sample tensors for the inputs only
     buffers = [arg.arg for arg in KernelArgumentParser.parse_all(input_shapes_str)]
     # Build sample torch tensors from input shapes to override hard-coded sizes in get_inputs().
-    if any(buf.dtype == torch.bfloat16 for buf in buffers):
+    if any(buf.dtype in [ml_dtypes.bfloat16, torch.bfloat16] for buf in buffers):
         print(
-            "Warning: bfloat16 is not natively supported by torch.from_numpy(), \
-            so we are reinterpreting the buffers as uint16. This may cause issues if the buffers are modified after creation."
+            "Warning: bfloat16 is not natively supported by torch.from_numpy(), "
+            "so we are reinterpreting the buffers as uint16. This may cause issues if "
+            "the buffers are modified after creation."
         )
     sample_tensors = [from_numpy(buf) for buf in buffers]
     init_args = string_to_type(init_args_str)
@@ -364,7 +366,7 @@ if __name__ == "__main__":
         "--pipeline",
         type=str,
         action="append",
-        help="A descriptor file (YAML) with the pipeline stages to apply. Minimal passes always apply.",
+        help="A descriptor file (YAML) with the pipeline stages to apply.",
     )
     Parser.add_argument(
         "-O",

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -17,7 +17,7 @@ from lighthouse.pipeline.driver import PipelineDriver, make_function_callable
 from lighthouse.schedule import convert_function_results
 from lighthouse import dialects as lh_dialects
 from lighthouse import ingress as lh_ingress
-from lighthouse.ingress.torch import cpu_backend
+from lighthouse.ingress.torch import cpu_backend, gpu_backend
 from lighthouse.utils.mlir import get_mlir_library_path
 import os
 
@@ -211,21 +211,31 @@ def torch_compile(args, model: torch.nn.Module, sample_tensors: list):
     if args.dump_assembly:
         obj_file = Path(args.kernel_bench_model).stem + ".o"
 
-    # TODO: Support GPU backend
-    backend = cpu_backend(
-        compiler_pipeline, shared_libs=[c_runner_lib], dump_obj_file=obj_file
-    )
+    shared_libs = [c_runner_lib]
+    if args.target == "xegpu":
+        shared_libs.append("libmlir_levelzero_runtime.so")
+        backend = gpu_backend(
+            compiler_pipeline,
+            device=torch.device("xpu"),
+            shared_libs=shared_libs,
+            dump_obj_file=obj_file,
+        )
+    else:
+        backend = cpu_backend(
+            compiler_pipeline, shared_libs=shared_libs, dump_obj_file=obj_file
+        )
 
     # Reconfigure the model to be compiled using torch.compile, take the compiled output.
     model.compile(dynamic=False, backend=backend)
     out = model(*sample_tensors, **sample_kwargs)
+    out = out.to("cpu")
 
     if args.dump_assembly and obj_file:
         dump_assembly(args, obj_file)
 
     if args.benchmark:
         time_array = backend.jit_function.benchmark(
-            *sample_tensors, nruns=args.nruns, nwarmup=args.nwarmup
+            *model.parameters(), *sample_tensors, nruns=args.nruns, nwarmup=args.nwarmup
         )
         print(f"{len(time_array)} runs: {np.mean(time_array)} seconds")
 
@@ -236,6 +246,7 @@ def torch_import(args, model: torch.nn.Module, buffers: list, sample_tensors: li
     """
     Imports the model to MLIR and compiles with a custom MLIR backend.
     """
+    assert args.target != "xegpu", "xegpu target is not supported for torch_import."
     # Import the model with the custom sample inputs from the command line.
     mlir_module = import_mlir(model, sample_args=sample_tensors)
     if args.print_original_module:
@@ -436,7 +447,7 @@ if __name__ == "__main__":
     Parser.add_argument(
         "--target",
         type=str,
-        help="Specify a particular target architecture (x86_64, arm64, etc.). Default is to auto-detect.",
+        help="Specify a particular target architecture (x86_64, arm64, xegpu,etc.). Default is to auto-detect.",
     )
     Parser.add_argument(
         "--feature",
@@ -479,8 +490,15 @@ if __name__ == "__main__":
         model_init_args=init_args,
         model_datatype=model_datatype,
     )
+    if args.target == "xegpu":
+        assert torch.xpu.is_available(), "XPU backend is not available."
+        sample_tensors = [t.to("xpu") for t in sample_tensors]
+        for k, v in sample_kwargs.items():
+            if isinstance(v, torch.Tensor):
+                sample_kwargs[k] = v.to("xpu")
     if args.validate:
         out_ref = model(*sample_args, **sample_kwargs)
+        out_ref = out_ref.to("cpu")
         if args.print_output:
             print(f"Reference output:\n{out_ref}")
 

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -36,7 +36,7 @@ def from_numpy(buf):
     """
     return (
         torch.from_numpy(buf.view(np.uint16)).view(torch.bfloat16)
-        if buf.dtype in [ml_dtypes.bfloat16, torch.bfloat16]
+        if buf.dtype == ml_dtypes.bfloat16
         else torch.from_numpy(buf)
     )
 


### PR DESCRIPTION
- Adds a simplified xegpu matmul schedule that takes tile size parameters as kwargs. This is easier to hook up with the yaml desciptors.
- Adds xegpu target support to `kernel-bench` tool. Currently enabled only in the torch.compile code path.
- `test_kernel_bench.py` example:
  - Add `--pipeline` arg to optionally override the schedule yaml file look up.
  - Adds `schedules/xegpu/matmul/bf16.yaml` example schedule for a ~4k matmul. Compatible with the existing schedule lookup scheme.
  
 Examples (executes, verifies, okayish performance):
 
 ```bash
python test-kernel-bench.py --kernel level1/1_ --dtype bf16 --target xegpu --torch-compile --benchmark --nruns 500 --nwarmup 500
python test-kernel-bench.py --kernel level1/2_ --dtype bf16 --target xegpu --torch-compile --benchmark --nruns 500 --nwarmup 500
 ```