### PR TITLE
[CI] Linter - disallow assignments in asserts

### DIFF
--- a/lighthouse/tune/trace.py
+++ b/lighthouse/tune/trace.py
@@ -292,7 +292,8 @@ def trace_tune_and_smt_ops(op: ir.Operation, env: Optional[dict] = None) -> dict
 
             env[op] = Predicate(lambda *args: all(args), child_predicates)
 
-            assert isinstance(smt_yield := op.body.operations[-1], smt.YieldOp)
+            smt_yield = op.body.operations[-1]
+            assert isinstance(smt_yield, smt.YieldOp)
 
             # Map the op's results to the nodes already associated to the
             # corresponding values yielded by the region/block's terminator.

--- a/lit.cfg.py
+++ b/lit.cfg.py
@@ -8,7 +8,8 @@ import lit.formats
 from lit.TestingConfig import TestingConfig
 
 # Imagine that, all your variables defined and with type information!
-assert isinstance(config := eval("config"), TestingConfig)
+config = eval("config")
+assert isinstance(config, TestingConfig)
 
 
 def find_filecheck() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ select = [
   "E", # Error
   "F", # Pyflakes
   "PERF", # Perflint
+  "RUF018", # assignment in assert
   "RUF022", # __all__ is not sorted
   "RUF030", # print() call in assert
   "RUF034", # useless if-else


### PR DESCRIPTION
Adds a new rule to prohibit assigning values to variables within assert statements which may result in unexpected behavior when asserts are disabled.