### PR TITLE
[schedule][KB] Parallelize execution using OpenMP

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install the project and its dependencies
         run: |
           sudo apt-get install -y llvm-dev # Obtain FileCheck, used in testing.
+          sudo apt-get install -y libomp-dev # Obtain LLVM OpenMP, used in testing.
           uv sync --extra ingress-torch-cpu --extra runtime_mpich
 
       - name: Run lit-enabled tests

--- a/examples/KernelBench/schedules/x86_64/lower.yaml
+++ b/examples/KernelBench/schedules/x86_64/lower.yaml
@@ -3,6 +3,7 @@ Pipeline:
   ## Bufferization
   - include: bufferization.yaml
   - include: bufferization_cleanup.yaml
+  - schedule: "omp.py[gen=parallelize]"
 
   ## Buffer vectorization (gets rid of all the rest)
   - schedule: "x86/amx_move_offsets.py[gen=amx_move_offsets]"

--- a/examples/KernelBench/test-kernel-bench.py
+++ b/examples/KernelBench/test-kernel-bench.py
@@ -5,7 +5,6 @@
 # REQUIRES: kernel_bench
 
 import argparse
-import os
 import re
 import subprocess
 import platform
@@ -228,11 +227,6 @@ if __name__ == "__main__":
     for test in tests:
         kb_kernel = kb_path / test["kernel"]
         command_line = []
