### PR TITLE
Include YAML descriptors in installed package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 include = ["lighthouse*"]
 
+[tool.setuptools.package-data]
+"lighthouse" = ["*.yaml"]
+
 [tool.setuptools.dynamic]
 version = {attr = "lighthouse.__version__"}
 


### PR DESCRIPTION
Adds any YAML files found under top-level module directory to lighthouse installable package.

This setup ensures that the default pipeline descriptors are also distributed and can be easily reused via the descriptor submodule utilities.