### PR TITLE
[Script] Simple script to run kernel bench modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Lighthouse's inter-component cache
 cache
+build
 
 # Python caches
 __pycache__/

--- a/scripts/KernelBench/run_kernels.sh
+++ b/scripts/KernelBench/run_kernels.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Script that runs the kernel bench script for a list of kernels,
+# saves the logs, assembly and object files in the current directory.
+#
+# You can run this from anywhere, but the execution must run inside the
+# git repo. To avoid poluting the git repo, you can run on the 'build'
+# directory, since it's currently being ignored by git.
+#
+# cd build && ../scripts/KernelBench/run_kernels.sh level1/1_...
+#
+# Arguments with -- prefix are passed to the kernel bench script.
+# Everything else is treated as a kernel name, with the format levelN/NN_...
+#
+# A reasonable way to use is to use a name generator in bash like:
+# $(for k in $(seq 1 9) 13 $(seq 15 20); do echo level1/$k\_; done)
+#  - This can be appended with more names, since the script will just
+#    append them to the list of kernels to run.
+
+KERNELS=
+ARGS=
+for i in $*; do
+  if [[ $i == --* ]]; then
+    ARGS="$ARGS $i"
+  else
+    KERNELS="$KERNELS $i"
+  fi
+done
+
+# Verify data type, if any
+dtype=f32
+for arg in $ARGS; do
+  if [[ $arg == --dtype=* ]]; then
+    dtype=${arg#*=}
+    if [[ $dtype != f32 && $dtype != f16 && $dtype != bf16 && $dtype != i8 ]]; then
+      echo "Invalid data type: $dtype"
+      exit 1
+    fi
+    break
+  fi
+done
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+SCRIPT=$GIT_ROOT/examples/KernelBench/test-kernel-bench.py
+
+for kernel in $KERNELS; do
+  # Avoid slashes on file names
+  filename="${kernel//\//_}$dtype"
+  LOG=$filename.log
+  RESULTS=$filename.out
+  OBJ=$filename.o
+  ASM=$filename.s
+
+  # First, try to run and dump the pipeline. If it crashes, we can
+  # investigate which pass is broken.
+  echo -e "\nRunning kernel: $kernel with args: $ARGS"
+  uv run $SCRIPT --kernel $kernel \
+                 --print-mlir-after-all \
+                 $ARGS 2>&1 > $LOG
+  if [ $? != 0 ]; then
+    echo "Error executing kernel, bailing..."
+    continue
+  fi
+  echo "Pipeline at $LOG"
+
+  # Benchmark the kernel and dump the assembly.
+  echo "Benchmarking kernel: $kernel with args: $ARGS"
+  uv run $SCRIPT --kernel $kernel \
+                 --benchmark \
+                 $ARGS \
+                 --no-validate \
+                 --dump-assembly \
+                 --assembly-file $ASM \
+                 --object-file $OBJ \
+                 2>&1 > $RESULTS
+  grep Performance $RESULTS
+done

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -64,7 +64,7 @@ def dump_assembly(obj_file, asm_file):
     except subprocess.CalledProcessError as e:
         print(f"Error disassembling object file: {e.stderr}", file=sys.stderr)
         print("'objdump' must be in the path.", file=sys.stderr)
-        raise ()
+        raise e
 
 
 def import_torch(

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -41,26 +41,30 @@ def from_numpy(buf):
     )
 
 
-def dump_assembly(args, object_file_path: str):
+def dump_assembly(obj_file, asm_file):
     """
     Dumps the assembly of the object file as an S file
-    next to the original PyTorch module.
     """
-    asm_file_path = Path(args.kernel_bench_model).stem + ".s"
+    if asm_file == "" or obj_file == "":
+        raise ValueError("Both object file and assembly file must be provided.")
+    if not Path(obj_file).exists():
+        raise FileNotFoundError(f"Object file {obj_file} does not exist.")
+
     try:
         result = subprocess.run(
-            ["objdump", "-d", object_file_path],
+            ["objdump", "-d", obj_file],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
             check=True,
         )
-        with open(asm_file_path, "w") as f:
+        with open(asm_file, "w") as f:
             f.write(result.stdout)
-        print(f"Assembly written to {asm_file_path}")
+        print(f"Assembly written to {asm_file}")
     except subprocess.CalledProcessError as e:
         print(f"Error disassembling object file: {e.stderr}", file=sys.stderr)
         print("'objdump' must be in the path.", file=sys.stderr)
+        raise ()
 
 
 def import_torch(
@@ -207,10 +211,6 @@ def torch_compile(args, model: torch.nn.Module, sample_tensors: list):
             print(module)
         return module
 
-    obj_file = ""
-    if args.dump_assembly:
-        obj_file = Path(args.kernel_bench_model).stem + ".o"
-
     shared_libs = [c_runner_lib]
     if args.target == "xegpu":
         shared_libs.append("libmlir_levelzero_runtime.so")
@@ -218,11 +218,11 @@ def torch_compile(args, model: torch.nn.Module, sample_tensors: list):
             compiler_pipeline,
             device=torch.device("xpu"),
             shared_libs=shared_libs,
-            dump_obj_file=obj_file,
+            dump_obj_file=args.object_file,
         )
     else:
         backend = cpu_backend(
-            compiler_pipeline, shared_libs=shared_libs, dump_obj_file=obj_file
+            compiler_pipeline, shared_libs=shared_libs, dump_obj_file=args.object_file
         )
 
     # Reconfigure the model to be compiled using torch.compile, take the compiled output.
@@ -230,8 +230,8 @@ def torch_compile(args, model: torch.nn.Module, sample_tensors: list):
     out = model(*sample_tensors, **sample_kwargs)
     out = out.to("cpu")
 
-    if args.dump_assembly and obj_file:
-        dump_assembly(args, obj_file)
+    if args.object_file and args.assembly_file:
+        dump_assembly(args.object_file, args.assembly_file)
 
     if args.benchmark:
         time_array = backend.jit_function.benchmark(
@@ -280,9 +280,9 @@ def torch_import(args, model: torch.nn.Module, buffers: list, sample_tensors: li
             host_input_buffers=buffers,
         )
 
-    if args.dump_assembly:
-        obj_file = Path(args.kernel_bench_model).stem + ".o"
-        dump_assembly(args, runner.dump_object_file(obj_file))
+    if args.object_file and args.assembly_file:
+        runner.dump_object_file(args.object_file)
+        dump_assembly(args.object_file, args.assembly_file)
 
     return from_numpy(buffers[0])
 
@@ -446,6 +446,18 @@ if __name__ == "__main__":
         help="Whether to dump the assembly of the compiled object file to a .s file. Default is False.",
     )
     Parser.add_argument(
+        "--object-file",
+        type=str,
+        default="",
+        help=r"Filename to dump the compiled object file into. Default is '\$kernel_name.o'.",
+    )
+    Parser.add_argument(
+        "--assembly-file",
+        type=str,
+        default="",
+        help=r"Filename to disassemble the compiled object file into. Default is '\$kernel_name.s'.",
+    )
+    Parser.add_argument(
         "--target",
         type=str,
         help="Specify a particular target architecture (x86_64, arm64, xegpu,etc.). Default is to auto-detect.",
@@ -502,6 +514,14 @@ if __name__ == "__main__":
         out_ref = out_ref.to("cpu")
         if args.print_output:
             print(f"Reference output:\n{out_ref}")
+
+    # Normalize object / assembly dump arguments
+    if args.dump_assembly and args.assembly_file == "" and args.object_file == "":
+        args.assembly_file = str(Path(args.kernel_bench_model).with_suffix(".s").name)
+    if args.assembly_file == "" and args.object_file != "":
+        args.assembly_file = str(Path(args.object_file).with_suffix(".s"))
+    elif args.object_file == "" and args.assembly_file != "":
+        args.object_file = str(Path(args.assembly_file).with_suffix(".o"))
 
     # Now run the MLIR compiler on either imported or Dynamo plugin
     if sample_tensors is None:


### PR DESCRIPTION
Batched script to execute a number of kernels and capture a lot of information on the execution for _every kernel_:
* `kernel-bench` command line, as driven by `test-kernel-bench.py`
* Full MLIR pipeline dump, into a log file
* Object and assembly files
* Validation against PyTorch, benchmark numbers, etc.

The main point of this script is to help remote execution in a batched way, for example when SSH/SRUN on remote compute nodes, or multiple nodes, for wide collection of data and benchmark results.

The secondary point is to help debug individual compilations by providing as much information as possible for various choices (different cmd-line args) and allowing one to compare them offline.

Also, update kernel-bench's ability to receive names for the object and assembly files directly, to make it easier to automate and not pollute the repo or the KernelBench submodule.