### PR TITLE
[CI] Linter - upgrade syntax to target Python version

### DIFF
--- a/examples/llama/ref_model.py
+++ b/examples/llama/ref_model.py
@@ -7,7 +7,6 @@
 
 import math as pymath
 from dataclasses import dataclass
-from typing import Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -19,10 +18,10 @@ class ModelArgs:
     dim: int = 4096
     n_layers: int = 32
     n_heads: int = 32
-    n_kv_heads: Optional[int] = None
+    n_kv_heads: int | None = None
     vocab_size: int = -1
     multiple_of: int = 256  # make SwiGLU hidden layer size multiple of large power of 2
-    ffn_dim_multiplier: Optional[float] = None
+    ffn_dim_multiplier: float | None = None
     norm_eps: float = 1e-5
     rope_theta: float = 500000
 
@@ -64,7 +63,7 @@ def apply_rotary_emb(
     xq: torch.Tensor,
     xk: torch.Tensor,
     freqs_cis: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
     xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
     freqs_cis = reshape_for_broadcast(freqs_cis, xq_)
@@ -140,7 +139,7 @@ class Attention(torch.nn.Module):
         x: torch.Tensor,
         start_pos: int,
         freqs_cis: torch.Tensor,
-        mask: Optional[torch.Tensor],
+        mask: torch.Tensor | None,
     ):
         bsz, seqlen, _ = x.shape
         xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
@@ -189,7 +188,7 @@ class FeedForward(nn.Module):
         dim: int,
         hidden_dim: int,
         multiple_of: int,
-        ffn_dim_multiplier: Optional[float],
+        ffn_dim_multiplier: float | None,
     ):
         super().__init__()
         hidden_dim = int(2 * hidden_dim / 3)
@@ -228,7 +227,7 @@ class TransformerBlock(nn.Module):
         x: torch.Tensor,
         start_pos: int,
         freqs_cis: torch.Tensor,
-        mask: Optional[torch.Tensor],
+        mask: torch.Tensor | None,
     ):
         h = x + self.attention(self.attention_norm(x), start_pos, freqs_cis, mask)
         out = h + self.feed_forward(self.ffn_norm(h))

--- a/examples/xegpu/fused_attention.py
+++ b/examples/xegpu/fused_attention.py
@@ -6,7 +6,6 @@ XeGPU fused attention benchmark.
 """
 
 import argparse
-from typing import Optional
 from functools import cached_property
 
 import numpy as np
@@ -175,7 +174,7 @@ class XeGPUFusedAttention:
         return mod
 
     def schedule_modules(
-        self, stop_at_stage: Optional[str] = None, parameters: Optional[dict] = None
+        self, stop_at_stage: str | None = None, parameters: dict | None = None
     ) -> list[ir.Module]:
         """Generate transform schedule for fused attention."""
         schedules = []

--- a/examples/xegpu/kernel_bench.py
+++ b/examples/xegpu/kernel_bench.py
@@ -306,7 +306,7 @@ def infer_params_and_lower(
         # runtime tuning for matmul kernels
         if os.path.isfile(params_cache_json):
             print(f"Loading cached parameters from {params_cache_json}")
-            with open(params_cache_json, "r") as f:
+            with open(params_cache_json) as f:
                 params_dict = json.load(f)
             schedule_params = [params_dict]
         else:

--- a/examples/xegpu/layer_norm.py
+++ b/examples/xegpu/layer_norm.py
@@ -6,7 +6,6 @@ XeGPU layer_norm benchmark.
 """
 
 import argparse
-from typing import Optional
 from functools import cached_property
 
 import numpy as np
@@ -135,7 +134,7 @@ class XeGPULayerNorm:
         return mod
 
     def schedule_modules(
-        self, stop_at_stage: Optional[str] = None, parameters: Optional[dict] = None
+        self, stop_at_stage: str | None = None, parameters: dict | None = None
     ) -> list[ir.Module]:
         """Generate transform schedule for layer_norm."""
         schedules = []

--- a/examples/xegpu/matmul.py
+++ b/examples/xegpu/matmul.py
@@ -20,7 +20,7 @@ import argparse
 import json
 import warnings
 from dataclasses import dataclass, field
-from typing import Optional, ClassVar
+from typing import ClassVar
 
 import numpy as np
 from mlir import ir
