### PR TITLE
[KB][x86] Expose more parallelism

### DIFF
--- a/examples/KernelBench/schedules/x86_64/element-wise.yaml
+++ b/examples/KernelBench/schedules/x86_64/element-wise.yaml
@@ -3,6 +3,11 @@
 Pipeline:
   # Tries to combine as much as possible into one big generic
   - pass: "linalg-fuse-elementwise-ops"
+  # Tile for parallelism
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic
+                                       tile_sizes=[1]
+                                       filter_ops=True
+                                       use_forall=True}"
   # Register tiling and unroll to fill the pipeline
   - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic
                                        tile_sizes=[1,$register_tile]

--- a/examples/KernelBench/schedules/x86_64/matmul-like.yaml
+++ b/examples/KernelBench/schedules/x86_64/matmul-like.yaml
@@ -26,7 +26,7 @@ Pipeline:
                                                                   }"
   - pass: "linalg-morph-ops{named-to-category generic-to-named}"
   - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.fill tile_sizes=$fill_tiling filter_ops=True}"
-  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic tile_sizes=$generic_tiling filter_ops=True}"
+  - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic tile_sizes=$generic_tiling filter_ops=True use_forall=True}"
   - schedule: "tiling.py[gen=tile_ops]{target_op=linalg.generic tile_sizes=$2D_generic_tiling filter_ops=True}"
 
   - include: vectorize.yaml

--- a/lighthouse/schedule/x86/pack_lowering.py
+++ b/lighthouse/schedule/x86/pack_lowering.py
@@ -22,9 +22,9 @@ def lower_packs_for_vectorization(
         vector_unroll_factors: Unroll factors for each vector loop.
     """
     with lh_transform.foreach(pack_ops) as pack_op:
-        tiled_pack = structured.TileUsingForOp(
-            pack_op, sizes=pack_tile_sizes
-        ).tiled_linalg_op
+        tiled_pack = structured.TileUsingForallOp(
+            pack_op, tile_sizes=pack_tile_sizes
+        ).tiled_op
         _, _, transpose = structured.structured_lower_pack(
             transform.OperationType.get("tensor.pad"),
             transform.OperationType.get("tensor.expand_shape"),
@@ -53,9 +53,9 @@ def lower_unpacks_for_vectorization(
         vector_tile_sizes: Target vector shapes
     """
     with lh_transform.foreach(unpack_ops) as unpack_op:
-        tiled_unpack = structured.TileUsingForOp(
-            unpack_op, sizes=unpack_tile_sizes
-        ).tiled_linalg_op
+        tiled_unpack = structured.TileUsingForallOp(
+            unpack_op, tile_sizes=unpack_tile_sizes
+        ).tiled_op
         for size in vector_tile_sizes:
             tiled_unpack = structured.TileUsingForOp(
                 tiled_unpack, sizes=[size]


### PR DESCRIPTION
Adjusts pipelines to expose more parallelism by tiling using forall. Packing schedule now also uses forall by default.