### PR TITLE
[KB] Factor CPU Pipeline

### DIFF
--- a/examples/xegpu/kernel_bench.py
+++ b/examples/xegpu/kernel_bench.py
@@ -67,7 +67,6 @@ from lighthouse.schedule.xegpu import mlp_schedule, elemwise_schedule, xegpu_to_
 from lighthouse.pipeline.helper import PipelineInterrupt
 from lighthouse.ingress.torch import gpu_backend, TargetDialect
 from lighthouse.ingress.torch.compile import TorchMemoryManager
-from lighthouse.pipeline.driver import make_function_callable
 from tune_matmul_costmodel import optimize_payload, dump_configs_json
 from tune_utils import run_with_timeout
 from csv_logger import CSVLogger
@@ -367,7 +366,7 @@ def lower_to_llvm(
     payload_func_name: str,
 ) -> ir.Module:
     """Lower payload module to LLVM using the specified schedule and parameters."""
-    make_function_callable(mod, payload_func_name)
+    Runner.make_function_callable(mod, payload_func_name)
     if schedule_kind == "mlp":
         schedule = mlp_schedule(
             params=schedule_params,

--- a/lighthouse/execution/runner.py
+++ b/lighthouse/execution/runner.py
@@ -300,3 +300,17 @@ class Runner:
             memory_manager.copy(inputs[arg_index], host_buffer)
 
         return argument_access_callback
+
+    @staticmethod
+    def make_function_callable(module: ir.Module, func_name: str) -> None:
+        """
+        Set the 'llvm.emit_c_interface' attribute of the given function in the module.
+        This is required to make the function callable from the execution engine.
+        It has to be called on a @func.func (not an @llvm.func), so should be called
+        before the LLVM lowering stages are added to the pipeline.
+        """
+        with module.context:
+            for func in module.body.operations:
+                if func.sym_name.value == func_name:
+                    func.attributes["llvm.emit_c_interface"] = ir.UnitAttr.get()
+                    break

--- a/lighthouse/pipeline/driver.py
+++ b/lighthouse/pipeline/driver.py
@@ -1,8 +1,10 @@
 import os
 
 from mlir import ir
+from lighthouse.execution.runner import Runner
 import lighthouse.pipeline.stage as lhs
 from lighthouse.pipeline.descriptor import PipelineDescriptor, Descriptor
+from lighthouse.schedule.func import convert_function_results
 from lighthouse.utils.importer import import_mlir_module
 import lighthouse.dialects as lh_dialects
 
@@ -118,6 +120,60 @@ class TransformDriver(PipelineDriver):
 
         for s in schedules:
             self.add_transform(s)
+
+
+class BenchmarkDriver(PipelineDriver):
+    """
+    A pipeline driver for benchmarking kernels.
+    This is a thin wrapper around PipelineDriver that adds benchmarking stages to the pipeline.
+    """
+
+    def __init__(
+        self,
+        module: ir.Module,
+        entry_point: str,
+        schedule: str | list[str] | ir.Module,
+        result_to_args: bool = False,
+        single_run: bool = False,
+    ):
+        if not isinstance(module, ir.Module):
+            raise ValueError("Module must be an ir.Module")
+        if not isinstance(schedule, (str, ir.Module, list)):
+            raise ValueError(
+                "Schedule must be a string, a list of strings, or an ir.Module"
+            )
+        if not entry_point:
+            raise ValueError("Entry point must be a valid function name")
+        super().__init__(module.context)
+
+        with module.context:
+            lh_dialects.register_and_load()
+            if result_to_args:
+                self.add_transform(convert_function_results(entry_point))
+
+            # The entry point must always be callable: the torch.compile backend's
+            # JITFunction calls it directly on every `model(...)` invocation, even in
+            # benchmark mode (where benchmarking goes through a separate wrapper).
+            make_function_callable(module, entry_point)
+
+            if not single_run:
+                # Additionally emit the benchmark wrapper, called by the runner's
+                # benchmark method. This wraps, but does not replace, the entry point.
+                # FIXME: Eliminate this cross-dependency between the Runner and the Driver.
+                self.add_transform(Runner.get_bench_wrapper_schedule(entry_point))
+
+            # Add the schedule(s) to the pipeline.
+            if isinstance(schedule, ir.Module):
+                self.add_transform(schedule)
+            elif isinstance(schedule, list):
+                for yaml in schedule:
+                    if not os.path.exists(yaml):
+                        raise ValueError(f"Schedule file '{yaml}' does not exist.")
+                    self.add_stage(Descriptor(yaml))
+            else:
+                if not os.path.exists(schedule):
+                    raise ValueError(f"Schedule file '{schedule}' does not exist.")
+                self.add_stage(Descriptor(str(schedule)))
 
 
 class CompilerDriver:

--- a/lighthouse/pipeline/driver.py
+++ b/lighthouse/pipeline/driver.py
@@ -137,7 +137,6 @@ class BackendDriver(PipelineDriver):
             # The entry point must always be callable: the torch.compile backend's
             # JITFunction calls it directly on every `model(...)` invocation, even in
             # benchmark mode (where benchmarking goes through a separate wrapper).
-            # FIXME: Can we move this to the Runner?
             Runner.make_function_callable(module, entry_point)
 
             # Convert results to arguments to allow Python buffers to be passed in

--- a/lighthouse/pipeline/driver.py
+++ b/lighthouse/pipeline/driver.py
@@ -9,20 +9,6 @@ from lighthouse.utils.importer import import_mlir_module
 import lighthouse.dialects as lh_dialects
 
 
-def make_function_callable(module: ir.Module, func_name: str) -> None:
-    """
-    Set the 'llvm.emit_c_interface' attribute of the given function in the module.
-    This is required to make the function callable from the execution engine.
-    It has to be called on a @func.func (not an @llvm.func), so should be called
-    before the LLVM lowering stages are added to the pipeline.
-    """
-    with module.context:
-        for func in module.body.operations:
-            if func.sym_name.value == func_name:
-                func.attributes["llvm.emit_c_interface"] = ir.UnitAttr.get()
-                break
-
-
 class PipelineDriver:
     """
     A simple driver that runs the optimization pipeline on a given workload.
@@ -122,58 +108,49 @@ class TransformDriver(PipelineDriver):
             self.add_transform(s)
 
 
-class BenchmarkDriver(PipelineDriver):
+class BackendDriver(PipelineDriver):
     """
-    A pipeline driver for benchmarking kernels.
-    This is a thin wrapper around PipelineDriver that adds benchmarking stages to the pipeline.
+    A pipeline driver for running kernels through a back-end (of various compilers).
+    This is a thin wrapper around PipelineDriver that prepares the kernel for execution.
+
+    Needs module to be able to in-place transform the entry point function to make it
+    callable from the execution engine. By the point the module gets to the runner,
+    it may already be too late.
     """
 
     def __init__(
         self,
         module: ir.Module,
         entry_point: str,
-        schedule: str | list[str] | ir.Module,
         result_to_args: bool = False,
-        single_run: bool = False,
+        benchmark: bool = False,
     ):
         if not isinstance(module, ir.Module):
             raise ValueError("Module must be an ir.Module")
-        if not isinstance(schedule, (str, ir.Module, list)):
-            raise ValueError(
-                "Schedule must be a string, a list of strings, or an ir.Module"
-            )
         if not entry_point:
             raise ValueError("Entry point must be a valid function name")
         super().__init__(module.context)
 
         with module.context:
             lh_dialects.register_and_load()
-            if result_to_args:
-                self.add_transform(convert_function_results(entry_point))
 
             # The entry point must always be callable: the torch.compile backend's
             # JITFunction calls it directly on every `model(...)` invocation, even in
             # benchmark mode (where benchmarking goes through a separate wrapper).
-            make_function_callable(module, entry_point)
+            # FIXME: Can we move this to the Runner?
+            Runner.make_function_callable(module, entry_point)
 
-            if not single_run:
-                # Additionally emit the benchmark wrapper, called by the runner's
-                # benchmark method. This wraps, but does not replace, the entry point.
-                # FIXME: Eliminate this cross-dependency between the Runner and the Driver.
+            # Convert results to arguments to allow Python buffers to be passed in
+            # for output, allowing the memmory manager to "read the output" directly.
+            # Torch.compile already does that, but not all back-ends do that.
+            if result_to_args:
+                self.add_transform(convert_function_results(entry_point))
+
+            # Additionally emit the benchmark wrapper, called by the runner's
+            # benchmark method. This wraps, but does not replace, the entry point.
+            # FIXME: Eliminate this cross-dependency between the Runner and the Driver.
+            if benchmark:
                 self.add_transform(Runner.get_bench_wrapper_schedule(entry_point))
-
-            # Add the schedule(s) to the pipeline.
-            if isinstance(schedule, ir.Module):
-                self.add_transform(schedule)
-            elif isinstance(schedule, list):
-                for yaml in schedule:
-                    if not os.path.exists(yaml):
-                        raise ValueError(f"Schedule file '{yaml}' does not exist.")
-                    self.add_stage(Descriptor(yaml))
-            else:
-                if not os.path.exists(schedule):
-                    raise ValueError(f"Schedule file '{schedule}' does not exist.")
-                self.add_stage(Descriptor(str(schedule)))
 
 
 class CompilerDriver:

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -12,10 +12,7 @@ import torch
 from mlir import ir
 from lighthouse.execution.runner import Runner
 from lighthouse.execution.init import KernelArgumentParser
-from lighthouse.pipeline.descriptor import Descriptor
-from lighthouse.pipeline.driver import PipelineDriver, make_function_callable
-from lighthouse.schedule import convert_function_results
-from lighthouse import dialects as lh_dialects
+from lighthouse.pipeline.driver import BenchmarkDriver
 from lighthouse import ingress as lh_ingress
 from lighthouse.ingress.torch import cpu_backend, gpu_backend
 from lighthouse.utils.mlir import get_mlir_library_path
@@ -125,45 +122,23 @@ def import_mlir(
 def define_compiler_pipeline(
     args: argparse.Namespace,
     module: ir.Module,
-    pipeline_yaml: str | None,
-    benchmark: bool = False,
     convert_results: bool = False,
 ) -> None:
     """
     Defines the compiler pipeline by adding stages to the driver.
     The stages can be defined in a YAML file, or added manually in this function.
     """
-    driver = PipelineDriver(module.context)
+    if not args.pipeline:
+        # Search for the yaml file in the script directory.
+        args.pipeline = Path(__file__).parent / "kernel-bench.yaml"
 
-    with module.context:
-        lh_dialects.register_and_load()
-        if convert_results:
-            driver.add_transform(convert_function_results(args.entry_point))
-
-        # The entry point must always be callable: the torch.compile backend's
-        # JITFunction calls it directly on every `model(...)` invocation, even in
-        # benchmark mode (where benchmarking goes through a separate wrapper).
-        make_function_callable(module, args.entry_point)
-
-        if benchmark:
-            # Additionally emit the benchmark wrapper, called by the runner's
-            # benchmark method. This wraps, but does not replace, the entry point.
-            # FIXME: Eliminate this cross-dependency between the Runner and the Driver.
-            bench_wrapper = Runner.get_bench_wrapper_schedule(args.entry_point)
-            driver.add_transform(bench_wrapper)
-
-        if not pipeline_yaml:
-            # Search for the yaml file in the script directory.
-            pipeline_yaml = Path(__file__).parent / "kernel-bench.yaml"
-        if isinstance(pipeline_yaml, list):
-            for yaml in pipeline_yaml:
-                desc = Descriptor(yaml)
-                driver.add_stage(desc)
-        else:
-            desc = Descriptor(str(pipeline_yaml))
-            driver.add_stage(desc)
-
-    return driver
+    return BenchmarkDriver(
+        module,
+        args.entry_point,
+        args.pipeline,
+        result_to_args=convert_results,
+        single_run=not args.benchmark,
+    )
 
 
 def parse_module_arguments(
@@ -205,7 +180,7 @@ def torch_compile(args, model: torch.nn.Module, sample_tensors: list):
         # The pipeline is fixed and cannot be modified after the first run, to avoid accidentally modifying the pipeline after it has been run.
         if args.print_original_module:
             print(module)
-        driver = define_compiler_pipeline(args, module, args.pipeline, args.benchmark)
+        driver = define_compiler_pipeline(args, module, convert_results=False)
         driver.apply(module, print_after_all=args.print_mlir_after_all)
         if args.print_optimized_module:
             print(module)
@@ -253,9 +228,7 @@ def torch_import(args, model: torch.nn.Module, buffers: list, sample_tensors: li
         print(mlir_module)
 
     # Create the driver and run the pipeline.
-    driver = define_compiler_pipeline(
-        args, mlir_module, args.pipeline, args.benchmark, convert_results=True
-    )
+    driver = define_compiler_pipeline(args, mlir_module, convert_results=True)
 
     # Run the pipeline to get the optimized module.
     optimized_module = driver.apply(

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -12,7 +12,8 @@ import torch
 from mlir import ir
 from lighthouse.execution.runner import Runner
 from lighthouse.execution.init import KernelArgumentParser
-from lighthouse.pipeline.driver import BenchmarkDriver
+from lighthouse.pipeline.descriptor import Descriptor
+from lighthouse.pipeline.driver import BackendDriver
 from lighthouse import ingress as lh_ingress
 from lighthouse.ingress.torch import cpu_backend, gpu_backend
 from lighthouse.utils.mlir import get_mlir_library_path
@@ -128,17 +129,24 @@ def define_compiler_pipeline(
     Defines the compiler pipeline by adding stages to the driver.
     The stages can be defined in a YAML file, or added manually in this function.
     """
-    if not args.pipeline:
-        # Search for the yaml file in the script directory.
-        args.pipeline = Path(__file__).parent / "kernel-bench.yaml"
-
-    return BenchmarkDriver(
+    driver = BackendDriver(
         module,
         args.entry_point,
-        args.pipeline,
         result_to_args=convert_results,
-        single_run=not args.benchmark,
+        benchmark=args.benchmark,
     )
+
+    stages = (
+        args.pipeline
+        if args.pipeline
+        else [Path(__file__).parent / "kernel-bench.yaml"]
+    )
+
+    # Add the schedule(s) to the pipeline.
+    for stage in stages:
+        driver.add_stage(Descriptor(stage))
+
+    return driver
 
 
 def parse_module_arguments(

--- a/tools/lh-run
+++ b/tools/lh-run
@@ -7,7 +7,7 @@ import numpy as np
 from lighthouse.execution.runner import Runner
 from lighthouse.execution.init import KernelArgumentParser
 from lighthouse.pipeline.descriptor import Descriptor
-from lighthouse.pipeline.driver import CompilerDriver, make_function_callable
+from lighthouse.pipeline.driver import CompilerDriver
 from lighthouse import dialects as lh_dialects
 
 
@@ -94,7 +94,7 @@ if __name__ == "__main__":
             driver.add_module_stage(bench_wrapper)
     else:
         # Calling the entry point directly, so set the attribute on the entry point function.
-        make_function_callable(driver.module, args.entry_point)
+        Runner.make_function_callable(driver.module, args.entry_point)
 
     # Add the remaining stages defined by the user.
     driver.add_stages(args.stage)


### PR DESCRIPTION
Creates a BenchmarkPipeline to simplify the creation of PyTorch Compile cpu_pipeline functions and allow downstreams to implement simpler hooks.

This can simplify / join with TransformDriver later as a cleanup.