@@ -201,7 +201,7 @@ class XeGPUMatMul:
         return mod
 
     def schedule_modules(
-        self, stop_at_stage: Optional[str] = None, parameters: Optional[dict] = None
+        self, stop_at_stage: str | None = None, parameters: dict | None = None
     ) -> list[ir.Module]:
         assert parameters is not None, "Schedule parameters must be provided"
         schedules = []
@@ -496,7 +496,7 @@ enabled via CLI arguments.
     # By default the tile size parameters are left undefined
     if args.json:
         # Override parameters with values from JSON file if provided
-        with open(args.json, "r") as f:
+        with open(args.json) as f:
             json_params = json.load(f)
         params.update(json_params)
         # Override with CLI params

--- a/examples/xegpu/mlp.py
+++ b/examples/xegpu/mlp.py
@@ -19,7 +19,7 @@ lowered and executed.
 
 import argparse
 from dataclasses import dataclass
-from typing import Optional, ClassVar
+from typing import ClassVar
 from functools import cached_property
 import warnings
 
@@ -115,7 +115,7 @@ class XeGPUMLP:
     batch_size: int = 1024
     input_size: int = 1024
     output_size: int = 1024
-    hidden_layer_sizes: Optional[list[int]] = None
+    hidden_layer_sizes: list[int] | None = None
     ab_type: ir.Type | str | None = None
     acc_type: ir.Type | str | None = None
     transpose_a: bool = False
@@ -244,7 +244,7 @@ class XeGPUMLP:
         return mod
 
     def schedule_modules(
-        self, stop_at_stage: Optional[str] = None, parameters: Optional[dict] = None
+        self, stop_at_stage: str | None = None, parameters: dict | None = None
     ) -> list[ir.Module]:
         assert parameters is not None, "Schedule parameters must be provided"
         schedules = []

--- a/examples/xegpu/softmax.py
+++ b/examples/xegpu/softmax.py
@@ -6,7 +6,6 @@ XeGPU softmax benchmark.
 """
 
 import argparse
-from typing import Optional
 from functools import cached_property
 
 import numpy as np
@@ -131,7 +130,7 @@ class XeGPUSoftmax:
         )
 
     def schedule_modules(
-        self, stop_at_stage: Optional[str] = None, parameters: Optional[dict] = None
+        self, stop_at_stage: str | None = None, parameters: dict | None = None
     ) -> list[ir.Module]:
         """Generate transform schedule for softmax."""
         schedules = []

--- a/examples/xegpu/torch_matmul.py
+++ b/examples/xegpu/torch_matmul.py
@@ -5,7 +5,6 @@
 
 import argparse
 import json
-from typing import Optional
 from functools import partial
 import os
 
@@ -29,7 +28,7 @@ from lighthouse.ingress.torch import gpu_backend, TargetDialect
 
 class Model(nn.Module):
     def __init__(self):
-        super(Model, self).__init__()
+        super().__init__()
 
     def forward(self, A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
         return torch.matmul(A, B)
@@ -49,7 +48,7 @@ def shared_libs() -> list[str]:
 
 
 def schedule_modules(
-    parameters: Optional[dict] = None, benchmark: bool = False, entry_func: str = "main"
+    parameters: dict | None = None, benchmark: bool = False, entry_func: str = "main"
 ) -> list[ir.Module]:
     assert parameters is not None, "Schedule parameters must be provided"
     schedules = []
@@ -78,7 +77,7 @@ def schedule_modules(
 
 def lower_to_llvm(
     module: ir.Module,
-    parameters: Optional[dict] = None,
+    parameters: dict | None = None,
     benchmark: bool = False,
     entry_func: str = "main",
 ) -> ir.Module:
@@ -217,7 +216,7 @@ enabled via CLI arguments.
         params["device"] = args.target
     if args.json:
         # Override parameters with values from JSON file if provided
-        with open(args.json, "r") as f:
+        with open(args.json) as f:
             json_params = json.load(f)
         params.update(json_params)
 

--- a/lighthouse/dialects/smt_ext/dialect.py
+++ b/lighthouse/dialects/smt_ext/dialect.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 from mlir import ir
 from mlir.dialects import smt

--- a/lighthouse/dialects/transform/smt_ext/ops/constrain_params.py
+++ b/lighthouse/dialects/transform/smt_ext/ops/constrain_params.py
@@ -1,4 +1,5 @@
-from typing import overload, Sequence, Callable
+from typing import overload
+from collections.abc import Sequence, Callable
 
 from mlir import ir
 from mlir.dialects import ext, smt, transform

--- a/lighthouse/dialects/transform/transform_ext/ops/get_tiling_sizes.py
+++ b/lighthouse/dialects/transform/transform_ext/ops/get_tiling_sizes.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Optional
+from collections.abc import Sequence
 
 from mlir import ir
 from mlir.dialects import ext, transform, linalg
@@ -28,7 +28,7 @@ class GetTilingSizesOp(TransformExtensionDialect.Operation, name="get_tiling_siz
     """
 
     target: ext.Operand[transform.AnyOpType]
