### PR TITLE
[runner] Target-dependent system configuration

### DIFF
--- a/examples/KernelBench/test-kernel-bench.py
+++ b/examples/KernelBench/test-kernel-bench.py
@@ -148,7 +148,9 @@ if __name__ == "__main__":
         Parser.print_help()
         exit(1)
 
-    target_info = TargetInfo(args.target, args.feature)
+    target_info = TargetInfo(
+        args.target, args.feature.split(",") if args.feature else None
+    )
     tests = get_tests(args, target_info)
     if len(tests) == 0:
         if args.kernel:

--- a/lighthouse/execution/runner.py
+++ b/lighthouse/execution/runner.py
@@ -16,6 +16,8 @@ from mlir.dialects.transform import structured
 from mlir.execution_engine import ExecutionEngine
 from mlir.runtime.np_to_memref import get_ranked_memref_descriptor
 
+from lighthouse.execution.target import TargetInfo
+from lighthouse.utils.sys_config import enable_amx
 from lighthouse.dialects.transform import transform_ext
 from lighthouse.schedule import schedule_boilerplate
 from lighthouse.utils.memref import to_packed_args
@@ -50,8 +52,10 @@ class Runner:
         mem_manager_cls: type = None,
         shared_libs: list[str] = None,
         opt_level: int = 3,
+        target: TargetInfo = None,
     ):
         self.payload = module
+        self.target = target if target else TargetInfo()
         self.mem_manager_cls = mem_manager_cls
         if shared_libs is None:
             shared_libs = []
@@ -65,6 +69,15 @@ class Runner:
         self.shared_libs = list(dict.fromkeys(shared_libs))
         self.opt_level = opt_level
         self.engine = self._get_engine()
+        self._configure_system()
+
+    def _configure_system(self):
+        """
+        Apply target-specific configurations.
+        """
+        # Enable AMX register support.
+        if self.target.is_supported("amx"):
+            enable_amx()
 
     def _uses_openmp(self) -> bool:
         """

--- a/lighthouse/execution/target.py
+++ b/lighthouse/execution/target.py
@@ -48,3 +48,11 @@ class TargetInfo:
             if ext in filter:
                 compatible.append(ext)
         return compatible
+
+    def is_supported(self, hw_extension: str) -> bool:
+        """
+        Return True if the target supports the given hardware extension
+        e.g., AMX or AVX512.
+        """
+        hw_extension = hw_extension.lower()
+        return any(hw_extension in feature for feature in self.features)

--- a/lighthouse/execution/target.py
+++ b/lighthouse/execution/target.py
@@ -55,4 +55,4 @@ class TargetInfo:
         e.g., AMX or AVX512.
         """
         hw_extension = hw_extension.lower()
-        return any(hw_extension in feature for feature in self.features)
+        return any(feature.startswith(hw_extension) for feature in self.features)

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -11,6 +11,7 @@ import torch
 
 from mlir import ir
 from lighthouse.execution.runner import Runner
+from lighthouse.execution.target import TargetInfo
 from lighthouse.execution.init import KernelArgumentParser
 from lighthouse.pipeline.descriptor import Descriptor
 from lighthouse.pipeline.driver import BackendDriver
@@ -20,7 +21,6 @@ from lighthouse.utils.mlir import get_mlir_library_path
 import os
 
 from lighthouse.utils.types import string_to_type
-from lighthouse.utils.sys_config import enable_amx
 
 lib_dir = get_mlir_library_path()
 c_runner_lib = os.path.join(lib_dir, "libmlir_c_runner_utils.so")
@@ -246,7 +246,10 @@ def torch_import(args, model: torch.nn.Module, buffers: list, sample_tensors: li
         print(optimized_module)
 
     # Create the runner and execute/benchmark the module.
-    runner = Runner(optimized_module, opt_level=args.O)
+    target = TargetInfo(
+        arch=args.target, features=args.feature.split(",") if args.feature else None
+    )
+    runner = Runner(optimized_module, opt_level=args.O, target=target)
 
     if args.benchmark:
         print("Running the benchmark...")
@@ -463,11 +466,6 @@ if __name__ == "__main__":
         raise ValueError(
             "--input-shapes and --output-shape must be provided together for non-torch-compile mode."
         )
-
-    # Enable AMX support if requested
-    # TODO: This should be handled by the runner.
-    if args.feature and "amx" in args.feature:
-        enable_amx()
 
     # Validate data type argument
     model_datatype = get_torch_data_type(args.dtype)


### PR DESCRIPTION
Adds target information to the runner to allow automatic configuration of AMX registers when these are available on the current system.