-
-        # Pin the process to avoid migration
-        if args.benchmark:
-            core = min(os.cpu_count() - 1, 3)
-            command_line += ["taskset", "-c", f"{core}"]
 
         command_line += [
             str(kb_program),

--- a/lighthouse/execution/runner.py
+++ b/lighthouse/execution/runner.py
@@ -20,6 +20,7 @@ from lighthouse.dialects.transform import transform_ext
 from lighthouse.schedule import schedule_boilerplate
 from lighthouse.utils.memref import to_packed_args
 from lighthouse.utils.mlir import get_mlir_library_path
+from lighthouse.utils.lib_finder import find_openmp_library
 from .memory_manager import GPUMemoryManager, ExternalMemoryManager, MemoryManager
 
 
@@ -65,6 +66,24 @@ class Runner:
         self.opt_level = opt_level
         self.engine = self._get_engine()
 
+    def _uses_openmp(self) -> bool:
+        """
+        Return True if the payload contains OpenMP dialect operations.
+
+        Their presence means the jitted code must be linked against an OpenMP library.
+        """
+        found = False
+
+        def match(op: ir.Operation) -> ir.WalkResult:
+            nonlocal found
+            if op.name.startswith("omp."):
+                found = True
+                return ir.WalkResult.INTERRUPT
+            return ir.WalkResult.ADVANCE
+
+        self.payload.operation.walk(match)
+        return found
+
     def _find_shared_libs(self, shared_libs: list[str]) -> list[str]:
         """
         Find the shared libraries in the given directory that match the names in self.shared_libs.
@@ -80,6 +99,18 @@ class Runner:
             if not os.path.isfile(so_path):
                 raise ValueError(f"Could not find shared library {so_path}")
             found_libs.append(so_path)
+
+        # The OpenMP runtime lives outside the MLIR library directory and must
+        # be located on the host when the payload was parallelized with OpenMP.
+        if self._uses_openmp():
+            omp_lib = find_openmp_library()
+            if omp_lib is None:
+                raise RuntimeError(
+                    "Payload requires the OpenMP runtime but no OpenMP library "
+                    "could be found on the system."
+                )
+            found_libs.append(omp_lib)
+
         return found_libs
 
     def _get_engine(self) -> ExecutionEngine:

--- a/lighthouse/pipeline/descriptors/llvm_lowering.yaml
+++ b/lighthouse/pipeline/descriptors/llvm_lowering.yaml
@@ -4,6 +4,7 @@ Pipeline:
   - pass: "canonicalize"
   - pass: "convert-vector-to-scf"
   - pass: "lower-affine"
+  - pass: "finalize-memref-to-llvm"
   - pass: "convert-scf-to-cf"
   - pass: "convert-vector-to-llvm"
   - pass: "convert-math-to-llvm"

--- a/lighthouse/schedule/__init__.py
+++ b/lighthouse/schedule/__init__.py
@@ -13,6 +13,7 @@ from .vectorization import vectorize_all
 from .vectorization import x86_vectorization
 from .bufferization import bufferize
 from .debug import print_ir
+from .omp import parallelize
 
 __all__ = [
     "block_pack_matmuls",
@@ -23,6 +24,7 @@ __all__ = [
     "flatten_vector_ops",
     "hoist_loops",
     "linalg_contract_fold_unit_dims",
+    "parallelize",
     "print_ir",
     "schedule_boilerplate",
     "simplify_vector_ops",

--- a/lighthouse/schedule/omp.py
+++ b/lighthouse/schedule/omp.py
@@ -1,0 +1,20 @@
+from mlir import ir
+from mlir.dialects import transform
+
+from lighthouse.pipeline.helper import apply_registered_pass
+from lighthouse.schedule.builders import schedule_boilerplate
+
+
+def parallelize() -> ir.Module:
+    """
+    Parallelizes execution using OpenMP.
+
+    Returns:
+        Schedule
+    """
+    with schedule_boilerplate() as (schedule, named_seq):
+        target = named_seq.bodyTarget
+        target = apply_registered_pass(target, "scf-forall-to-parallel")
+        apply_registered_pass(target, "convert-scf-to-openmp")
+        transform.yield_()
+    return schedule

--- a/lighthouse/utils/lib_finder.py
+++ b/lighthouse/utils/lib_finder.py
@@ -1,0 +1,93 @@
+import ctypes
+import ctypes.util
+from functools import cache
+
+
+class _LinkMap(ctypes.Structure):
+    """Wrapper around the 'link_map' structure from libdl."""
+
+    _fields_ = [
+        ("l_addr", ctypes.c_void_p),
+        ("l_name", ctypes.c_char_p),
+        ("l_ld", ctypes.c_void_p),
+        ("l_next", ctypes.c_void_p),
+        ("l_prev", ctypes.c_void_p),
+    ]
+
+
+class DLInfo:
+    """
+    Wrapper around 'libdl' to obtain information about a dynamically
+    loaded objects.
+    """
+
+    def __init__(self):
+        self.libdl = self.load_library("dl")
+        if not self.libdl:
+            raise RuntimeError("Could not load libdl.so")
+        self.dlinfo = self.libdl.dlinfo
+        self.dlinfo.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p]
+        self.dlinfo.restype = ctypes.c_int
+
+    @staticmethod
+    def load_library(lib_name: str) -> ctypes.CDLL | None:
+        """
+        Load a dynamically linked library.
+
+        Args:
+            lib_name: Full or partial name of the library to load
+                (e.g., "c", "libomp", "libm.so")
+        Returns:
+            Handle to the loaded library on success.
+        """
+        lib_path = ctypes.util.find_library(lib_name)
+        if not lib_path:
+            return None
+
+        try:
+            lib = ctypes.CDLL(lib_path)
+        except OSError:
+            return None
+
+        return lib
+
+    def lib_path(self, lib_name: str) -> str | None:
+        """
+        Get the full path of a shared library.
+
+        Args:
+            lib_name: Full or partial name of the library to find
+                (e.g., "c", "libomp", "libm.so")
+        Returns:
+            Full path to the library if found, None otherwise.
+        """
+        lib = self.load_library(lib_name)
+        if not lib:
+            return None
+
+        # Get the link map for the library.
+        link_map = ctypes.POINTER(_LinkMap)()
+        RTLD_DI_LINKMAP = 2
+        if (
+            self.dlinfo(lib._handle, RTLD_DI_LINKMAP, ctypes.byref(link_map)) != 0
+            or not link_map
+        ):
+            return None
+
+        # Get the full path.
+        return link_map.contents.l_name.decode()
+
+
+@cache
+def find_openmp_library() -> str | None:
+    """
+    Locate an OpenMP runtime shared library on the host system.
+
+    Returns:
+        Absolute path if found, None otherwise.
+    """
+    try:
+        dlinfo = DLInfo()
+    except RuntimeError:
+        return None
+    return dlinfo.lib_path("omp")


### PR DESCRIPTION
Adds helper to find OpenMP library and a new schedule that injects OpenMP calls over parallel loops.

The new parallelization schedule is integrated into x86 KernelBench pipelines to enable multicore execution.

Assisted-by: Claude