-    tile_dim: Optional[ext.Operand[transform.AnyParamType]] = None
+    tile_dim: ext.Operand[transform.AnyParamType] | None = None
     tile_sizes_param: ext.Result[transform.AnyParamType[()]] = ext.infer_result()
 
     @classmethod

--- a/lighthouse/dialects/transform/transform_ext/ops/replace.py
+++ b/lighthouse/dialects/transform/transform_ext/ops/replace.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Optional
+from collections.abc import Sequence
 
 from mlir import ir
 from mlir.dialects import ext, transform
@@ -113,7 +113,7 @@ def replace(
     target: ir.Value,
     op_kind: str | ir.StringAttr,
     *new_operands: ir.Value,
-    new_result_types: Optional[ir.TupleType | Sequence[ir.Type]] = None,
+    new_result_types: ir.TupleType | Sequence[ir.Type] | None = None,
     new_attrs=None,
 ) -> ir.Value:
     if not isinstance(op_kind, ir.StringAttr):

--- a/lighthouse/dialects/transform/tune_ext/dialect.py
+++ b/lighthouse/dialects/transform/tune_ext/dialect.py
@@ -3,7 +3,8 @@ import re
 import ast
 import math
 from dataclasses import dataclass
-from typing import Any, Callable, Literal, Optional, Sequence
+from typing import Any, Literal
+from collections.abc import Callable, Sequence
 from functools import wraps
 from operator import mod
 
@@ -18,7 +19,7 @@ def register_and_load(**kwargs):
 
 def knob(
     *args,
-    result: Optional[ir.Type] = None,
+    result: ir.Type | None = None,
     **kwargs,
 ) -> "KnobValue":
     """Create a `transform.tune.knob` op whose result is wrapped in/cast to KnobValue."""

--- a/lighthouse/execution/runner.py
+++ b/lighthouse/execution/runner.py
@@ -8,7 +8,7 @@ import ctypes
 import os
 from contextlib import contextmanager
 from functools import partial
-from typing import Optional, Callable
+from collections.abc import Callable
 
 from mlir import ir
 from mlir.dialects import transform
@@ -35,7 +35,7 @@ class RunnerCallable(typing.Protocol):
         self,
         inputs: list[ctypes.Structure],
         execution_engine: ExecutionEngine,
-        memory_manager: Optional[MemoryManager],
+        memory_manager: MemoryManager | None,
     ) -> None: ...
 
 
@@ -147,9 +147,10 @@ class Runner:
         self,
         host_input_buffers: list,
         payload_function_name: str = "",
-        argument_access_callback: Optional[
-            Callable[[list[ctypes.Structure], ExecutionEngine, MemoryManager], None]
-        ] = None,
+        argument_access_callback: Callable[
+            [list[ctypes.Structure], ExecutionEngine, MemoryManager], None
+        ]
+        | None = None,
         nruns: int = 100,
         nwarmup: int = 10,
         benchmark: bool = True,

--- a/lighthouse/ingress/mlir_gen/main.py
+++ b/lighthouse/ingress/mlir_gen/main.py
@@ -2,7 +2,8 @@ import random
 import sys
 
 from argparse import ArgumentParser
-from typing import Sequence, Dict, Any, Optional
+from typing import Any
+from collections.abc import Sequence
 from collections import namedtuple
 
 import numpy as np
@@ -16,7 +17,7 @@ from .utils import get_outputs, get_weights, get_bias, get_mlir_elem_type
 BlockFactors = namedtuple("BlockFactors", "m n k vnni")
 
 
-def config_from_args(args: Sequence[str]) -> Dict[str, Any]:
+def config_from_args(args: Sequence[str]) -> dict[str, Any]:
     def csints(s: str) -> Sequence[int]:
         return [int(n) for n in s.split(",")]
 
@@ -102,14 +103,12 @@ def config_from_args(args: Sequence[str]) -> Dict[str, Any]:
 
 
 class TensorType:
