### PR TITLE
[KB] Default to torch-compile

### DIFF
--- a/examples/KernelBench/test-kernel-bench.py
+++ b/examples/KernelBench/test-kernel-bench.py
@@ -1,5 +1,5 @@
 # RUN: python %s --ci | FileCheck %s
-# RUN: python %s --ci --torch-compile | FileCheck %s
+# RUN: python %s --ci --no-torch-compile | FileCheck %s
 
 # REQUIRES: torch
 # REQUIRES: kernel_bench

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -411,7 +411,8 @@ if __name__ == "__main__":
     Parser.add_argument(
         "--torch-compile",
         action=argparse.BooleanOptionalAction,
-        help="Whether to use TorchScript compilation. Default is False.",
+        default=True,
+        help="Whether to use TorchScript compilation. Default is True.",
     )
     Parser.add_argument(
         "--print-original-module",


### PR DESCRIPTION
Now that benchmarking is working for torch-compile, and that it's more stable than full conversion (less fiddling with arguments), we should have it as our default mode.