### PR TITLE
[dialects][pipeline] Avoid reloading dialects when possible

### DIFF
--- a/lighthouse/dialects/__init__.py
+++ b/lighthouse/dialects/__init__.py
@@ -3,14 +3,26 @@ from .dialect_base import DialectExtension
 __all__ = ["DialectExtension"]
 
 
-def register_and_load(**kwargs):
-    """Register and load custom extensions."""
+def register_and_load(reload: bool = False, **kwargs):
+    """Register and load custom extensions.
+
+    Args:
+        reload: Force reload the dialects.
+        **kwargs: Additional keyword arguments to pass to the dialects' load methods.
+    """
+    from mlir import ir
     from . import smt_ext
     from .transform import transform_ext
     from .transform import smt_ext as td_smt_ext
     from .transform import tune_ext
 
-    smt_ext.register_and_load(**kwargs)
-    transform_ext.register_and_load(**kwargs)
-    td_smt_ext.register_and_load(**kwargs)
-    tune_ext.register_and_load(**kwargs)
+    dialects = [smt_ext, transform_ext, td_smt_ext, tune_ext]
+    for dialect in dialects:
+        if (
+            not reload
+            and hasattr(dialect, "_mlir_module")
+            and dialect._mlir_module.context is ir.Context.current
+        ):
+            # Avoid reloading the dialect when possible.
+            continue
+        dialect.register_and_load(reload=reload, **kwargs)

--- a/lighthouse/pipeline/driver.py
+++ b/lighthouse/pipeline/driver.py
@@ -133,12 +133,7 @@ class BackendDriver(PipelineDriver):
         super().__init__(module.context)
 
         with module.context:
-            try:
-                lh_dialects.register_and_load(reload=reload_dialects)
-            except RuntimeError as e:
-                raise RuntimeError(
-                    "Lighthouse dialects must be loaded in the same context as the module."
-                ) from e
+            lh_dialects.register_and_load(reload=reload_dialects)
 
             # The entry point must always be callable: the torch.compile backend's
             # JITFunction calls it directly on every `model(...)` invocation, even in

--- a/lighthouse/pipeline/driver.py
+++ b/lighthouse/pipeline/driver.py
@@ -124,6 +124,7 @@ class BackendDriver(PipelineDriver):
         entry_point: str,
         result_to_args: bool = False,
         benchmark: bool = False,
+        reload_dialects: bool = False,
     ):
         if not isinstance(module, ir.Module):
             raise ValueError("Module must be an ir.Module")
@@ -132,7 +133,12 @@ class BackendDriver(PipelineDriver):
         super().__init__(module.context)
 
         with module.context:
-            lh_dialects.register_and_load()
+            try:
+                lh_dialects.register_and_load(reload=reload_dialects)
+            except RuntimeError as e:
+                raise RuntimeError(
+                    "Lighthouse dialects must be loaded in the same context as the module."
+                ) from e
 
             # The entry point must always be callable: the torch.compile backend's
             # JITFunction calls it directly on every `model(...)` invocation, even in


### PR DESCRIPTION
Skips dialects loading when they are already present in the current MLIR context.
Also, allows the backend driver to reload dialects on request.

This allows pipeline drivers to ensure the Lighthouse dialects have been loaded correctly without unnecessary runtime overhead and to avoid forced dialect reloading unless requested.