-    def __init__(
-        self, block_factors: BlockFactors, elem_type: Optional[ir.Type] = None
-    ):
+    def __init__(self, block_factors: BlockFactors, elem_type: ir.Type | None = None):
         self.block_factors = block_factors
         self.elem_type = elem_type
 
     def input(
-        self, shape: Sequence[int], elem_type: Optional[ir.Type] = None
+        self, shape: Sequence[int], elem_type: ir.Type | None = None
     ) -> ir.RankedTensorType:
         elem_type, block = elem_type or self.elem_type, self.block_factors
 
@@ -127,7 +126,7 @@ class TensorType:
         return ir.RankedTensorType.get(shape, elem_type)
 
     def weights(
-        self, shape: Sequence[int], elem_type: Optional[ir.Type] = None
+        self, shape: Sequence[int], elem_type: ir.Type | None = None
     ) -> ir.RankedTensorType:
         elem_type, block = elem_type or self.elem_type, self.block_factors
 
@@ -160,7 +159,7 @@ class TensorType:
         return ir.RankedTensorType.get(shape, elem_type)
 
     def bias(
-        self, shape: Sequence[int], elem_type: Optional[ir.Type] = None
+        self, shape: Sequence[int], elem_type: ir.Type | None = None
     ) -> ir.RankedTensorType:
         elem_type, block = elem_type or self.elem_type, self.block_factors
 
@@ -172,7 +171,7 @@ class TensorType:
         return ir.RankedTensorType.get(shape, elem_type)
 
     def output(
-        self, shape: Sequence[int], elem_type: Optional[ir.Type] = None
+        self, shape: Sequence[int], elem_type: ir.Type | None = None
     ) -> ir.RankedTensorType:
         elem_type, block = elem_type or self.elem_type, self.block_factors
         if block.m and block.n:
@@ -189,7 +188,7 @@ class TensorType:
 
 
 def neural_net_as_func(
-    overall_args_types: Sequence[ir.Type], config: Dict[str, Any]
+    overall_args_types: Sequence[ir.Type], config: dict[str, Any]
 ) -> ir.Operation:
     keys = ["times_weights", "add_bias", "relu", "softmax"]
     times_weights, add_bias, relu, softmax = {
@@ -239,7 +238,7 @@ def neural_net_as_func(
     return entry
 
 
-def create_metadata(config: Dict[str, Any]) -> str:
+def create_metadata(config: dict[str, Any]) -> str:
     flops = 0
     for layer_num_neurons, next_layer_num_neurons in zip(
         config["layers"][:-1], config["layers"][1:]

--- a/lighthouse/ingress/mlir_gen/utils.py
+++ b/lighthouse/ingress/mlir_gen/utils.py
@@ -1,7 +1,6 @@
 import struct
 from enum import Enum, auto
 from collections import abc
-from typing import Union
 
 import numpy as np
 
@@ -121,7 +120,7 @@ def gen_tensor_cst(tensor_type: ir.RankedTensorType) -> ir.Value:
     return arith.constant(tensor_type, value)
 
 
-def get_outputs(outputs_or_outputs_type: Union[ir.Value, ir.Type]) -> ir.Value:
+def get_outputs(outputs_or_outputs_type: ir.Value | ir.Type) -> ir.Value:
     if isinstance(outputs_or_outputs_type, ir.Value):
         return outputs_or_outputs_type
     else:
@@ -135,7 +134,7 @@ def get_outputs(outputs_or_outputs_type: Union[ir.Value, ir.Type]) -> ir.Value:
         return linalg.fill(zero, outs=out_uninit)
 
 
-def get_weights(weights_or_weights_type: Union[ir.Value, ir.Type]) -> ir.Value:
+def get_weights(weights_or_weights_type: ir.Value | ir.Type) -> ir.Value:
     if isinstance(weights_or_weights_type, ir.Value):
         return weights_or_weights_type
     else:

--- a/lighthouse/ingress/torch/importer.py
+++ b/lighthouse/ingress/torch/importer.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 import warnings
 
 from lighthouse.ingress.torch.utils import (

--- a/lighthouse/pipeline/descriptor.py
+++ b/lighthouse/pipeline/descriptor.py
@@ -225,7 +225,7 @@ class PipelineDescriptor:
         self.base_path = (
             os.path.dirname(desc.basename) if desc.basename else desc.base_path
         )
-        with open(desc.basename, "r") as f:
+        with open(desc.basename) as f:
             self.pipeline_desc = yaml.safe_load(f)
         self._apply_variables()
         self.stages: list[str] = []

--- a/lighthouse/schedule/xegpu/fused_attention_schedule.py
+++ b/lighthouse/schedule/xegpu/fused_attention_schedule.py
@@ -1,7 +1,5 @@
 """Generate MLIR transform schedule for XeGPU fused attention operation."""
 
-from typing import Optional
-
 from mlir import ir
 from mlir.dialects import transform
 from mlir.dialects.transform import structured, loop, xegpu
@@ -26,8 +24,8 @@ from lighthouse.dialects.transform.transform_ext import (
 
 
 def fused_attention_schedule(
-    stop_at_stage: Optional[str] = None,
-    parameters: Optional[dict] = None,
+    stop_at_stage: str | None = None,
+    parameters: dict | None = None,
 ) -> ir.Module:
     """
     Generate transform schedule for attention kernel.

--- a/lighthouse/schedule/xegpu/layer_norm_schedule.py
+++ b/lighthouse/schedule/xegpu/layer_norm_schedule.py
@@ -1,7 +1,5 @@
 """Generate MLIR transform schedule for XeGPU layer_norm operation."""
 
-from typing import Optional
-
 from mlir import ir
 from mlir.dialects import transform
 from mlir.dialects.transform import structured, loop, xegpu
@@ -20,8 +18,8 @@ from lighthouse.dialects.transform import transform_ext
 
 
 def layer_norm_schedule(
-    stop_at_stage: Optional[str] = None,
-    parameters: Optional[dict] = None,
+    stop_at_stage: str | None = None,
+    parameters: dict | None = None,
 ) -> ir.Module:
     """
     Generate transform schedule for layer_norm operation.

--- a/lighthouse/schedule/xegpu/matmul_costmodel.py
+++ b/lighthouse/schedule/xegpu/matmul_costmodel.py
@@ -4,7 +4,7 @@ estimation for XeGPU targets.
 """
 
 from itertools import product
-from typing import Callable
+from collections.abc import Callable
 
 from .xegpu_specs import XeGPUSpecs
 from .matmul_constraints import (

--- a/lighthouse/schedule/xegpu/softmax_schedule.py
+++ b/lighthouse/schedule/xegpu/softmax_schedule.py
@@ -1,7 +1,5 @@
 """Generate MLIR transform schedule for XeGPU softmax operation."""
 
-from typing import Optional
-
 from mlir import ir
 from mlir.dialects import transform
 from mlir.dialects.transform import structured, loop, xegpu
@@ -20,8 +18,8 @@ from lighthouse.dialects.transform import transform_ext
 
 
 def softmax_schedule(
-    stop_at_stage: Optional[str] = None,
-    parameters: Optional[dict] = None,
+    stop_at_stage: str | None = None,
+    parameters: dict | None = None,
 ) -> ir.Module:
     """
     Generate transform schedule for softmax operation.

--- a/lighthouse/schedule/xegpu/xegpu_parameter_selector.py
+++ b/lighthouse/schedule/xegpu/xegpu_parameter_selector.py
@@ -12,7 +12,7 @@ DEFAULT_JSON_FILE = str(Path(__file__).parent / "matmul_params.json")
 
 def load_param_database(json_file: str = DEFAULT_JSON_FILE) -> dict:
     matmul_param_db = {}
-    with open(json_file, "r") as f:
+    with open(json_file) as f:
         data = json.load(f)
         for entry in data:
             M = entry["m"]

--- a/lighthouse/transform/tiling.py
+++ b/lighthouse/transform/tiling.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from collections.abc import Sequence
 
 from mlir import ir
 from mlir.dialects import transform

--- a/lighthouse/tune/enumerate.py
+++ b/lighthouse/tune/enumerate.py
@@ -1,5 +1,5 @@
 from itertools import product
-from typing import Sequence
+from collections.abc import Sequence
 
 from .trace import Tuneable, Predicate
 

--- a/lighthouse/tune/rewrite.py
+++ b/lighthouse/tune/rewrite.py
@@ -1,4 +1,4 @@
-from typing import Mapping
+from collections.abc import Mapping
 
 from mlir import ir
 from mlir.dialects.transform import tune as transform_tune

--- a/lighthouse/tune/trace.py
+++ b/lighthouse/tune/trace.py
@@ -5,7 +5,7 @@ from itertools import islice
 
 from operator import eq, ge, gt, le, lt, ne, mul, mod, floordiv, add
 
-from typing import Callable, Generator, Sequence, Optional
+from collections.abc import Callable, Generator, Sequence
 
 from mlir import ir
 from mlir.dialects import transform, smt
@@ -60,11 +60,11 @@ class Knob(Tuneable):
 
     Intended to represent the `Value` associated with a tuneable knob in IR."""
 
-    options: Optional[Sequence[int]] = None
-    lower_bound: Optional[int] = None
-    upper_bound: Optional[int] = None
-    divisible_by: Optional[int] = None
-    divides: Optional[int] = None
+    options: Sequence[int] | None = None
+    lower_bound: int | None = None
+    upper_bound: int | None = None
+    divisible_by: int | None = None
+    divides: int | None = None
 
     def __post_init__(self):
         assert self.options or (None not in (self.lower_bound, self.upper_bound)), (
@@ -203,7 +203,7 @@ def trace_smt_op(op: ir.Operation, env: dict) -> dict:
     return env
 
 
-def trace_tune_and_smt_ops(op: ir.Operation, env: Optional[dict] = None) -> dict:
+def trace_tune_and_smt_ops(op: ir.Operation, env: dict | None = None) -> dict:
     """Recursively add mapping from transform(.tune) and SMT ops to representative Nodes to env."""
 
     env = env if env is not None else {}  # TODO: nested scopes

--- a/lighthouse/utils/importer.py
+++ b/lighthouse/utils/importer.py
@@ -2,7 +2,7 @@ import importlib
 import importlib.util
 import os
 import sys
-from functools import lru_cache
+from functools import cache
 from pathlib import Path
 from types import ModuleType
 
@@ -23,11 +23,11 @@ def import_mlir_module(path: str, context: ir.Context) -> ir.Module:
         raise ValueError("Path to the module must be provided.")
     if not os.path.exists(path):
         raise ValueError(f"Path to the module does not exist: {path}")
-    with open(path, "r") as f:
+    with open(path) as f:
         return ir.Module.parse(f.read(), context=context)
 
 
-@lru_cache(maxsize=None)
+@cache
 def _resolve_package(directory: Path) -> tuple[str, str]:
     """
     Resolve the enclosing package for a directory.

--- a/lighthouse/utils/memref.py
+++ b/lighthouse/utils/memref.py
@@ -1,5 +1,5 @@
 import ctypes
-from typing import Sequence
+from collections.abc import Sequence
 
 
 def to_ctype(memref_desc) -> ctypes._Pointer:

--- a/lighthouse/utils/types.py
+++ b/lighthouse/utils/types.py
@@ -1,4 +1,5 @@
-from typing import TypeVar, Generic, Callable
+from typing import TypeVar, Generic
+from collections.abc import Callable
 
 from collections.abc import Mapping
 

--- a/lit.cfg.py
+++ b/lit.cfg.py
@@ -23,7 +23,7 @@ def find_filecheck() -> str:
         return "FileCheck"  # Avoid full path when none is needed
     # Otherwise, search for FileCheck in the system and return the newest one.
     for version in range(21, 0, -1):
-        path = shutil.which("FileCheck-{}".format(version))
+        path = shutil.which(f"FileCheck-{version}")
         if path:
             return path
     # If not found, raise an error.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ select = [
   "RUF034", # useless if-else
   "RUF047", # empty else
   "RUF200", # invalid pyproject.toml
+  "UP", # upgrade syntax to target version
   "W", # Warning
 ]
 ignore = [

--- a/tools/kernel-bench
+++ b/tools/kernel-bench
@@ -51,8 +51,7 @@ def dump_assembly(obj_file, asm_file):
     try:
         result = subprocess.run(
             ["objdump", "-d", obj_file],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
             check=True,
         )

--- a/tools/lh-tune
+++ b/tools/lh-tune
@@ -2,7 +2,7 @@
 
 import sys
 import argparse
-from typing import Mapping
+from collections.abc import Mapping
 
 from mlir import ir
 from mlir.dialects import transform
@@ -22,7 +22,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-file = sys.stdin if args.file == "-" else open(args.file, "r")
+file = sys.stdin if args.file == "-" else open(args.file)
 with ir.Context() as ctx, ir.Location.unknown():
     lh_dialects.register_and_load()
 


### PR DESCRIPTION
Adds a new ruff rule based on pyupgrade that upgrades Python syntax to match PEP recommendations for the project's target Python version.

The new rule keeps code base more up to date and consistent.