### PR TITLE
Linalg/XeGPU llama3 forward-pass example

### DIFF
--- a/examples/xegpu/lit.local.cfg
+++ b/examples/xegpu/lit.local.cfg
@@ -2,5 +2,7 @@ config.excludes = [
     "csv_logger.py",
     "nanoGPT_payload.py",
     "nanoGPT_schedule.py",
+    "llama3_payload.py",
+    "llama3_schedule.py",
     "tune_utils.py",
 ]

--- a/examples/xegpu/llama3.py
+++ b/examples/xegpu/llama3.py
@@ -1,0 +1,333 @@
+# RUN: %PYTHON %s --dump xegpu-wg --n-layers 1 | FileCheck %s
+# CHECK: module attributes {gpu.container_module} {
+
+"""Llama-3 forward pass on the Intel GPU (XeGPU) -- the DRIVER ("run it").
+
+Runs a Llama-3 transformer forward/inference as one MLIR module lowered to many
+separate un-fused XeGPU kernels with on-device handoff. Llama building blocks:
+
+  * RMSNorm
+  * SwiGLU FFN     w2( silu(z @ w1) * (z @ w3) )
+  * grouped-query attention via the fused flash kernel (causal by default;
+    --no-causal to disable), with RoPE applied to q/k
+  * no biases (Llama uses bias=False on every Linear)
+
+Each transformer block is
+    h   = x + wo( MHA( rms_attn(x) ) )       # attention sublayer
+    out = h + swiglu( rms_ffn(h) )           # MLP sublayer
+and the full model is
+    x = tok_embeddings(tokens)         # embeddings done host-side
+    for _ in range(n_layers): x = Block(x)
+    x = rms_final(x); logits = x @ output_weight
+
+Config: n_layers=6, dim=256, n_heads=4 (head_dim=64), hidden=1024, vocab=256,
+seq_len=256.
+
+Three-stage organization (compiling a model to the GPU here):
+  1. Payload  ("what to compute") -> examples/xegpu/llama3_payload.py
+  2. Schedule ("how to lower it")  -> examples/xegpu/llama3_schedule.py
+  3. Driver   ("run it")           -> this file.
+
+Run:
+  .venv/bin/python examples/xegpu/llama3.py [--n-layers N] [--check]
+  .venv/bin/python examples/xegpu/llama3.py [--dump STAGE]
+"""
+
+import argparse
+import numpy as np
+from mlir import ir
+
+from lighthouse import dialects as lh_dialects
+from lighthouse.pipeline.driver import TransformDriver
+from lighthouse.execution.runner import Runner
+from lighthouse.execution import GPUMemoryManager
+from lighthouse.schedule.xegpu import xegpu_to_binary, XeGPUParameterSelector
+from llama3_payload import build_llama_payload
+from llama3_schedule import build_combined_schedule
+
+
+# =============================================================================
+# NUMPY REFERENCE -- the same math in plain numpy, to CHECK the GPU result.
+# `_f16` rounds through float16 to model the GPU's f16 matmul precision.
+# =============================================================================
+def _rms(x, weight, eps=1e-5):
+    ms = np.mean(x.astype(np.float32) ** 2, axis=-1, keepdims=True)
+    return x / np.sqrt(ms + eps) * weight
+
+
+def _f16(a):
+    # round f32 -> f16 -> f32: models the precision loss of the GPU's f16 matmul.
+    return a.astype(np.float16).astype(np.float32)
+
+
+def _silu(x):
+    return x / (1.0 + np.exp(-x))
+
+
+def _rope_tables(T, hs, theta=10000.0):
+    """Precompute (cos, sin) tables of shape (T, hs/2) for half-split RoPE.
+    freq[i] = theta**(-2i/hs); angle[t,i] = t * freq[i]. Matches the payload's
+    cos/sin memref args (see Builder.rope)."""
+    half = hs // 2
+    freqs = theta ** (-np.arange(0, half, dtype=np.float32) * 2.0 / hs)
+    ang = np.outer(np.arange(T, dtype=np.float32), freqs)  # (T, half)
+    return np.cos(ang).astype(np.float32), np.sin(ang).astype(np.float32)
+
+
+def _rope(x, cos, sin, nh):
+    """Half-split (GPT-NeoX / HF-Llama) rotary embedding on (T, nh*hs) f32, per head.
+    Mirrors Builder.rope: within each head, coord d (first half) pairs with d+half
+    (second half): out[d]=a*cos-b*sin, out[d+half]=b*cos+a*sin. cos/sin are (T,half)."""
+    T, D = x.shape
+    hs = D // nh
+    half = hs // 2
+    v = x.reshape(T, nh, hs)
+    a = v[:, :, :half]
+    b = v[:, :, half:]
+    c = cos[:, None, :]  # (T,1,half) broadcast over heads
+    s = sin[:, None, :]
+    out = np.empty_like(v)
+    out[:, :, :half] = a * c - b * s
+    out[:, :, half:] = b * c + a * s
+    return out.reshape(T, D)
+
+
+def _mha(q, k, v, H, n_kv, causal=False):
+    """Grouped-query attention over q (T,C) and narrow k/v (T, n_kv*hs), per query
+    head, with an optional causal mask. Returns (T,C). Query head h reads KV head
+    h // n_rep (n_rep = H // n_kv), matching the fused kernel's floordiv K/V index.
+    Mirrors the fused kernel's math; pass `causal` to match `fa_params["causal"]`."""
+    T, C = q.shape
+    hs = C // H
+    n_rep = H // n_kv
+    scale = 1.0 / (hs**0.5)
+    mask = np.triu(np.full((T, T), -np.inf, np.float32), k=1) if causal else 0.0
+    attn = np.zeros((T, C), np.float32)
+    for h in range(H):
+        q_sl = slice(h * hs, (h + 1) * hs)
+        kv = h // n_rep  # GQA: this query head's KV head
+        kv_sl = slice(kv * hs, (kv + 1) * hs)
+        scores = (q[:, q_sl] @ k[:, kv_sl].T) * scale + mask
+        scores = scores - scores.max(-1, keepdims=True)
+        e = np.exp(scores)
+        w = e / e.sum(-1, keepdims=True)
+        attn[:, q_sl] = _f16(w) @ v[:, kv_sl]
+    return attn
+
+
+def numpy_ref_block_llama(x, w, cos, sin, H, n_kv, eps=1e-5, causal=False):
+    """Grouped-query + RoPE Llama block reference (matches _emit_block_llama). wk/wv
+    are narrow (C, n_kv*hs), so k/v are (T, n_kv*hs) and _mha does the head grouping.
+    RoPE is applied to q and k on the f32 projection, before the f16 cast (v skips
+    RoPE) -- matching Builder.fused_attention."""
+    rms1 = _f16(_rms(x, w["an"], eps))
+    q = _f16(_rope(rms1 @ w["wq"].astype(np.float32), cos, sin, H))
+    k = _f16(_rope(rms1 @ w["wk"].astype(np.float32), cos, sin, n_kv))
+    v = _f16(rms1 @ w["wv"].astype(np.float32))
+    attn = _mha(q, k, v, H, n_kv, causal)
+    proj = _f16(attn) @ w["wo"].astype(np.float32)
+    h = x + proj
+    rms2 = _f16(_rms(h, w["fn"], eps))
+    gate = _silu(rms2 @ w["w1"].astype(np.float32))
+    up = rms2 @ w["w3"].astype(np.float32)
+    o = _f16(gate * up) @ w["w2"].astype(np.float32)
+    return h + o
+
+
+def numpy_ref_llama(x, layer_w, fn_w, lmw, cos, sin, H, n_kv, eps=1e-5, causal=False):
+    """Grouped-query + RoPE full-Llama reference (matches build_llama_payload);
+    `causal` toggles the autoregressive attention mask to match the fused kernel."""
+    h = x
+    for w in layer_w:
+        h = numpy_ref_block_llama(h, w, cos, sin, H, n_kv, eps, causal)
+    hf = _rms(h, fn_w, eps)
+    return _f16(hf) @ lmw.astype(np.float32)
+
+
+def main():
+    """Entry point. Builds the full Llama model (n_layers blocks -> rms_final ->
+    output), with flash grouped-query attention (RoPE, causal) per block.
+
+    Flow: build payload module -> build combined schedule (which folds in the
+    fused attention rewrite) -> TransformDriver lowers it to XeGPU + xegpu_to_binary
+    makes the GPU binary -> Runner JIT-runs it -> compare to the numpy reference.
+    """
+    parser = argparse.ArgumentParser(
+        description="Llama-3-style forward pass on the Intel GPU (XeGPU).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--n-layers",
+        type=int,
+        default=1,
+        help="Number of transformer layers (the full model uses 6).",
+    )
+    parser.add_argument(
+        "--no-causal",
+        action="store_true",
+        help="Disable causal masking (run non-causal attention).",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Run on the GPU and compare the result against the numpy reference.",
+    )
+    parser.add_argument(
+        "--dump",
+        type=str,
+        default=None,
+        choices=[
+            "initial",
+            "schedule",
+            "tiled",
+            "vectorized",
+            "bufferized",
+            "inner-tiled",
+            "gpu-outlining",
+            "xegpu-initial",
+            "xegpu-wg",
+            "final",
+        ],
+        help="Print the IR at the given stage and exit.",
+    )
+    args = parser.parse_args()
+    dump = args.dump
+    check = args.check
+    n_layers = args.n_layers
+    causal = not args.no_causal  # Llama-3 is autoregressive/causal
+
+    # Kernel-friendly shapes: T=dim=256 (q/k/v/proj matmuls), hidden=1024,
+    # vocab=256. Multi-head: H heads of head_size=dim/H=64. GQA: n_kv KV heads
+    # (n_kv <= H, H % n_kv == 0); each query head reads KV head h // (H//n_kv).
+    T, C, hidden = 256, 256, 1024
+    vocab = 256
+    H = 4  # attention (query) heads (hs = C/H = 64)
+    # KV heads for grouped-query attention: 1 < n_kv < H, and n_kv | H. Each query
+    # head reads KV head h // (H//n_kv). The degenerate ends -- n_kv == H (plain MHA,
+    # n_rep=1) and n_kv == 1 (multi-query) -- collapse a factored head dim to 1,
+    # which reshapes the fused-attention region so its QK^T/@V don't co-tile into one
+    # forall; use the plain-MHA example for n_kv == H.
+    n_kv = 2  # 2 query heads share each KV head (n_rep = H // n_kv = 2)
+    hs = C // H
+    kv_dim = n_kv * hs  # narrow K/V feature width
+    param_selector = XeGPUParameterSelector()
+    mm_params = dict(param_selector.get_parameters((T, C, C)))
+    mm_params["gpu_specs"] = param_selector.gpu_specs
+    ln_params = {
+        "wg_rows": 64,
+        "sg_rows": 8,
+        "subgroup_size": 16,
+        "reduction_step_size": 16,
+        "T": T,
+    }
+    fa_params = {
+        "batch_size": 1,
+        "num_heads": H,
+        "n_ctx": T,
+        "n_head": C // H,
+        "wg_rows": 128,
+        "sg_rows": 16,
+        "subgroup_size": 16,
+        "inner_loop_tile_size": 64,
+        "causal": causal,
+    }
+
+    with ir.Context(), ir.Location.unknown():
+        lh_dialects.register_and_load()
+        mod, kinds, mm_shapes = build_llama_payload(
+            "payload", T, C, hidden, vocab, n_layers, H, n_kv
+        )
+        if dump == "initial":
+            print(mod)
+            print("KINDS:", kinds)
+            return
+
+        # Per-matmul DPAS params: the K/V projections are narrow (N = n_kv*hs < C),
+        # so they need different wg_n/sg_n tiling than the wide matmuls. Select once
+        # per distinct (M,N,K) shape (the selector reads the tuple as (M,N,K)).
+        shape_params = {}
+        for shp in mm_shapes:
+            if shp not in shape_params:
+                p = dict(param_selector.get_parameters(shp))
+                p["gpu_specs"] = param_selector.gpu_specs
+                shape_params[shp] = p
+        mm_params_list = [dict(shape_params[shp]) for shp in mm_shapes]
+
+        sched = build_combined_schedule(
+            dict(mm_params),
+            dict(ln_params),
+            kinds,
+            stop_at_stage=(dump or ""),
+            fa_params=dict(fa_params),
+            mm_params_list=mm_params_list,
+        )
+        if dump == "schedule":
+            print(sched)
+            return
+        schedules = [sched]
+        if not dump or dump == "final":
+            schedules.append(xegpu_to_binary())
+        payload = TransformDriver(schedules).apply(mod)
+        if dump:
+            print(payload)
+            return
+        print(f"LOWERED OK: 'llama' to {len(kinds)} kernels in one module")
+
+        if not check:
+            return
+        runner = Runner(
+            payload,
+            mem_manager_cls=GPUMemoryManager,
+            shared_libs=["libmlir_levelzero_runtime.so"],
+        )
+        np.random.seed(0)
+        out = np.zeros((T, vocab), np.float32)
+        cb = Runner.get_gpu_argument_access_callback(out, arg_index=0)
+        sc = 0.05  # small weight scale -> O(1) activations so f16 stays accurate
+
+        # host "embeddings": simulate tok_embeddings(tokens) as the input x.
+        x = (np.random.randn(T, C) * 0.5).astype(np.float32)
+        cos, sin = _rope_tables(T, hs)  # RoPE (T, hs/2) tables, shared across layers
+        layers = []
+        host = [out, x, cos, sin]  # matches payload arg order: out, x, cos, sin, ...
+        for _ in range(n_layers):
+            lw = dict(
+                an=np.ones(C, np.float32),
+                wq=(np.random.randn(C, C) * sc).astype(np.float16),
+                wk=(np.random.randn(C, kv_dim) * sc).astype(np.float16),
+                wv=(np.random.randn(C, kv_dim) * sc).astype(np.float16),
+                wo=(np.random.randn(C, C) * sc).astype(np.float16),
+                fn=np.ones(C, np.float32),
+                w1=(np.random.randn(C, hidden) * sc).astype(np.float16),
+                w2=(np.random.randn(hidden, C) * sc).astype(np.float16),
+                w3=(np.random.randn(C, hidden) * sc).astype(np.float16),
+            )
+            layers.append(lw)
+            host += [
+                lw["an"],
+                lw["wq"],
+                lw["wk"],
+                lw["wv"],
+                lw["wo"],
+                lw["fn"],
+                lw["w1"],
+                lw["w2"],
+                lw["w3"],
+            ]
+        fn_w = np.ones(C, np.float32)
+        lmw = (np.random.randn(C, vocab) * sc).astype(np.float16)
+        host += [fn_w, lmw]
+        runner.execute(
+            host_input_buffers=host,
+            payload_function_name="payload",
+            argument_access_callback=cb,
+        )
+        ref = numpy_ref_llama(x, layers, fn_w, lmw, cos, sin, H, n_kv, causal=causal)
+
+        rel = np.abs(out - ref).max() / (np.abs(ref).max() + 1e-6)
+        print(f"max abs diff={np.abs(out - ref).max():.4f}  rel={rel:.6f}")
+        print("PASSED" if rel < 5e-2 else "FAILED")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/xegpu/llama3.py
+++ b/examples/xegpu/llama3.py
@@ -50,21 +50,21 @@ from llama3_schedule import build_combined_schedule
 # NUMPY REFERENCE -- the same math in plain numpy, to CHECK the GPU result.
 # `_f16` rounds through float16 to model the GPU's f16 matmul precision.
 # =============================================================================
-def _rms(x, weight, eps=1e-5):
+def _numpy_rms(x, weight, eps=1e-5):
     ms = np.mean(x.astype(np.float32) ** 2, axis=-1, keepdims=True)
     return x / np.sqrt(ms + eps) * weight
 
 
-def _f16(a):
+def _numpy_f16(a):
     # round f32 -> f16 -> f32: models the precision loss of the GPU's f16 matmul.
     return a.astype(np.float16).astype(np.float32)
 
 
-def _silu(x):
+def _numpy_silu(x):
     return x / (1.0 + np.exp(-x))
 
 
-def _rope_tables(T, hs, theta=10000.0):
+def _numpy_rope_tables(T, hs, theta=10000.0):
     """Precompute (cos, sin) tables of shape (T, hs/2) for half-split RoPE.
     freq[i] = theta**(-2i/hs); angle[t,i] = t * freq[i]. Matches the payload's
     cos/sin memref args (see Builder.rope)."""
@@ -74,7 +74,7 @@ def _rope_tables(T, hs, theta=10000.0):
     return np.cos(ang).astype(np.float32), np.sin(ang).astype(np.float32)
 
 
-def _rope(x, cos, sin, nh):
+def _numpy_rope(x, cos, sin, nh):
     """Half-split (GPT-NeoX / HF-Llama) rotary embedding on (T, nh*hs) f32, per head.
     Mirrors Builder.rope: within each head, coord d (first half) pairs with d+half
     (second half): out[d]=a*cos-b*sin, out[d+half]=b*cos+a*sin. cos/sin are (T,half)."""
@@ -92,7 +92,7 @@ def _rope(x, cos, sin, nh):
     return out.reshape(T, D)
 
 
-def _mha(q, k, v, H, n_kv, causal=False):
+def _numpy_mha(q, k, v, H, n_kv, causal=False):
     """Grouped-query attention over q (T,C) and narrow k/v (T, n_kv*hs), per query
     head, with an optional causal mask. Returns (T,C). Query head h reads KV head
     h // n_rep (n_rep = H // n_kv), matching the fused kernel's floordiv K/V index.
@@ -111,7 +111,7 @@ def _mha(q, k, v, H, n_kv, causal=False):
         scores = scores - scores.max(-1, keepdims=True)
         e = np.exp(scores)
         w = e / e.sum(-1, keepdims=True)
-        attn[:, q_sl] = _f16(w) @ v[:, kv_sl]
+        attn[:, q_sl] = _numpy_f16(w) @ v[:, kv_sl]
     return attn
 
 
@@ -120,17 +120,17 @@ def numpy_ref_block_llama(x, w, cos, sin, H, n_kv, eps=1e-5, causal=False):
     are narrow (C, n_kv*hs), so k/v are (T, n_kv*hs) and _mha does the head grouping.
     RoPE is applied to q and k on the f32 projection, before the f16 cast (v skips
     RoPE) -- matching Builder.fused_attention."""
-    rms1 = _f16(_rms(x, w["an"], eps))
-    q = _f16(_rope(rms1 @ w["wq"].astype(np.float32), cos, sin, H))
-    k = _f16(_rope(rms1 @ w["wk"].astype(np.float32), cos, sin, n_kv))
-    v = _f16(rms1 @ w["wv"].astype(np.float32))
-    attn = _mha(q, k, v, H, n_kv, causal)
-    proj = _f16(attn) @ w["wo"].astype(np.float32)
+    rms1 = _numpy_f16(_numpy_rms(x, w["attn_norm"], eps))
+    q = _numpy_f16(_numpy_rope(rms1 @ w["wq"].astype(np.float32), cos, sin, H))
+    k = _numpy_f16(_numpy_rope(rms1 @ w["wk"].astype(np.float32), cos, sin, n_kv))
+    v = _numpy_f16(rms1 @ w["wv"].astype(np.float32))
+    attn = _numpy_mha(q, k, v, H, n_kv, causal)
+    proj = _numpy_f16(attn) @ w["wo"].astype(np.float32)
     h = x + proj
-    rms2 = _f16(_rms(h, w["fn"], eps))
-    gate = _silu(rms2 @ w["w1"].astype(np.float32))
+    rms2 = _numpy_f16(_numpy_rms(h, w["ffn_norm"], eps))
+    gate = _numpy_silu(rms2 @ w["w1"].astype(np.float32))
     up = rms2 @ w["w3"].astype(np.float32)
-    o = _f16(gate * up) @ w["w2"].astype(np.float32)
+    o = _numpy_f16(gate * up) @ w["w2"].astype(np.float32)
     return h + o
 
 
@@ -140,8 +140,8 @@ def numpy_ref_llama(x, layer_w, fn_w, lmw, cos, sin, H, n_kv, eps=1e-5, causal=F
     h = x
     for w in layer_w:
         h = numpy_ref_block_llama(h, w, cos, sin, H, n_kv, eps, causal)
-    hf = _rms(h, fn_w, eps)
-    return _f16(hf) @ lmw.astype(np.float32)
+    hf = _numpy_rms(h, fn_w, eps)
+    return _numpy_f16(hf) @ lmw.astype(np.float32)
 
 
 def main():
@@ -287,29 +287,31 @@ def main():
 
         # host "embeddings": simulate tok_embeddings(tokens) as the input x.
         x = (np.random.randn(T, C) * 0.5).astype(np.float32)
-        cos, sin = _rope_tables(T, hs)  # RoPE (T, hs/2) tables, shared across layers
+        cos, sin = _numpy_rope_tables(
+            T, hs
+        )  # RoPE (T, hs/2) tables, shared across layers
         layers = []
         host = [out, x, cos, sin]  # matches payload arg order: out, x, cos, sin, ...
         for _ in range(n_layers):
             lw = dict(
-                an=np.ones(C, np.float32),
+                attn_norm=np.ones(C, np.float32),
                 wq=(np.random.randn(C, C) * sc).astype(np.float16),
                 wk=(np.random.randn(C, kv_dim) * sc).astype(np.float16),
                 wv=(np.random.randn(C, kv_dim) * sc).astype(np.float16),
                 wo=(np.random.randn(C, C) * sc).astype(np.float16),
-                fn=np.ones(C, np.float32),
+                ffn_norm=np.ones(C, np.float32),
                 w1=(np.random.randn(C, hidden) * sc).astype(np.float16),
                 w2=(np.random.randn(hidden, C) * sc).astype(np.float16),
                 w3=(np.random.randn(C, hidden) * sc).astype(np.float16),
             )
             layers.append(lw)
             host += [
-                lw["an"],
+                lw["attn_norm"],
                 lw["wq"],
                 lw["wk"],
                 lw["wv"],
                 lw["wo"],
-                lw["fn"],
+                lw["ffn_norm"],
                 lw["w1"],
                 lw["w2"],
                 lw["w3"],

--- a/examples/xegpu/llama3_payload.py
+++ b/examples/xegpu/llama3_payload.py
@@ -1,0 +1,571 @@
+"""Generate the Llama-3 forward pass payload at the linalg level (GPU / XeGPU).
+
+This is stage 1 -- the payload ("what to compute"): an MLIR module describing
+the Llama forward at linalg level. Llama's building blocks:
+
+  * RMSNorm
+  * SwiGLU FFN     w2( silu(x @ w1) * (x @ w3) )   -- 3 matmuls, no bias
+  * grouped-query attention via the fused flash kernel (causal by default),
+    with RoPE applied to q/k
+  * no biases anywhere (Llama uses bias=False on every Linear)
+
+  -> class `Builder` (emits one op at a time) and `build_llama_payload`.
+
+Each transformer block is
+    h   = x + attn_proj( MHA( rms_attn(x) ) )       # attention sublayer
+    out = h + swiglu_ffn( rms_ffn(h) )              # MLP sublayer
+and the full model is
+    x = tok_embeddings(tokens)         # embeddings done host-side
+    for _ in range(n_layers): x = Block(x)
+    x = rms_final(x); logits = x @ output_weight
+
+Kernel-friendly dims (functional correctness, shapes are free): dim=256,
+n_heads=4 (head_dim=64), hidden=1024, vocab=256.
+"""
+
+from mlir import ir
+from mlir.dialects import linalg, bufferization, tensor, arith, math, gpu, memref
+
+from lighthouse.ingress.mlir_gen.utils import (
+    emit_buf_to_tensor,
+    affine_map,
+    parallel,
+    reduction,
+)
+from lighthouse.ingress.mlir_gen.gpu_utils import emit_gpu_util_funcs
+from lighthouse.ingress.mlir_gen.named import times_weights
+from lighthouse.utils.mlir import func_cif
+
+
+def F32():  # 32-bit float (used for accumulation / norms)
+    return ir.F32Type.get()
+
+
+def F16():  # 16-bit float (required by the GPU matmul units)
+    return ir.F16Type.get()
+
+
+# =============================================================================
+# Payload: describe what to compute (high-level linalg ops; no tiling/XeGPU yet)
+# =============================================================================
+# Each Builder method emits one high-level op that writes its result into a fresh
+# on-device buffer (`gpu.alloc`), and returns a tensor "view" of that buffer for
+# the next op to read. Because each op writes a distinct device buffer, each will
+# become its OWN GPU kernel later; the buffers are the on-device handoff between
+# kernels (kernel N writes buffer B, kernel N+1 reads B -- no host round-trip).
+#
+# dtype convention: the GPU matmul (DPAS) hardware needs f16 inputs and produces
+# an f32 result. RMSNorm/softmax run in f32. So between a norm/softmax and a
+# matmul we insert an explicit f32->f16 `cast` op (its own kernel).
+# =============================================================================
+class Builder:
+    """Emits the model's ops and remembers the order/kind of each one.
+
+    `kinds` is the crucial bookkeeping: an ordered list, one entry per op emitted,
+    recording its "class" so the schedule (stage 2) can later tile and annotate
+    each kernel correctly. Classes:
+      'mm'  = matmul (linalg.matmul)          -> DPAS systolic-array kernel
+      'rms' = RMSNorm (2 generics + 1 fill)   -> reduction kernel (uses shared mem)
+      'fa'  = flash multi-head attention -> one kernel (QK^T->softmax->@V,
+              online-softmax over K/V tiles; causal mask added by the schedule).
+      'ew'  = elementwise (cast / silu / mul / residual) -> row-parallel kernel
+    The op build order in the payload == the order of `kinds` == the order the
+    kernels appear in the final module, which is how the schedule matches them up.
+    """
+
+    def __init__(self, T):
+        self.T = T
+        self.f32, self.f16 = F32(), F16()
+        self.kinds = []  # ordered kernel classes (see docstring)
+        self.mm_shapes = []  # (M,N,K) per matmul, in build order (for per-mm params)
+        self.to_dealloc = []  # device buffers to gpu.dealloc at the end
+
+    def _buf(self, shape, dtype):
+        # Allocate a DEVICE buffer (lives in GPU memory). Returns the memref.
+        b = gpu.alloc(ir.MemRefType.get(shape, dtype), None, [], [], [])
+        self.to_dealloc.append(b)
+        return b
+
+    def _par(self, rank=2):
+        # Identity affine map (d0,d1,...) -> (d0,d1,...): a plain elementwise
+        # access pattern where output[i,j] depends on input[i,j].
+        return affine_map(rank, [ir.AffineDimExpr.get(i) for i in range(rank)])
+
+    # ---- matmul: a(M,K) f16 @ b(K,N) f16 -> (M,N) f32 buffer ----
+    def matmul(self, a, b, M, N, out_buf=None):
+        # Standard C = A @ B. `times_weights` emits linalg.matmul; we first fill the
+        # accumulator with 0. f16 inputs, f32 output -- matches the DPAS hardware.
+        buf = out_buf if out_buf is not None else self._buf((M, N), self.f32)
+        out_t = emit_buf_to_tensor(buf, restrict=True, writable=True)
+        acc = linalg.fill(arith.constant(self.f32, 0.0), outs=[out_t])
+        res = times_weights(a, b, acc)
+        bufferization.materialize_in_destination(
+            None, res, buf, restrict=True, writable=True
+        )
+        self.kinds.append("mm")
+        K = a.type.shape[-1]
+        self.mm_shapes.append((M, N, K))
+        if out_buf is not None:  # caller gave the final output buffer
+            return None
+        return emit_buf_to_tensor(buf, restrict=True)
+
+    # ---- RMSNorm(x (M,N) f32, weight (N,)) -> (M,N) f32 buffer ----
+    def rmsnorm(self, x, weight, M, N, eps=1e-5):
+        # RMSNorm: out[i,j] = x[i,j] * rsqrt(mean_k x[i,k]^2 + eps) * weight[j].
+        # No mean-subtraction (unlike LayerNorm). Built from 2 linalg.generic ops:
+        #   (1) ss[i]     = sum_k x[i,k]^2                  (row reduction)
+        #   (2) out[i,j]  = x[i,j] * rsqrt(ss_i/N + eps) * weight[j]
+        # Affine maps:
+        #   par2  (d0,d1)->(d0,d1) : full 2-D elementwise
+        #   red2  (d0,d1)->(d0)    : reduce over j -> one value per row
+        #   bias2 (d0,d1)->(d1)    : weight indexed by column only
+        f32 = self.f32
+        par2, red2 = self._par(), affine_map(2, [ir.AffineDimExpr.get(0)])
+        bias2 = affine_map(2, [ir.AffineDimExpr.get(1)])
+        inv_n = arith.constant(f32, 1.0 / float(N))
+        eps_c = arith.constant(f32, eps)
+        zero = arith.constant(f32, 0.0)
+        # (1) sum of squares -> ss (linalg.fill zeroes the accumulator first)
+        ss_acc = linalg.fill(zero, outs=[tensor.empty((M,), f32)])
+
+        @linalg.generic([x], [ss_acc], [par2, red2], [parallel, reduction])
+        def ss_sum(v, acc):
+            return arith.AddFOp(arith.MulFOp(v, v).result, acc)
+
+        # (2) normalize + scale -> output
+        buf = self._buf((M, N), f32)
+        out_t = emit_buf_to_tensor(buf, restrict=True, writable=True)
+
+        @linalg.generic(
+            [x, ss_sum, weight],
+            [out_t],
+            [par2, red2, bias2, par2],
+            [parallel, parallel],
+        )
+        def normed(v, s, w, _o):
+            ms = arith.MulFOp(s, inv_n).result
+            inv_rms = math.rsqrt(arith.AddFOp(ms, eps_c).result)
+            return arith.MulFOp(arith.MulFOp(v, inv_rms).result, w)
+
+        bufferization.materialize_in_destination(
+            None, normed, buf, restrict=True, writable=True
+        )
+        self.kinds.append("rms")
+        return emit_buf_to_tensor(buf, restrict=True)
+
+    # ---- elementwise cast f32 -> f16 ----
+    def cast_f16(self, x, M, N):
+        par2 = self._par()
+        buf = self._buf((M, N), self.f16)
+        out_t = emit_buf_to_tensor(buf, restrict=True, writable=True)
+
+        @linalg.generic([x], [out_t], [par2, par2], [parallel, parallel])
+        def c(s, _o):
+            return arith.TruncFOp(self.f16, s)
+
+        bufferization.materialize_in_destination(
+            None, c, buf, restrict=True, writable=True
+        )
+        self.kinds.append("ew")
+        return emit_buf_to_tensor(buf, restrict=True)
+
+    # ---- silu (swish): out = x * sigmoid(x)  (x (M,N) f32) ----
+    def silu(self, x, M, N):
+        par2 = self._par()
+        one = arith.constant(self.f32, 1.0)
+        buf = self._buf((M, N), self.f32)
+        out_t = emit_buf_to_tensor(buf, restrict=True, writable=True)
+
+        @linalg.generic([x], [out_t], [par2, par2], [parallel, parallel])
+        def s(v, _o):
+            # sigmoid(v) = 1 / (1 + exp(-v)); silu = v * sigmoid(v)
+            neg = arith.NegFOp(v).result
+            sig = arith.DivFOp(one, arith.AddFOp(one, math.exp(neg)).result).result
+            return arith.MulFOp(v, sig)
+
+        bufferization.materialize_in_destination(
+            None, s, buf, restrict=True, writable=True
+        )
+        self.kinds.append("ew")
+        return emit_buf_to_tensor(buf, restrict=True)
+
+    # ---- elementwise multiply: out = a * b  (both (M,N) f32) ----
+    def mul(self, a, b, M, N):
+        par2 = self._par()
+        buf = self._buf((M, N), self.f32)
+        out_t = emit_buf_to_tensor(buf, restrict=True, writable=True)
+
+        @linalg.generic([a, b], [out_t], [par2, par2, par2], [parallel, parallel])
+        def m(x, y, _o):
+            return arith.MulFOp(x, y)
+
+        bufferization.materialize_in_destination(
+            None, m, buf, restrict=True, writable=True
+        )
+        self.kinds.append("ew")
+        return emit_buf_to_tensor(buf, restrict=True)
+
+    # ---- residual add: out = a + b  (both (M,N) f32) ----
+    def add(self, a, b, M, N, out_buf=None):
+        par2 = self._par()
+        buf = out_buf if out_buf is not None else self._buf((M, N), self.f32)
+        out_t = emit_buf_to_tensor(buf, restrict=True, writable=True)
+
+        @linalg.generic([a, b], [out_t], [par2, par2, par2], [parallel, parallel])
+        def r(x, y, _o):
+            return arith.AddFOp(x, y)
+
+        bufferization.materialize_in_destination(
+            None, r, buf, restrict=True, writable=True
+        )
+        self.kinds.append("ew")
+        if out_buf is not None:
+            return None
+        return emit_buf_to_tensor(buf, restrict=True)
+
+    # ---- RoPE (rotary position embedding), half-split -> (T,D) f32 buffer ----
+    def rope(self, src_buf, cos, sin, T, D, nh):
+        # Rotary embedding on a (T, D=nh*hs) f32 projection buffer, applied per head.
+        # HALF-SPLIT (GPT-NeoX / HF-Llama) convention: within each head's hs coords,
+        # coordinate d in the first half pairs with d+hs/2 in the second half, and
+        #   out[d]        = x[d]*cos[t,d] - x[d+half]*sin[t,d]
+        #   out[d+half]   = x[d+half]*cos[t,d] + x[d]*sin[t,d]
+        # One multi-output row-parallel linalg.generic. The head-dim halves are
+        # CONTIGUOUS sub-blocks (no stride-2 gather, unlike the interleaved
+        # convention). CRUCIAL: the buffers are viewed HEAD-OUTERMOST (nh, T, hs)
+        # (the same strided transpose as heads_view), NOT (T, nh, hs). Under the
+        # (1, wg_rows, 0) tiling each grid block then owns one head's (wg_rows, half)
+        # 2D slab, which lowers to a BLOCK load_nd/store_nd. The (T, nh, hs) layout
+        # instead makes the head a middle vector dim over a big stride, which
+        # convert-vector-to-xegpu turns into a scatter/gather that crashes codegen.
+        # cos/sin are (T, half) f32, indexed (row t, coord d). Its own kind 'rope'
+        # (tiled like the fused-attention head grid, not like a flat 'ew').
+        f32 = self.f32
+        hs = D // nh
+        half = hs // 2
+        out_buf = self._buf((T, D), f32)
+        # view (T,D) buffers as (nh, T, hs) strided (head-outermost transpose view).
+        src3 = self._heads_view_of(src_buf, T, nh, hs)
+        out3 = self._heads_view_of(out_buf, T, nh, hs)
+        # (nh,T,hs) has strides [hs, D, 1]; split the last (hs) dim into two halves.
+        lo = ir.StridedLayoutAttr.get(0, [hs, D, 1])  # first half, offset 0
+        hi = ir.StridedLayoutAttr.get(half, [hs, D, 1])  # second half, offset half
+        t_lo = ir.MemRefType.get((nh, T, half), f32, layout=lo)
+        t_hi = ir.MemRefType.get((nh, T, half), f32, layout=hi)
+        s1 = memref.subview(src3, [0, 0, 0], [nh, T, half], [1, 1, 1], result_type=t_lo)
+        s2 = memref.subview(
+            src3, [0, 0, half], [nh, T, half], [1, 1, 1], result_type=t_hi
+        )
+        o1 = memref.subview(out3, [0, 0, 0], [nh, T, half], [1, 1, 1], result_type=t_lo)
+        o2 = memref.subview(
+            out3, [0, 0, half], [nh, T, half], [1, 1, 1], result_type=t_hi
+        )
+        s1t = emit_buf_to_tensor(s1, restrict=True)
+        s2t = emit_buf_to_tensor(s2, restrict=True)
+        cos_t = emit_buf_to_tensor(cos, restrict=True)
+        sin_t = emit_buf_to_tensor(sin, restrict=True)
+        o1t = emit_buf_to_tensor(o1, restrict=True, writable=True)
+        o2t = emit_buf_to_tensor(o2, restrict=True, writable=True)
+        d0, d1, d2 = (ir.AffineDimExpr.get(i) for i in range(3))
+        idn = affine_map(3, [d0, d1, d2])  # (head, t, coord)
+        csm = affine_map(3, [d1, d2])  # cos/sin indexed by (t, coord)
+
+        @linalg.generic(
+            [s1t, s2t, cos_t, sin_t],
+            [o1t, o2t],
+            [idn, idn, csm, csm, idn, idn],
+            [parallel, parallel, parallel],
+        )
+        def rot(a, b, co, si, _o1, _o2):
+            r1 = arith.SubFOp(arith.MulFOp(a, co).result, arith.MulFOp(b, si).result)
+            r2 = arith.AddFOp(arith.MulFOp(b, co).result, arith.MulFOp(a, si).result)
+            return r1.result, r2.result
+
+        bufferization.materialize_in_destination(
+            None, rot[0], o1, restrict=True, writable=True
+        )
+        bufferization.materialize_in_destination(
+            None, rot[1], o2, restrict=True, writable=True
+        )
+        self.kinds.append("rope")
+        return emit_buf_to_tensor(out_buf, restrict=True)
+
+    # ---- cast f32 (T,C) -> f16 (T,C), returning the MEMREF buffer (for views) ----
+    def cast_f16_buf(self, x, T, C):
+        par2 = self._par()
+        buf = self._buf((T, C), self.f16)
+        out_t = emit_buf_to_tensor(buf, restrict=True, writable=True)
+
+        @linalg.generic([x], [out_t], [par2, par2], [parallel, parallel])
+        def c(s, _o):
+            return arith.TruncFOp(self.f16, s)
+
+        bufferization.materialize_in_destination(
+            None, c, buf, restrict=True, writable=True
+        )
+        self.kinds.append("ew")
+        return buf
+
+    # ---- view a (T, H*hs) memref as (H, T, hs) -- no kernel, no data move ----
+    def _heads_view_of(self, buf2d, T, H, hs):
+        # Present the 2D (T, H*hs) projection buffer as a (H,T,hs) strided view:
+        #   (T,H*hs) --memref.expand_shape--> (T,H,hs) [strides C,hs,1]
+        #            --memref.transpose [1,0,2]--> (H,T,hs) [strides hs,C,1]
+        # Both are pure layout ops (no compute, no kinds entry). When the fused
+        # schedule tiles (1,wg_rows,0,0), the grid peels head h -> a 2D
+        # memref<T x hs, strided<[C,1], offset:h*hs>> -> 2D load_nd (XeGPU supports
+        # such strided block loads).
+        C = H * hs
+        et = buf2d.type.element_type
+        exp_t = ir.MemRefType.get((T, H, hs), et)
+        e = memref.expand_shape(
+            exp_t, buf2d, [[0], [1, 2]], [], static_output_shape=[T, H, hs]
+        )
+        d0, d1, d2 = (ir.AffineDimExpr.get(i) for i in range(3))
+        perm = ir.AffineMap.get(3, 0, [d1, d0, d2])  # (H,T,hs) <- (T,H,hs)
+        layout = ir.StridedLayoutAttr.get(0, [hs, C, 1])
+        res_t = ir.MemRefType.get((H, T, hs), et, layout=layout)
+        return memref.transpose(res_t, e, perm)
+
+    def heads_view(self, buf2d, T, H, hs):
+        return emit_buf_to_tensor(self._heads_view_of(buf2d, T, H, hs), restrict=True)
+
+    # ---- view (T, H*hs) as (n_kv, n_rep, T, hs) -- no kernel, no data move ----
+    def _grouped_heads_view_of(self, buf2d, T, n_kv, n_rep, hs):
+        # For GQA the Q head axis H = n_kv*n_rep is split so query head
+        # h = kv*n_rep + rep. Presenting Q (and the attention output) as a 4D
+        # (n_kv, n_rep, T, hs) view lets the QK^T/@V generics index the narrow
+        # (n_kv, T, hs) K/V by the OUTER kv dim alone -- a projected permutation
+        # (rep/query-row dropped), which vectorizes to a plain vector.contract.
+        # A floordiv map (kv = h // n_rep over a flat H axis) would NOT vectorize.
+        #   (T, H*hs) --expand--> (T, n_kv, n_rep, hs) --transpose [1,2,0,3]-->
+        #   (n_kv, n_rep, T, hs).  Pure layout ops (no compute, no kinds entry).
+        C = n_kv * n_rep * hs
+        et = buf2d.type.element_type
+        exp_t = ir.MemRefType.get((T, n_kv, n_rep, hs), et)
+        e = memref.expand_shape(
+            exp_t, buf2d, [[0], [1, 2, 3]], [], static_output_shape=[T, n_kv, n_rep, hs]
+        )
+        d0, d1, d2, d3 = (ir.AffineDimExpr.get(i) for i in range(4))
+        perm = ir.AffineMap.get(
+            4, 0, [d1, d2, d0, d3]
+        )  # (n_kv,n_rep,T,hs)<-(T,n_kv,n_rep,hs)
+        # (T,n_kv,n_rep,hs) row-major strides are [C, n_rep*hs, hs, 1]; permute them.
+        layout = ir.StridedLayoutAttr.get(0, [n_rep * hs, hs, C, 1])
+        res_t = ir.MemRefType.get((n_kv, n_rep, T, hs), et, layout=layout)
+        return memref.transpose(res_t, e, perm)
+
+    def grouped_heads_view(self, buf2d, T, n_kv, n_rep, hs):
+        return emit_buf_to_tensor(
+            self._grouped_heads_view_of(buf2d, T, n_kv, n_rep, hs), restrict=True
+        )
+
+    # ---- fused grouped-query attention core -----------------------------------
+    # Q / output views are (n_kv, n_rep, T, hs); K / V views are the narrow
+    # (n_kv, T, hs). GQA (grouped-query attention): K/V have n_kv <= H heads, and
+    # query head h = kv*n_rep + rep reads KV head kv. Instead of materializing a
+    # `repeat_kv` copy, QK^T and @V are linalg.generic ops that index the narrow
+    # K/V by the OUTER kv dim ONLY -- a projected permutation (the n_rep and
+    # query-row dims are simply dropped from the K/V map). That vectorizes to a
+    # plain vector.contract, and after tiling (kv,rep) by 1 the per-head inner op
+    # is byte-identical to plain MHA, so the fused-attention rewrite/annotations
+    # are unchanged. (A floordiv map kv = h // n_rep over a flat H axis would NOT
+    # vectorize -- it is not a projected permutation.)
+    def attention_4d(self, Qh, Kh, Vh, n_kv, n_rep, T, hs, out_view, out_view_memref):
+        # linalg op sequence: QK^T generic -> scale-mul -> softmax -> @V generic.
+        # After the per-region fused tiling, these fuse into one scf.forall -> one
+        # GPU kernel (the flash/online-softmax kernel). Counts as one 'fa'.
+        f16 = self.f16
+        scale = 1.0 / (hs**0.5)
+        zero = arith.constant(f16, 0.0)
+
+        # QK^T: qkt[kv,rep,i,j] = sum_k Q[kv,rep,i,k] * K[kv,j,k]  (no explicit K^T;
+        # the generic contracts the head-dim k directly, K read as (kv, seq, head)).
+        # iter dims: (kv d0, rep d1, i d2, j d3, k d4); k is the reduction.
+        d0, d1, d2, d3, d4 = (ir.AffineDimExpr.get(d) for d in range(5))
+        q_map = affine_map(5, [d0, d1, d2, d4])
+        k_map = affine_map(5, [d0, d3, d4])  # drops rep/i -> projected permutation
+        qkt_map = affine_map(5, [d0, d1, d2, d3])
+        qkt_init = linalg.fill(zero, outs=[tensor.empty((n_kv, n_rep, T, T), f16)])
+
+        @linalg.generic(
+            [Qh, Kh],
+            [qkt_init],
+            [q_map, k_map, qkt_map],
+            [parallel, parallel, parallel, parallel, reduction],
+        )
+        def qkt(qv, kv, _o):
+            return arith.AddFOp(arith.MulFOp(qv, kv).result, _o)
+
+        sc = arith.constant(f16, scale)
+        scale_t = linalg.fill(sc, outs=[tensor.empty((n_kv, n_rep, T, T), f16)])
+        scaled = linalg.mul(qkt, scale_t, outs=[tensor.empty((n_kv, n_rep, T, T), f16)])
+        aw = linalg.softmax(
+            result=[ir.RankedTensorType.get((n_kv, n_rep, T, T), f16)],
+            input=scaled,
+            output=tensor.empty((n_kv, n_rep, T, T), f16),
+            dimension=3,  # softmax over the key-seq (last) dim
+        )
+        # @V: out[kv,rep,i,l] = sum_j aw[kv,rep,i,j] * V[kv,j,l]  (l = head_dim out,
+        # j = key-seq reduction). Materialized f16 into the (n_kv,n_rep,T,hs) view.
+        e0, e1, e2, e3, e4 = (ir.AffineDimExpr.get(d) for d in range(5))
+        aw_map = affine_map(5, [e0, e1, e2, e4])
+        v_map = affine_map(5, [e0, e4, e3])  # drops rep/i -> projected permutation
+        out_map = affine_map(5, [e0, e1, e2, e3])
+        out_filled = linalg.fill(zero, outs=[out_view])
+
+        @linalg.generic(
+            [aw, Vh],
+            [out_filled],
+            [aw_map, v_map, out_map],
+            [parallel, parallel, parallel, parallel, reduction],
+        )
+        def out(av, vv, _o):
+            return arith.AddFOp(arith.MulFOp(av, vv).result, _o)
+
+        bufferization.materialize_in_destination(
+            None, out, out_view_memref, restrict=True, writable=True
+        )
+        self.kinds.append("fa")
+
+    # ---- fused grouped-query attention(rms_f32 (T,C) f32) -> (T,C) f16 ----
+    # Emits non-causal linalg; the causal mask (if enabled) is injected later by
+    # the fused-attention transform op in the schedule, not here.
+    def fused_attention(self, x, wq, wk, wv, cos, sin, T, C, H, n_kv):
+        # True grouped-query attention via the flash kernel, no on-device
+        # head-transpose or repeat_kv kernel. Flow:
+        #   x(f32) -cast-> f16 -q proj-> (T,C) f32 -RoPE-> -cast-> f16
+        #                    -grouped_heads_view (free)-> (n_kv,n_rep,T,hs) Q view
+        #                  -k/v proj-> (T,kv_dim) f32; k gets RoPE too -cast-> f16
+        #                    -heads_view-> (n_kv,T,hs) K/V
+        #   -> attention_4d (fused flash kernel, K/V shared across the n_rep group)
+        #   -> @V written into a (T,C) f16 buffer via its (n_kv,n_rep,T,hs) view ->
+        #   return (T,C) f16.
+        # RoPE (rotary pos emb) is applied to q and k (NOT v) on the f32 projection
+        # output, before the f16 cast, per head. cos/sin are (T, hs/2) f32 args.
+        hs = C // H
+        n_rep = H // n_kv  # query heads sharing each KV head
+        kv_dim = n_kv * hs  # narrow K/V feature width (GQA: kv_dim <= C)
+        x16 = self.cast_f16(x, T, C)  # ew
+        qp = self._buf((T, C), self.f32)
+        self.matmul(x16, wq, T, C, out_buf=qp)  # mm -> f32 q projection
+        qbuf = self.cast_f16_buf(self.rope(qp, cos, sin, T, C, H), T, C)  # ew(rope), ew
+        kp = self._buf((T, kv_dim), self.f32)
+        self.matmul(x16, wk, T, kv_dim, out_buf=kp)  # mm -> f32 k projection
+        kbuf = self.cast_f16_buf(
+            self.rope(kp, cos, sin, T, kv_dim, n_kv), T, kv_dim
+        )  # ew(rope), ew
+        vbuf = self.cast_f16_buf(self.matmul(x16, wv, T, kv_dim), T, kv_dim)  # mm, ew
+        Qh = self.grouped_heads_view(qbuf, T, n_kv, n_rep, hs)  # (n_kv,n_rep,T,hs)
+        Kh = self.heads_view(kbuf, T, n_kv, hs)  # (n_kv,T,hs) strided view
+        Vh = self.heads_view(vbuf, T, n_kv, hs)
+        out_buf = self._buf((T, C), self.f16)
+        out_view_memref = self._grouped_heads_view_of(out_buf, T, n_kv, n_rep, hs)
+        out_view = emit_buf_to_tensor(out_view_memref, restrict=True, writable=True)
+        self.attention_4d(
+            Qh, Kh, Vh, n_kv, n_rep, T, hs, out_view, out_view_memref
+        )  # fa
+        return emit_buf_to_tensor(out_buf, restrict=True)  # (T,C) f16
+
+
+# ---------------------------------------------------------------------------
+# Payload assembly -- wire the Builder ops into a complete MLIR function.
+# `build_llama_payload` creates one `func.func` (the "payload") whose arguments
+# are the input + all weights (as device memrefs) and whose body is the op graph.
+# Returns (module, kinds) where `kinds` drives the schedule.
+# ---------------------------------------------------------------------------
+
+
+def _emit_block_llama(bld, x, w, cos, sin, T, C, hidden, H, n_kv, eps, out_buf=None):
+    """Emit one Llama transformer block (fused GQA + RoPE, no bias; causal
+    masking, if any, is applied by the schedule's fused-attention transform).
+    `w` weight keys: an (attention RMSNorm weight), wq,wk,wv, wo,
+    fn (ffn RMSNorm weight), w1,w2,w3.  wk/wv are narrow (C, n_kv*hs) for GQA.
+    cos/sin are the shared (T, hs/2) RoPE tables.
+        h   = x + wo( GQA( RoPE(rms_attn(x)) ) )  # attention sublayer + residual
+        out = h + swiglu( rms_ffn(h) )            # FFN sublayer + residual
+    SwiGLU: w2( silu(z@w1) * (z@w3) ).
+    """
+    # ---- attention sublayer: h = x + wo(GQA(RoPE(rms(x)))) ----
+    rms1 = bld.rmsnorm(x, w["an"], T, C, eps)
+    attn16 = bld.fused_attention(
+        rms1, w["wq"], w["wk"], w["wv"], cos, sin, T, C, H, n_kv
+    )  # f16 (T,C)
+    proj = bld.matmul(attn16, w["wo"], T, C)  # (T,C) f32, no bias
+    h = bld.add(x, proj, T, C)
+    # ---- FFN sublayer: out = h + swiglu(rms(h)) ----
+    rms2 = bld.rmsnorm(h, w["fn"], T, C, eps)
+    z16 = bld.cast_f16(rms2, T, C)
+    gate = bld.matmul(z16, w["w1"], T, hidden)  # z@w1 -> (T,hidden) f32
+    gate = bld.silu(gate, T, hidden)  # silu(z@w1)
+    up = bld.matmul(z16, w["w3"], T, hidden)  # z@w3 -> (T,hidden) f32
+    prod = bld.mul(gate, up, T, hidden)  # silu(z@w1) * (z@w3)
+    prod16 = bld.cast_f16(prod, T, hidden)
+    o = bld.matmul(prod16, w["w2"], T, C)  # (T,C) f32
+    return bld.add(h, o, T, C, out_buf=out_buf)
+
+
+def build_llama_payload(func_name, T, C, hidden, vocab, n_layers, H, n_kv, eps=1e-5):
+    """Full Llama-3 forward as one module, fused grouped-query attention per block
+    (n_kv KV heads, RoPE on q/k, causal masking applied later by the schedule),
+    RMSNorm, SwiGLU FFN, no biases. Embeddings done host-side. Returns
+    (module, kinds, mm_shapes) -- mm_shapes is the (M,N,K) of each matmul in build
+    order, so the schedule can pick per-matmul DPAS params (K/V projections are
+    narrow, N = n_kv*hs < C, and need different tiling than the wide matmuls)."""
+    f32, f16 = F32(), F16()
+    kv_dim = n_kv * (C // H)  # narrow K/V feature width (GQA: kv_dim <= C)
+    half = (C // H) // 2  # RoPE cos/sin table width (head_dim/2)
+    mod = ir.Module.create()
+    x_t = ir.MemRefType.get((T, C), f32)  # input activations f32
+    cs_t = ir.MemRefType.get((T, half), f32)  # RoPE cos/sin tables (T, hs/2) f32
+    n_t = ir.MemRefType.get((C,), f32)  # RMSNorm weight vectors (C,) f32
+    wq_t = ir.MemRefType.get((C, C), f16)  # q projection weight f16
+    wkv_t = ir.MemRefType.get((C, kv_dim), f16)  # narrow k/v projection weights f16
+    wo_t = ir.MemRefType.get((C, C), f16)  # attention output proj weight f16
+    w1_t = ir.MemRefType.get((C, hidden), f16)  # SwiGLU gate/up projections f16
+    w2_t = ir.MemRefType.get((hidden, C), f16)  # SwiGLU down projection f16
+    lmw_t = ir.MemRefType.get((C, vocab), f16)  # output (lm_head) weight f16
+    out_t = ir.MemRefType.get((T, vocab), f32)  # output logits f32
+    # per-layer arg types: an, wq,wk,wv, wo, fn, w1,w2,w3 (9) -- no bias, no mask.
+    per_layer = [n_t, wq_t, wkv_t, wkv_t, wo_t, n_t, w1_t, w2_t, w1_t]
+    fargs = [out_t, x_t, cs_t, cs_t]  # output, input, RoPE cos, RoPE sin
+    for _ in range(n_layers):
+        fargs += per_layer
+    fargs += [n_t, lmw_t]  # final RMSNorm weight, output weight
+    bld = Builder(T)
+    with ir.InsertionPoint(mod.body):
+
+        @func_cif(*fargs, name=func_name)
+        def payload(*args):
+            output = args[0]
+            emit_buf_to_tensor(output, restrict=True, writable=True)
+            x = emit_buf_to_tensor(args[1], restrict=True)
+            cos, sin = args[2], args[3]  # raw memrefs (rope views them itself)
+            idx = 4
+            layer_w = []
+            keys = ["an", "wq", "wk", "wv", "wo", "fn", "w1", "w2", "w3"]
+            for _ in range(n_layers):
+                w = {
+                    k: emit_buf_to_tensor(args[idx + i], restrict=True)
+                    for i, k in enumerate(keys)
+                }
+                idx += len(keys)
+                layer_w.append(w)
+            fn_w = emit_buf_to_tensor(args[idx], restrict=True)
+            idx += 1
+            lmw = emit_buf_to_tensor(args[idx], restrict=True)
+            idx += 1
+
+            h = x
+            for w in layer_w:
+                h = _emit_block_llama(bld, h, w, cos, sin, T, C, hidden, H, n_kv, eps)
+            hf = bld.rmsnorm(h, fn_w, T, C, eps)
+            hf16 = bld.cast_f16(hf, T, C)
+            bld.matmul(hf16, lmw, T, vocab, out_buf=output)
+            for b in bld.to_dealloc:
+                gpu.dealloc(None, [], b)
+
+        emit_gpu_util_funcs(f32, rank=2)
+        emit_gpu_util_funcs(f32, rank=1)
+        emit_gpu_util_funcs(f16, rank=2)
+    return mod, bld.kinds, bld.mm_shapes

--- a/examples/xegpu/llama3_payload.py
+++ b/examples/xegpu/llama3_payload.py
@@ -64,11 +64,12 @@ class Builder:
     `kinds` is the crucial bookkeeping: an ordered list, one entry per op emitted,
     recording its "class" so the schedule (stage 2) can later tile and annotate
     each kernel correctly. Classes:
-      'mm'  = matmul (linalg.matmul)          -> DPAS systolic-array kernel
-      'rms' = RMSNorm (2 generics + 1 fill)   -> reduction kernel (uses shared mem)
-      'fa'  = flash multi-head attention -> one kernel (QK^T->softmax->@V,
-              online-softmax over K/V tiles; causal mask added by the schedule).
-      'ew'  = elementwise (cast / silu / mul / residual) -> row-parallel kernel
+      'matmul'          = matmul (linalg.matmul)         -> DPAS systolic-array kernel
+      'rmsnorm'         = RMSNorm (2 generics + 1 fill)   -> reduction kernel (shared mem)
+      'fused_attention' = flash multi-head attention      -> one kernel (QK^T->softmax->@V,
+                          online-softmax over K/V tiles; causal mask added by the schedule).
+      'rope'            = rotary position embedding       -> head-grid row-parallel kernel
+      'elementwise'     = cast / silu / mul / residual    -> row-parallel kernel
     The op build order in the payload == the order of `kinds` == the order the
     kernels appear in the final module, which is how the schedule matches them up.
     """
@@ -91,10 +92,12 @@ class Builder:
         # access pattern where output[i,j] depends on input[i,j].
         return affine_map(rank, [ir.AffineDimExpr.get(i) for i in range(rank)])
 
-    # ---- matmul: a(M,K) f16 @ b(K,N) f16 -> (M,N) f32 buffer ----
     def matmul(self, a, b, M, N, out_buf=None):
-        # Standard C = A @ B. `times_weights` emits linalg.matmul; we first fill the
-        # accumulator with 0. f16 inputs, f32 output -- matches the DPAS hardware.
+        """Matmul C = A @ B: a(M,K) f16 @ b(K,N) f16 -> (M,N) f32 buffer.
+
+        `times_weights` emits linalg.matmul; we first fill the accumulator with 0.
+        f16 inputs, f32 output -- matches the DPAS hardware.
+        """
         buf = out_buf if out_buf is not None else self._buf((M, N), self.f32)
         out_t = emit_buf_to_tensor(buf, restrict=True, writable=True)
         acc = linalg.fill(arith.constant(self.f32, 0.0), outs=[out_t])
@@ -102,23 +105,25 @@ class Builder:
         bufferization.materialize_in_destination(
             None, res, buf, restrict=True, writable=True
         )
-        self.kinds.append("mm")
+        self.kinds.append("matmul")
         K = a.type.shape[-1]
         self.mm_shapes.append((M, N, K))
         if out_buf is not None:  # caller gave the final output buffer
             return None
         return emit_buf_to_tensor(buf, restrict=True)
 
-    # ---- RMSNorm(x (M,N) f32, weight (N,)) -> (M,N) f32 buffer ----
     def rmsnorm(self, x, weight, M, N, eps=1e-5):
-        # RMSNorm: out[i,j] = x[i,j] * rsqrt(mean_k x[i,k]^2 + eps) * weight[j].
-        # No mean-subtraction (unlike LayerNorm). Built from 2 linalg.generic ops:
-        #   (1) ss[i]     = sum_k x[i,k]^2                  (row reduction)
-        #   (2) out[i,j]  = x[i,j] * rsqrt(ss_i/N + eps) * weight[j]
-        # Affine maps:
-        #   par2  (d0,d1)->(d0,d1) : full 2-D elementwise
-        #   red2  (d0,d1)->(d0)    : reduce over j -> one value per row
-        #   bias2 (d0,d1)->(d1)    : weight indexed by column only
+        """RMSNorm(x (M,N) f32, weight (N,)) -> (M,N) f32 buffer.
+
+        out[i,j] = x[i,j] * rsqrt(mean_k x[i,k]^2 + eps) * weight[j]. No
+        mean-subtraction (unlike LayerNorm). Built from 2 linalg.generic ops:
+          (1) ss[i]     = sum_k x[i,k]^2                  (row reduction)
+          (2) out[i,j]  = x[i,j] * rsqrt(ss_i/N + eps) * weight[j]
+        Affine maps:
+          par2  (d0,d1)->(d0,d1) : full 2-D elementwise
+          red2  (d0,d1)->(d0)    : reduce over j -> one value per row
+          bias2 (d0,d1)->(d1)    : weight indexed by column only
+        """
         f32 = self.f32
         par2, red2 = self._par(), affine_map(2, [ir.AffineDimExpr.get(0)])
         bias2 = affine_map(2, [ir.AffineDimExpr.get(1)])
@@ -150,11 +155,11 @@ class Builder:
         bufferization.materialize_in_destination(
             None, normed, buf, restrict=True, writable=True
         )
-        self.kinds.append("rms")
+        self.kinds.append("rmsnorm")
         return emit_buf_to_tensor(buf, restrict=True)
 
-    # ---- elementwise cast f32 -> f16 ----
     def cast_f16(self, x, M, N):
+        """Elementwise cast f32 -> f16 -> (M,N) f16 buffer."""
         par2 = self._par()
         buf = self._buf((M, N), self.f16)
         out_t = emit_buf_to_tensor(buf, restrict=True, writable=True)
@@ -166,11 +171,11 @@ class Builder:
         bufferization.materialize_in_destination(
             None, c, buf, restrict=True, writable=True
         )
-        self.kinds.append("ew")
+        self.kinds.append("elementwise")
         return emit_buf_to_tensor(buf, restrict=True)
 
-    # ---- silu (swish): out = x * sigmoid(x)  (x (M,N) f32) ----
     def silu(self, x, M, N):
+        """SiLU / swish: out = x * sigmoid(x)  (x (M,N) f32) -> (M,N) f32 buffer."""
         par2 = self._par()
         one = arith.constant(self.f32, 1.0)
         buf = self._buf((M, N), self.f32)
@@ -186,11 +191,11 @@ class Builder:
         bufferization.materialize_in_destination(
             None, s, buf, restrict=True, writable=True
         )
-        self.kinds.append("ew")
+        self.kinds.append("elementwise")
         return emit_buf_to_tensor(buf, restrict=True)
 
-    # ---- elementwise multiply: out = a * b  (both (M,N) f32) ----
     def mul(self, a, b, M, N):
+        """Elementwise multiply: out = a * b  (both (M,N) f32) -> (M,N) f32 buffer."""
         par2 = self._par()
         buf = self._buf((M, N), self.f32)
         out_t = emit_buf_to_tensor(buf, restrict=True, writable=True)
@@ -202,11 +207,11 @@ class Builder:
         bufferization.materialize_in_destination(
             None, m, buf, restrict=True, writable=True
         )
-        self.kinds.append("ew")
+        self.kinds.append("elementwise")
         return emit_buf_to_tensor(buf, restrict=True)
 
-    # ---- residual add: out = a + b  (both (M,N) f32) ----
     def add(self, a, b, M, N, out_buf=None):
+        """Residual add: out = a + b  (both (M,N) f32) -> (M,N) f32 buffer."""
         par2 = self._par()
         buf = out_buf if out_buf is not None else self._buf((M, N), self.f32)
         out_t = emit_buf_to_tensor(buf, restrict=True, writable=True)
@@ -218,28 +223,30 @@ class Builder:
         bufferization.materialize_in_destination(
             None, r, buf, restrict=True, writable=True
         )
-        self.kinds.append("ew")
+        self.kinds.append("elementwise")
         if out_buf is not None:
             return None
         return emit_buf_to_tensor(buf, restrict=True)
 
-    # ---- RoPE (rotary position embedding), half-split -> (T,D) f32 buffer ----
     def rope(self, src_buf, cos, sin, T, D, nh):
-        # Rotary embedding on a (T, D=nh*hs) f32 projection buffer, applied per head.
-        # HALF-SPLIT (GPT-NeoX / HF-Llama) convention: within each head's hs coords,
-        # coordinate d in the first half pairs with d+hs/2 in the second half, and
-        #   out[d]        = x[d]*cos[t,d] - x[d+half]*sin[t,d]
-        #   out[d+half]   = x[d+half]*cos[t,d] + x[d]*sin[t,d]
-        # One multi-output row-parallel linalg.generic. The head-dim halves are
-        # CONTIGUOUS sub-blocks (no stride-2 gather, unlike the interleaved
-        # convention). CRUCIAL: the buffers are viewed HEAD-OUTERMOST (nh, T, hs)
-        # (the same strided transpose as heads_view), NOT (T, nh, hs). Under the
-        # (1, wg_rows, 0) tiling each grid block then owns one head's (wg_rows, half)
-        # 2D slab, which lowers to a BLOCK load_nd/store_nd. The (T, nh, hs) layout
-        # instead makes the head a middle vector dim over a big stride, which
-        # convert-vector-to-xegpu turns into a scatter/gather that crashes codegen.
-        # cos/sin are (T, half) f32, indexed (row t, coord d). Its own kind 'rope'
-        # (tiled like the fused-attention head grid, not like a flat 'ew').
+        """RoPE (rotary position embedding), half-split -> (T,D) f32 buffer.
+
+        Rotary embedding on a (T, D=nh*hs) f32 projection buffer, applied per head.
+        HALF-SPLIT (GPT-NeoX / HF-Llama) convention: within each head's hs coords,
+        coordinate d in the first half pairs with d+hs/2 in the second half, and
+          out[d]        = x[d]*cos[t,d] - x[d+half]*sin[t,d]
+          out[d+half]   = x[d+half]*cos[t,d] + x[d]*sin[t,d]
+        One multi-output row-parallel linalg.generic. The head-dim halves are
+        CONTIGUOUS sub-blocks (no stride-2 gather, unlike the interleaved
+        convention). CRUCIAL: the buffers are viewed HEAD-OUTERMOST (nh, T, hs)
+        (the same strided transpose as heads_view), NOT (T, nh, hs). Under the
+        (1, wg_rows, 0) tiling each grid block then owns one head's (wg_rows, half)
+        2D slab, which lowers to a BLOCK load_nd/store_nd. The (T, nh, hs) layout
+        instead makes the head a middle vector dim over a big stride, which
+        convert-vector-to-xegpu turns into a scatter/gather that crashes codegen.
+        cos/sin are (T, half) f32, indexed (row t, coord d). Its own kind 'rope'
+        (tiled like the fused-attention head grid, not like a flat 'elementwise').
+        """
         f32 = self.f32
         hs = D // nh
         half = hs // 2
@@ -290,8 +297,8 @@ class Builder:
         self.kinds.append("rope")
         return emit_buf_to_tensor(out_buf, restrict=True)
 
-    # ---- cast f32 (T,C) -> f16 (T,C), returning the MEMREF buffer (for views) ----
     def cast_f16_buf(self, x, T, C):
+        """Cast f32 (T,C) -> f16 (T,C), returning the MEMREF buffer (for views)."""
         par2 = self._par()
         buf = self._buf((T, C), self.f16)
         out_t = emit_buf_to_tensor(buf, restrict=True, writable=True)
@@ -303,7 +310,7 @@ class Builder:
         bufferization.materialize_in_destination(
             None, c, buf, restrict=True, writable=True
         )
-        self.kinds.append("ew")
+        self.kinds.append("elementwise")
         return buf
 
     # ---- view a (T, H*hs) memref as (H, T, hs) -- no kernel, no data move ----
@@ -374,7 +381,7 @@ class Builder:
     def attention_4d(self, Qh, Kh, Vh, n_kv, n_rep, T, hs, out_view, out_view_memref):
         # linalg op sequence: QK^T generic -> scale-mul -> softmax -> @V generic.
         # After the per-region fused tiling, these fuse into one scf.forall -> one
-        # GPU kernel (the flash/online-softmax kernel). Counts as one 'fa'.
+        # GPU kernel (the flash/online-softmax kernel). Counts as one 'fused_attention'.
         f16 = self.f16
         scale = 1.0 / (hs**0.5)
         zero = arith.constant(f16, 0.0)
@@ -426,7 +433,7 @@ class Builder:
         bufferization.materialize_in_destination(
             None, out, out_view_memref, restrict=True, writable=True
         )
-        self.kinds.append("fa")
+        self.kinds.append("fused_attention")
 
     # ---- fused grouped-query attention(rms_f32 (T,C) f32) -> (T,C) f16 ----
     # Emits non-causal linalg; the causal mask (if enabled) is injected later by
@@ -446,12 +453,14 @@ class Builder:
         hs = C // H
         n_rep = H // n_kv  # query heads sharing each KV head
         kv_dim = n_kv * hs  # narrow K/V feature width (GQA: kv_dim <= C)
-        x16 = self.cast_f16(x, T, C)  # ew
+        x16 = self.cast_f16(x, T, C)  # elementwise
         qp = self._buf((T, C), self.f32)
-        self.matmul(x16, wq, T, C, out_buf=qp)  # mm -> f32 q projection
-        qbuf = self.cast_f16_buf(self.rope(qp, cos, sin, T, C, H), T, C)  # ew(rope), ew
+        self.matmul(x16, wq, T, C, out_buf=qp)  # matmul -> f32 q projection
+        qbuf = self.cast_f16_buf(
+            self.rope(qp, cos, sin, T, C, H), T, C
+        )  # rope, elementwise
         kp = self._buf((T, kv_dim), self.f32)
-        self.matmul(x16, wk, T, kv_dim, out_buf=kp)  # mm -> f32 k projection
+        self.matmul(x16, wk, T, kv_dim, out_buf=kp)  # matmul -> f32 k projection
         kbuf = self.cast_f16_buf(
             self.rope(kp, cos, sin, T, kv_dim, n_kv), T, kv_dim
         )  # ew(rope), ew
@@ -479,22 +488,22 @@ class Builder:
 def _emit_block_llama(bld, x, w, cos, sin, T, C, hidden, H, n_kv, eps, out_buf=None):
     """Emit one Llama transformer block (fused GQA + RoPE, no bias; causal
     masking, if any, is applied by the schedule's fused-attention transform).
-    `w` weight keys: an (attention RMSNorm weight), wq,wk,wv, wo,
-    fn (ffn RMSNorm weight), w1,w2,w3.  wk/wv are narrow (C, n_kv*hs) for GQA.
+    `w` weight keys: attn_norm (attention RMSNorm weight), wq,wk,wv, wo,
+    ffn_norm (ffn RMSNorm weight), w1,w2,w3.  wk/wv are narrow (C, n_kv*hs) for GQA.
     cos/sin are the shared (T, hs/2) RoPE tables.
         h   = x + wo( GQA( RoPE(rms_attn(x)) ) )  # attention sublayer + residual
         out = h + swiglu( rms_ffn(h) )            # FFN sublayer + residual
     SwiGLU: w2( silu(z@w1) * (z@w3) ).
     """
     # ---- attention sublayer: h = x + wo(GQA(RoPE(rms(x)))) ----
-    rms1 = bld.rmsnorm(x, w["an"], T, C, eps)
+    rms1 = bld.rmsnorm(x, w["attn_norm"], T, C, eps)
     attn16 = bld.fused_attention(
         rms1, w["wq"], w["wk"], w["wv"], cos, sin, T, C, H, n_kv
     )  # f16 (T,C)
     proj = bld.matmul(attn16, w["wo"], T, C)  # (T,C) f32, no bias
     h = bld.add(x, proj, T, C)
     # ---- FFN sublayer: out = h + swiglu(rms(h)) ----
-    rms2 = bld.rmsnorm(h, w["fn"], T, C, eps)
+    rms2 = bld.rmsnorm(h, w["ffn_norm"], T, C, eps)
     z16 = bld.cast_f16(rms2, T, C)
     gate = bld.matmul(z16, w["w1"], T, hidden)  # z@w1 -> (T,hidden) f32
     gate = bld.silu(gate, T, hidden)  # silu(z@w1)
@@ -543,7 +552,7 @@ def build_llama_payload(func_name, T, C, hidden, vocab, n_layers, H, n_kv, eps=1
             cos, sin = args[2], args[3]  # raw memrefs (rope views them itself)
             idx = 4
             layer_w = []
-            keys = ["an", "wq", "wk", "wv", "wo", "fn", "w1", "w2", "w3"]
+            keys = ["attn_norm", "wq", "wk", "wv", "wo", "ffn_norm", "w1", "w2", "w3"]
             for _ in range(n_layers):
                 w = {
                     k: emit_buf_to_tensor(args[idx + i], restrict=True)

--- a/examples/xegpu/llama3_schedule.py
+++ b/examples/xegpu/llama3_schedule.py
@@ -1,0 +1,669 @@
+"""Transform-dialect schedule for the GPU Llama-3 forward pass.
+
+Stage 2 -- the schedule ("how to lower it"). A "schedule" here is an MLIR module
+written in the transform dialect: a program of rewrite ops that the transform
+interpreter runs over the payload module (built in `llama3_payload`). It does
+not compute anything; it rewrites the payload from high-level linalg ops down to
+GPU (XeGPU) kernels.
+
+  -> `build_combined_schedule` / `_bundle` (the orchestrator) plus the
+     `_tile_one_matmul` / `_tile_one_rmsnorm` / `_tile_one_fused_attention_region`
+     helpers.
+
+The payload is a mixed module (matmul + RMSNorm + fused-attention + elementwise),
+so this is one combined schedule that handles all op classes:
+
+  (a) Tile each op into its own parallel loop nest (`scf.forall` = the GPU
+      work-group grid). Different op classes tile differently:
+        - matmul   -> `_tile_one_matmul`  (work-group tile + k-loop tile; the
+                       DPAS tile sizes come from `mm_params`)
+        - rmsnorm  -> `_tile_one_rmsnorm` (tile rows, fuse the reduction +
+                       zero-fill into the loop)
+        - fused attn-> `_tile_one_fused_attention_region` (tile @V batch_matmul into
+                       a forall, fuse QK^T/scale/softmax/@V in; flash rewrite later)
+        - elementwise -> a single `structured_tile_using_forall` over rows
+  (b) Shared tail (same for every kernel): vectorize -> bufferize (tensors ->
+      memrefs) -> convert the forall grids to `gpu.launch` -> outline each into
+      its own `gpu.module`/`gpu.func` kernel -> attach the XeVM target.
+  (c) Annotate each kernel with XeGPU layout attributes (how data maps to
+      sub-groups / DPAS tiles).
+
+`kinds` (from the Builder) tells the schedule the class and order of every kernel,
+so steps (a) and (c) can treat each one correctly.
+"""
+
+from mlir import ir
+from mlir.dialects import transform
+from mlir.dialects.transform import structured, xegpu
+from mlir.dialects.transform import bufferization as transform_bufferization
+from mlir.dialects.transform.vector import (
+    apply_patterns_vector_cast_away_vector_leading_one_dim,
+    apply_patterns_vector_drop_unit_dims_with_shape_cast,
+)
+from mlir.dialects.bufferization import LayoutMapOption
+
+import lighthouse.transform as lh_transform
+from lighthouse.dialects.transform import transform_ext
+from lighthouse.pipeline.helper import (
+    apply_registered_pass,
+    canonicalize,
+    match,
+    match_and_split,
+    PipelineInterrupt,
+)
+from lighthouse.schedule import schedule_boilerplate
+from lighthouse.schedule.xegpu.mlp_schedule import xegpu_wg_annotation_for_mlp_layer
+from lighthouse.schedule.xegpu.lowering_common import convert_to_gpu_launch
+from llama3_payload import F32
+
+
+def _tile_one_matmul(matmul_op, anytype, mm_params):
+    """Tile one matmul for DPAS: a work-group `forall` tile (wg_m x wg_n) with any
+    elementwise consumer fused in, then an inner reduction (k) loop. Tile sizes
+    come from `mm_params` (chosen by xegpu_parameter_selector for the GPU)."""
+    wg_tile = [mm_params["wg_m"], mm_params["wg_n"]]
+    consumers = transform_ext.get_tileable_consumers(matmul_op)
+    leaf = transform_ext.extract_handle(consumers, -1)
+    _, [wg_loop], _ = lh_transform.tile(
+        leaf,
+        tile_sizes=wg_tile,
+        fuse_producers=True,
+        use_forall=True,
+        apply_cleanup=False,
+    )
+    wg_matmul = match(wg_loop, ops={"linalg.matmul"})
+    lh_transform.tile(wg_matmul, tile_sizes=[0, 0, mm_params["k_tile"]])
+
+
+def _tile_one_fused_attention_region(anytype, qkt_bmm, pv_bmm, softmax_op, fa_params):
+    """Tile + fuse one attention region (QK^T -> scale -> softmax -> @V) into a
+    single scf.forall, so it vectorizes/bufferizes into one kernel body that
+    `replace_with_fused_attention` later rewrites into the flash loop.
+
+    Operates on PRE-SPLIT, per-region
+    handles (qkt_bmm, pv_bmm, softmax_op) so it is region-local and works at any
+    multiplicity. All further producers are pulled in via get_producer_of_operand
+    (SSA-walk = inherently scoped to this region)."""
+    prod = transform.get_producer_of_operand
+
+    def fuse(p, c):
+        return structured.structured_fuse_into_containing_op(
+            anytype, anytype, producer_op=p, containing_op=c
+        )[1]
+
+    wg_rows = fa_params["wg_rows"]
+    # 1. Tile the @V op (a linalg.generic for GQA) into a forall grid. The generic
+    #    iterates (kv d0, rep d1, query-row i d2, head_dim l d3, key j d4); tiling
+    #    kv/rep by 1 and i by wg_rows peels one query head's row block, so the inner
+    #    op matches plain MHA (the fused-attention rewrite is unchanged).
+    tiled_pv, forall = structured.structured_tile_using_forall(
+        anytype,
+        anytype,
+        pv_bmm,
+        num_threads=[],
+        tile_sizes=[],
+        static_tile_sizes=(1, 1, wg_rows, 0, 0),
+    )
+    func = transform.get_parent_op(
+        anytype, forall, op_name="func.func", deduplicate=True
+    )
+    # 2. Fuse the @V output init fill (producer of forall operand 0).
+    forall = fuse(prod(anytype, forall, operand_number=0), forall)
+    transform.apply_cse(func)
+    canonicalize(func)
+    # 3. Decompose this region's softmax. linalg.softmax -> 4 generics + 2 fills:
+    #    max = reduce_max(scaled)         [+ -inf fill]
+    #    num = exp(scaled - max)
+    #    den = reduce_sum(num)            [+ 0 fill]
+    #    div = num / den                  (feeds @V)
+    structured.structured_decompose_interface(anytype, softmax_op)
+    transform.apply_cse(func)
+    canonicalize(func)
+    # Grab the whole producer chain up front via SSA walk (region-local; no count
+    # matching). Fusing op X invalidates only X's handle, so collect all, then fuse
+    # each once in consumer->producer topological order.
+    # tiled_pv operand 0 is the aw extract_slice inside the forall; hop through it
+    # to the func-scope softmax `div` that it slices.
+    aw_slice = prod(anytype, tiled_pv, operand_number=0)
+    div = prod(anytype, aw_slice, operand_number=0)  # num / den (softmax out)
+    num = prod(anytype, div, operand_number=0)  # exp generic
+    den = prod(anytype, div, operand_number=1)  # sum-reduce generic
+    den_fill = prod(anytype, den, operand_number=1)  # 0 fill (sum acc)
+    mx = prod(anytype, num, operand_number=1)  # max-reduce generic
+    mx_fill = prod(anytype, mx, operand_number=1)  # -inf fill (max acc)
+    scaled = prod(anytype, num, operand_number=0)  # linalg.mul (qkt*scale)
+    scale_fill = prod(anytype, scaled, operand_number=1)  # scale-constant fill
+    qkt = prod(anytype, scaled, operand_number=0)  # QK^T generic
+    # Q/K are block-arg views (operands 0/1), fused as loads later; operand 2 is
+    # the qkt accumulator fill. No K^T transpose op: the QK^T generic contracts the
+    # head-dim directly, reading K as (seq, head_dim).
+    qkt_fill = prod(anytype, qkt, operand_number=2)  # 0 fill (qkt acc)
+    for p in (
+        div,
+        den,
+        num,
+        mx,
+        scaled,
+        qkt,
+        den_fill,
+        mx_fill,
+        scale_fill,
+        qkt_fill,
+    ):
+        forall = fuse(p, forall)
+    transform.apply_cse(func)
+    canonicalize(func)
+    return func, forall
+
+
+def _fuse_attention_in_region(anytype, forall, fa_params):
+    """After the shared bufferize+vectorize, rewrite one attention region's
+    vector.contract pair (QK^T, @V) into the flash loop via the transform
+    op. Scoped to `forall` so counts are exact at any multiplicity."""
+    contract_ops = match_and_split(forall, ops={"vector.contract"}, nhandles=2)
+    first_contract, second_contract = contract_ops[0], contract_ops[1]
+    q_load = transform.get_producer_of_operand(
+        anytype, first_contract, operand_number=0
+    )
+    k_load = transform.get_producer_of_operand(
+        anytype, first_contract, operand_number=1
+    )
+    v_load = transform.get_producer_of_operand(
+        anytype, second_contract, operand_number=1
+    )
+    mulf_op = match_and_split(forall, ops={"arith.mulf"}, nhandles=1)[0]
+    scale = transform.get_producer_of_operand(anytype, mulf_op, operand_number=1)
+    # `causal` (default False) makes the flash op mask future keys per Q row.
+    transform_ext.replace_with_fused_attention(
+        q_load=q_load,
+        k_load=k_load,
+        v_load=v_load,
+        scale=scale,
+        output=second_contract,
+        tile_size=fa_params["inner_loop_tile_size"],
+        causal=fa_params.get("causal", False),
+    )
+
+
+def xegpu_fa_annotation(gf, anytype, fa_params):
+    """Attach XeGPU layouts to one fused-attention gpu.func."""
+    num_subgroups = fa_params["wg_rows"] // fa_params["sg_rows"]
+    n_head = fa_params["n_head"]
+    q_sg_layout = [num_subgroups, 1]
+    q_sg_data = [16, n_head]
+    q_inst_data = [8, 16]
+    k_sg_layout = [num_subgroups, 1]
+    k_sg_data = [16, n_head]
+    k_inst_data = [16, 16]
+    v_sg_layout, v_sg_data, v_inst_data = k_sg_layout, k_sg_data, k_inst_data
+    kt_sg_layout = [1, num_subgroups]
+    kt_sg_data = [n_head, 16]
+    kt_inst_data = [16, 16]
+    kt_order = [0, 1]
+    out_sg_layout, out_sg_data, out_inst_data = q_sg_layout, q_sg_data, q_inst_data
+    l128_sg_layout = [num_subgroups, 1]
+    l128_sg_data = [16, 16]
+    l128_inst_data = [8, 16]
+    qk_sg_layout, qk_sg_data, qk_inst_data = (
+        l128_sg_layout,
+        l128_sg_data,
+        l128_inst_data,
+    )
+
+    store_nd_op = match_and_split(gf, ops={"xegpu.store_nd"}, nhandles=1)[0]
+    xegpu.set_anchor_layout(
+        store_nd_op,
+        sg_layout=out_sg_layout,
+        sg_data=out_sg_data,
+        inst_data=out_inst_data,
+    )
+    load_nd_ops = match_and_split(gf, ops={"xegpu.load_nd"}, nhandles=9)
+    xegpu.set_anchor_layout(
+        load_nd_ops[0], sg_layout=q_sg_layout, sg_data=q_sg_data, inst_data=q_inst_data
+    )
+    for i in range(1, 5):
+        xegpu.set_anchor_layout(
+            load_nd_ops[i],
+            sg_layout=k_sg_layout,
+            sg_data=k_sg_data,
+            inst_data=k_inst_data,
+        )
+    for i in range(5, 9):
+        xegpu.set_anchor_layout(
+            load_nd_ops[i],
+            sg_layout=v_sg_layout,
+            sg_data=v_sg_data,
+            inst_data=v_inst_data,
+        )
+    dpas_ops = match_and_split(gf, ops={"xegpu.dpas"}, nhandles=8)
+    for i in range(4):
+        d = dpas_ops[i]
+        xegpu.set_anchor_layout(
+            d, sg_layout=q_sg_layout, sg_data=q_sg_data, inst_data=q_inst_data, index=0
+        )
+        xegpu.set_anchor_layout(
+            d,
+            sg_layout=kt_sg_layout,
+            sg_data=kt_sg_data,
+            inst_data=kt_inst_data,
+            order=kt_order,
+            index=1,
+        )
+        xegpu.set_anchor_layout(
+            d,
+            sg_layout=l128_sg_layout,
+            sg_data=l128_sg_data,
+            inst_data=l128_inst_data,
+            index=2,
+        )
+    for i in range(4, 8):
+        d = dpas_ops[i]
+        xegpu.set_anchor_layout(
+            d,
+            sg_layout=qk_sg_layout,
+            sg_data=qk_sg_data,
+            inst_data=qk_inst_data,
+            index=0,
+        )
+        xegpu.set_anchor_layout(
+            d, sg_layout=v_sg_layout, sg_data=v_sg_data, inst_data=v_inst_data, index=1
+        )
+        xegpu.set_anchor_layout(
+            d,
+            sg_layout=out_sg_layout,
+            sg_data=out_sg_data,
+            inst_data=out_inst_data,
+            index=2,
+        )
+
+
+def build_combined_schedule(
+    mm_params, ln_params, kinds, stop_at_stage="", fa_params=None, mm_params_list=None
+):
+    """Build the transform-dialect schedule module for a payload with op classes
+    `kinds`. Counts how many of each class there are, then delegates to `_bundle`
+    (wrapped in transform boilerplate). `stop_at_stage` lets callers halt early
+    for debugging (--dump <stage>).
+
+    `mm_params_list` (optional) gives per-matmul DPAS params in build order (one
+    dict per 'mm' in `kinds`); when omitted every matmul reuses `mm_params`. The
+    narrow K/V projections need their own wg_n/sg_n, so the driver passes a list."""
+    n_mm = kinds.count("mm")
+    n_rms = kinds.count("rms")
+    n_sm = kinds.count("sm")
+    n_ew = kinds.count("ew")
+    if mm_params_list is None:
+        mm_params_list = [mm_params] * n_mm
+    with schedule_boilerplate() as (schedule, named_seq):
+        anytype = transform.AnyOpType.get()
+        func0 = match(named_seq.bodyTarget, ops={"func.func"})
+        mod = transform.get_parent_op(
+            anytype, func0, op_name="builtin.module", deduplicate=True
+        )
+        try:
+            _bundle(
+                mod,
+                mm_params,
+                ln_params,
+                kinds,
+                n_mm,
+                n_rms,
+                n_sm,
+                n_ew,
+                stop_at_stage,
+                fa_params=fa_params,
+                mm_params_list=mm_params_list,
+            )
+        except PipelineInterrupt:
+            pass
+        finally:
+            transform.yield_()
+    return schedule
+
+
+def _bundle(
+    mod,
+    mm_params,
+    ln_params,
+    kinds,
+    n_mm,
+    n_rms,
+    n_sm,
+    n_ew,
+    stop_at_stage="",
+    fa_params=None,
+    mm_params_list=None,
+):
+    """The pass orchestrator -- emits the actual sequence of transform ops.
+
+    Runs in 3 phases over the whole payload module:
+      tile   -- tile every op into a GPU work-group `forall` (per op class)
+      shared tail -- vectorize, bufferize, forall->gpu.launch, outline kernels,
+                     attach the XeVM target, lower vector ops to XeGPU
+      annotate -- attach XeGPU sub-group/DPAS layout to each kernel
+    `stop_at_stage` raises PipelineInterrupt to halt after a phase (for --dump)."""
+    anytype = transform.AnyOpType.get()
+    rss = ln_params["reduction_step_size"]
+    wg_rows = ln_params["wg_rows"]
+    nkernels = len(kinds)
+    n_fa = kinds.count("fa")
+    n_rope = kinds.count("rope")
+    if mm_params_list is None:
+        mm_params_list = [mm_params] * n_mm
+
+    if stop_at_stage == "initial":
+        raise PipelineInterrupt()
+
+    # ===== Tile each op-class into its own forall =====
+    # match(linalg.generic) is not scoped: once an op is tiled into a forall, its
+    # generic is still matched (just nested), so the remaining bare generics can't
+    # be re-matched by count. Split all generic handles once up front (their build
+    # order is deterministic), then tile each using its preserved handle. A handle
+    # to op X stays valid across tiling of other ops. Tile the simple ew generics
+    # first (no fusion/cleanup, so rms handles survive), then the rmsnorms (which
+    # fuse + cleanup).
+    #
+    # Generic build order: each rmsnorm contributes [ss_sum, normed] (2), each
+    # elementwise contributes 1, each RoPE contributes 1 (one multi-output generic),
+    # and each fused-attention contributes [QK^T, @V] (2) -- the GQA QK^T and @V
+    # contractions are linalg.generic ops (not batch_matmul) indexing the narrow
+    # K/V by the outer kv dim, emitted right after the q/k/v cast ews. The slices are
+    # reconstructed from `kinds`. 'fa' softmax generics do not exist yet (fa is
+    # tiled last, softmax still un-decomposed). The fa core's linalg.mul (scale) is a
+    # named op, not a generic, so excluded. (The head reshape is a pure memref view
+    # -- no generic, no kernel; see Builder.heads_view.)
+    ngen_total = 2 * n_rms + n_ew + n_rope + 2 * n_fa
+    gen_handles = transform.split_handle(
+        (anytype,) * ngen_total, match(mod, ops={"linalg.generic"})
+    )
+    # Walk kinds to assign generic handles to ops. 'fa's kinds entry follows its
+    # four q/k/v/x cast ews, so gi has advanced past them and lands on (QK^T, @V).
+    rms_slices, ew_handles, rope_handles, fa_slices = [], [], [], []
+    gi = 0
+    for k in kinds:
+        if k == "rms":
+            rms_slices.append((gen_handles[gi], gen_handles[gi + 1]))
+            gi += 2
+        elif k == "ew":
+            ew_handles.append(gen_handles[gi])
+            gi += 1
+        elif k == "rope":
+            rope_handles.append(gen_handles[gi])
+            gi += 1
+        elif k == "fa":
+            fa_slices.append((gen_handles[gi], gen_handles[gi + 1]))
+            gi += 2
+        # mm contributes no bare linalg.generic here
+
+    # 1) Tile rmsnorms first, using preserved (ss_sum, normed) handles.
+    #    Doing this before ew/matmul tiling keeps the bare linalg.fill pool exactly
+    #    predictable: 1*(untiled rms) + n_mm (matmul accumulator fills). ew tiling
+    #    can introduce its own init fills, so finish rms fill-fusion first.
+    for i, (ss_red, normalize) in enumerate(rms_slices):
+        rms_untiled = n_rms - i
+        _tile_one_rmsnorm(
+            mod,
+            anytype,
+            wg_rows,
+            rss,
+            ss_red,
+            normalize,
+            rms_untiled,
+            n_mm,
+            ln_params["T"],
+        )
+
+    # 2) Tile ew generics into own foralls (handles preserved across rms tiling).
+    for eg in ew_handles:
+        structured.structured_tile_using_forall(
+            anytype,
+            anytype,
+            eg,
+            num_threads=[],
+            tile_sizes=[],
+            static_tile_sizes=(wg_rows,),
+        )
+
+    # 3) Tile RoPE generics. Each iterates (head, T-row, coord) over a head-outer
+    #    (nh,T,hs) view; tile (1, wg_rows, 0) so one grid block owns a single head's
+    #    (wg_rows, half) 2D slab -> block load_nd/store_nd (see Builder.rope).
+    for rg in rope_handles:
+        structured.structured_tile_using_forall(
+            anytype,
+            anytype,
+            rg,
+            num_threads=[],
+            tile_sizes=[],
+            static_tile_sizes=(1, wg_rows, 0),
+        )
+
+    # 4) Matmuls (their EW producers already wrapped in foralls). Each matmul uses
+    #    its own params (narrow K/V projections tile differently from wide matmuls).
+    mms = match_and_split(mod, ops={"linalg.matmul"}, nhandles=n_mm)
+    for mm, mmp in zip(mms, mm_params_list):
+        _tile_one_matmul(mm, anytype, mmp)
+
+    # 5) Fused-attention regions. Done last so the generic pre-split above ran while
+    #    each fa softmax was still one linalg.softmax (its decomposition generics
+    #    don't exist yet, so they can't inflate ngen_total). The QK^T/@V generics
+    #    use their preserved (pre-split) handles; the softmaxes still match by count.
+    #    Tile+fuse each region into one forall (softmax decompose happens in-region).
+    if n_fa:
+        fa_softmaxes = match_and_split(mod, ops={"linalg.softmax"}, nhandles=n_fa)
+        for r, (qkt_gen, pv_gen) in enumerate(fa_slices):
+            _tile_one_fused_attention_region(
+                anytype, qkt_gen, pv_gen, fa_softmaxes[r], fa_params
+            )
+
+    func = match(mod, ops={"func.func"})
+    lh_transform.cleanup(func)
+    if stop_at_stage == "tiled":
+        raise PipelineInterrupt()
+
+    # ===== Shared tail =====
+    func = structured.structured_vectorize_children_and_apply_patterns(
+        anytype, func, fold_type_extensions_into_contract=True
+    )
+    lh_transform.cleanup(func)
+    # Fused-attention regions carry a batch-of-1 dim from the (1,wg_rows,0,0) tiling;
+    # drop leading unit dims so the QK^T/@V vector.contracts become 2D, as the flash
+    # rewrite expects.
+    if n_fa:
+        with ir.InsertionPoint(transform.apply_patterns(func).patterns):
+            apply_patterns_vector_cast_away_vector_leading_one_dim()
+            apply_patterns_vector_drop_unit_dims_with_shape_cast()
+        transform.apply_cse(func)
+        canonicalize(func)
+    if stop_at_stage == "vectorized":
+        raise PipelineInterrupt()
+
+    mod = apply_registered_pass(mod, "eliminate-empty-tensors")
+    mod = transform_bufferization.OneShotBufferizeOp(
+        mod,
+        allow_return_allocs_from_loops=True,
+        bufferize_function_boundaries=True,
+        function_boundary_type_conversion=LayoutMapOption.IdentityLayoutMap,
+    ).result
+    mod = apply_registered_pass(mod, "fold-memref-alias-ops")
+    transform.apply_cse(mod)
+    canonicalize(mod)
+
+    func = match(mod, ops={"func.func"})
+    func = apply_registered_pass(
+        func,
+        "promote-buffers-to-stack",
+        options={
+            "max-alloc-size-in-bytes": "8192",
+            "max-rank-of-allocated-memref": "2",
+        },
+    )
+    if stop_at_stage == "bufferized":
+        raise PipelineInterrupt()
+
+    # ===== Fused-attention rewrite (after bufferize+vectorize, before gpu.launch) =====
+    # Re-find each attention forall by kinds index (forall IR order == kinds order,
+    # the invariant the launch/gpu_mods loops below also rely on) and rewrite its
+    # QK^T/@V vector.contract pair into the flash online-softmax loop. Must run
+    # before forall->gpu.launch so the producer-walks for q/k/v loads stay in-region.
+    if n_fa:
+        all_foralls = match_and_split(mod, ops={"scf.forall"}, nhandles=nkernels)
+        for idx, kind in enumerate(kinds):
+            if kind == "fa":
+                _fuse_attention_in_region(anytype, all_foralls[idx], fa_params)
+        func = match(mod, ops={"func.func"})
+        transform.apply_cse(func)
+        canonicalize(func)
+    if stop_at_stage == "inner-tiled":
+        raise PipelineInterrupt()
+
+    # Shared with the per-op xegpu schedules: forall -> scf.parallel -> gpu.launch.
+    func = convert_to_gpu_launch(mod, "payload", nlayers=nkernels)
+
+    # launch threads per kernel, in IR (build) order = `kinds`.
+    launches = match_and_split(mod, ops={"gpu.launch"}, nhandles=nkernels)
+
+    def mm_thread_count(mmp):
+        return (mmp["wg_m"] // mmp["sg_m"]) * (mmp["wg_n"] // mmp["sg_n"]) * 16
+
+    sm_threads = (ln_params["wg_rows"] // ln_params["sg_rows"]) * ln_params[
+        "subgroup_size"
+    ]
+    fa_threads = (
+        (fa_params["wg_rows"] // fa_params["sg_rows"]) * fa_params["subgroup_size"]
+        if fa_params
+        else 0
+    )
+    mi = 0  # matmul index into mm_params_list (narrow K/V need their own threads)
+    for launch, kind in zip(launches, kinds):
+        if kind == "mm":
+            nt = mm_thread_count(mm_params_list[mi])
+            mi += 1
+        else:
+            nt = {"fa": fa_threads}.get(kind, sm_threads)
+        xegpu.set_gpu_launch_threads(launch, threads=[nt, 1, 1])
+
+    func = apply_registered_pass(func, "lower-affine")
+    canonicalize(func)
+    func = apply_registered_pass(func, "gpu-launch-sink-index-computations")
+    mod = apply_registered_pass(mod, "gpu-kernel-outlining")
+    transform.apply_cse(mod)
+    if stop_at_stage == "gpu-outlining":
+        raise PipelineInterrupt()
+
+    mod = apply_registered_pass(
+        mod, "xevm-attach-target", options={"O": "3", "chip": "pvc"}
+    )
+
+    # per-gpu.module convert-vector-to-xegpu. Only rms needs SLM allocas (its
+    # cross-lane reduction goes through shared local memory -> store_matrix). The
+    # ew kernels (cast/silu/mul/residual) are pure row-parallel: forcing their
+    # allocas to SLM creates store_matrix paths that fail to lower. So SLM-ify rms
+    # only; leave ew (and mm) as store_nd.
+    gpu_mods = match_and_split(mod, ops={"gpu.module"}, nhandles=nkernels)
+    sg_layout = [ln_params["sg_rows"], 1]
+    sg_data = [ln_params["sg_rows"], rss]
+    for gm, kind in zip(gpu_mods, kinds):
+        gf = match(gm, ops={"gpu.func"})
+        if kind == "rms":
+            allocas = match(gf, ops={"memref.alloca"})
+            transform_ext.update_address_space(allocas, address_space=3)
+        gf = apply_registered_pass(gf, "convert-vector-to-xegpu")
+        transform.apply_cse(gf)
+        # Hoist loop invariants out of the kernel loops (e.g. the flash kernel
+        # carries state in iter_args). apply_licm targets a loop op, so match the
+        # kernel's scf.for loops and hoist each; foreach no-ops for loopless
+        # (elementwise) kernels.
+        with lh_transform.foreach(match(gf, ops={"scf.for"})) as k_loop:
+            transform.apply_licm(k_loop)
+            transform.yield_()
+    transform.apply_cse(mod)
+    canonicalize(mod)
+    if stop_at_stage == "xegpu-initial":
+        raise PipelineInterrupt()
+
+    # ===== Per-kernel annotation =====
+    #   mm   -> full mlp wg annotation
+    #   rms  -> store_nd (1) + store_matrix (the SLM reduction stores)
+    #   ew   -> store_nd (1) only (pure row-parallel, no SLM)
+    #   rope -> store_nd (2, the two rotated half-blocks) only, no SLM
+    gpu_mods = match_and_split(mod, ops={"gpu.module"}, nhandles=nkernels)
+    mi = 0  # matmul index into mm_params_list (narrow K/V need their own layout)
+    for gm, kind in zip(gpu_mods, kinds):
+        gf = match(gm, ops={"gpu.func"})
+        if kind == "mm":
+            xegpu_wg_annotation_for_mlp_layer(gf, **mm_params_list[mi])
+            mi += 1
+        elif kind == "fa":
+            xegpu_fa_annotation(gf, anytype, fa_params)
+        else:
+            # rms/ew/rope: anchor-layout their store_nd(s), and (rms) its SLM
+            # store_matrix. Pass the whole match handle to set_anchor_layout (it
+            # accepts a multi-handle) -- avoids guessing exact store counts (rope
+            # has 2 store_nd, one per rotated half).
+            xegpu.set_anchor_layout(
+                match(gf, ops={"xegpu.store_nd"}), sg_layout=sg_layout, sg_data=sg_data
+            )
+            if kind == "rms":
+                xegpu.set_anchor_layout(
+                    match(gf, ops={"xegpu.store_matrix"}),
+                    sg_layout=sg_layout,
+                    sg_data=sg_data,
+                )
+    if stop_at_stage == "xegpu-wg":
+        raise PipelineInterrupt()
+    return mod
+
+
+def _tile_one_rmsnorm(
+    mod, anytype, wg_rows, rss, ss_red, normalize, rms_untiled, n_mm, T_ROWS
+):
+    """Tile one rmsnorm into its own forall, using preserved handles to its 2
+    generics (ss_red = sum-of-squares reduction, normalize). Handles to other ops
+    stay valid.
+
+    The single accumulator fill is selected by result type: rms accumulators are
+    rank-1 tensor<T x f32>; matmul accumulators are rank-2. There are rms_untiled
+    such rank-1 fills (this rms + other untiled rms); this rms's is first in IR
+    order.
+    """
+    _, rms_forall = structured.structured_tile_using_forall(
+        anytype,
+        anytype,
+        normalize,
+        num_threads=[],
+        tile_sizes=[],
+        static_tile_sizes=(wg_rows,),
+    )
+    _, rms_forall = structured.structured_fuse_into_containing_op(
+        anytype, anytype, producer_op=ss_red, containing_op=rms_forall
+    )
+    rms_func = transform.get_parent_op(
+        anytype, rms_forall, op_name="func.func", deduplicate=True
+    )
+    reduce_t = ir.RankedTensorType.get((T_ROWS,), F32())  # rms accumulator type (T,)
+    fill_match = structured.MatchOp(
+        anytype, rms_func, ops=["linalg.fill"], filter_result_type=reduce_t
+    )
+    fills = transform.split_handle((anytype,) * rms_untiled, fill_match.results[0])
+    if rms_untiled == 1:
+        fills = [fills]  # split_handle returns a bare OpResult when nhandles==1
+    _, rms_forall = structured.structured_fuse_into_containing_op(
+        anytype, anytype, producer_op=fills[0], containing_op=rms_forall
+    )
+    # Fusion leaves the full-size original fill DEAD at func scope (fusion only
+    # slices a copy inside the forall). It must be removed or the next rms finds too
+    # many. canonicalize (DCE) at func scope, but never apply_cse at func scope --
+    # CSE would merge the identical live zero-fills ACROSS rmsnorms. CSE the
+    # duplicate generics inside the forall only (scoped), so the re-match below
+    # finds exactly 2.
+    transform.apply_cse(rms_forall)
+    canonicalize(rms_func)
+    # Re-match the 2 generics INSIDE the forall (scoped, so unambiguous: exactly 2),
+    # then tile the normalize and the sum-of-squares reduction by rss.
+    g2 = match_and_split(rms_forall, ops={"linalg.generic"}, nhandles=2)
+    structured.TileUsingForOp(g2[1], sizes=[0, rss])
+    structured.structured_tile_reduction_using_for(
+        [anytype], anytype, anytype, anytype, target=g2[0], tile_sizes=[0, rss]
+    )
+    transform.apply_cse(rms_forall)
+    canonicalize(rms_forall)

--- a/examples/xegpu/llama3_schedule.py
+++ b/examples/xegpu/llama3_schedule.py
@@ -57,7 +57,7 @@ from lighthouse.schedule.xegpu.lowering_common import convert_to_gpu_launch
 from llama3_payload import F32
 
 
-def _tile_one_matmul(matmul_op, anytype, mm_params):
+def _tile_one_matmul(matmul_op, mm_params):
     """Tile one matmul for DPAS: a work-group `forall` tile (wg_m x wg_n) with any
     elementwise consumer fused in, then an inner reduction (k) loop. Tile sizes
     come from `mm_params` (chosen by xegpu_parameter_selector for the GPU)."""
@@ -75,16 +75,37 @@ def _tile_one_matmul(matmul_op, anytype, mm_params):
     lh_transform.tile(wg_matmul, tile_sizes=[0, 0, mm_params["k_tile"]])
 
 
-def _tile_one_fused_attention_region(anytype, qkt_bmm, pv_bmm, softmax_op, fa_params):
+def _tile_one_fused_attention_region(
+    qkt_bmm: ir.Value,
+    pv_bmm: ir.Value,
+    softmax_op: ir.Value,
+    fa_params: dict,
+) -> tuple[ir.Value, ir.Value]:
     """Tile + fuse one attention region (QK^T -> scale -> softmax -> @V) into a
     single scf.forall, so it vectorizes/bufferizes into one kernel body that
     `replace_with_fused_attention` later rewrites into the flash loop.
 
-    Operates on PRE-SPLIT, per-region
-    handles (qkt_bmm, pv_bmm, softmax_op) so it is region-local and works at any
-    multiplicity. All further producers are pulled in via get_producer_of_operand
-    (SSA-walk = inherently scoped to this region)."""
-    prod = transform.get_producer_of_operand
+    Operates on PRE-SPLIT, per-region handles so it is region-local and works at
+    any multiplicity. All further producers are pulled in via
+    get_producer_of_operand (SSA-walk = inherently scoped to this region).
+
+    Args:
+        qkt_bmm: handle of the QK^T `linalg.generic` op for this region.
+        pv_bmm: handle of the attention-weights @ V `linalg.generic` op.
+        softmax_op: handle of the region's (still un-decomposed) `linalg.softmax`.
+        fa_params: fused-attention params (e.g. `wg_rows`).
+
+    Returns:
+        (func, forall): the enclosing `func.func` handle and the region's tiled
+        `scf.forall` handle.
+    """
+    anytype = transform.AnyOpType.get()
+
+    def get_producer(op, operand_number):
+        """Handle of the op producing `op`'s operand (hides the anytype arg)."""
+        return transform.get_producer_of_operand(
+            anytype, op, operand_number=operand_number
+        )
 
     def fuse(p, c):
         return structured.structured_fuse_into_containing_op(
@@ -108,7 +129,7 @@ def _tile_one_fused_attention_region(anytype, qkt_bmm, pv_bmm, softmax_op, fa_pa
         anytype, forall, op_name="func.func", deduplicate=True
     )
     # 2. Fuse the @V output init fill (producer of forall operand 0).
-    forall = fuse(prod(anytype, forall, operand_number=0), forall)
+    forall = fuse(get_producer(forall, 0), forall)
     transform.apply_cse(func)
     canonicalize(func)
     # 3. Decompose this region's softmax. linalg.softmax -> 4 generics + 2 fills:
@@ -124,20 +145,20 @@ def _tile_one_fused_attention_region(anytype, qkt_bmm, pv_bmm, softmax_op, fa_pa
     # each once in consumer->producer topological order.
     # tiled_pv operand 0 is the aw extract_slice inside the forall; hop through it
     # to the func-scope softmax `div` that it slices.
-    aw_slice = prod(anytype, tiled_pv, operand_number=0)
-    div = prod(anytype, aw_slice, operand_number=0)  # num / den (softmax out)
-    num = prod(anytype, div, operand_number=0)  # exp generic
-    den = prod(anytype, div, operand_number=1)  # sum-reduce generic
-    den_fill = prod(anytype, den, operand_number=1)  # 0 fill (sum acc)
-    mx = prod(anytype, num, operand_number=1)  # max-reduce generic
-    mx_fill = prod(anytype, mx, operand_number=1)  # -inf fill (max acc)
-    scaled = prod(anytype, num, operand_number=0)  # linalg.mul (qkt*scale)
-    scale_fill = prod(anytype, scaled, operand_number=1)  # scale-constant fill
-    qkt = prod(anytype, scaled, operand_number=0)  # QK^T generic
+    aw_slice = get_producer(tiled_pv, 0)
+    div = get_producer(aw_slice, 0)  # num / den (softmax out)
+    num = get_producer(div, 0)  # exp generic
+    den = get_producer(div, 1)  # sum-reduce generic
+    den_fill = get_producer(den, 1)  # 0 fill (sum acc)
+    mx = get_producer(num, 1)  # max-reduce generic
+    mx_fill = get_producer(mx, 1)  # -inf fill (max acc)
+    scaled = get_producer(num, 0)  # linalg.mul (qkt*scale)
+    scale_fill = get_producer(scaled, 1)  # scale-constant fill
+    qkt = get_producer(scaled, 0)  # QK^T generic
     # Q/K are block-arg views (operands 0/1), fused as loads later; operand 2 is
     # the qkt accumulator fill. No K^T transpose op: the QK^T generic contracts the
     # head-dim directly, reading K as (seq, head_dim).
-    qkt_fill = prod(anytype, qkt, operand_number=2)  # 0 fill (qkt acc)
+    qkt_fill = get_producer(qkt, 2)  # 0 fill (qkt acc)
     for p in (
         div,
         den,
@@ -286,12 +307,13 @@ def build_combined_schedule(
     for debugging (--dump <stage>).
 
     `mm_params_list` (optional) gives per-matmul DPAS params in build order (one
-    dict per 'mm' in `kinds`); when omitted every matmul reuses `mm_params`. The
-    narrow K/V projections need their own wg_n/sg_n, so the driver passes a list."""
-    n_mm = kinds.count("mm")
-    n_rms = kinds.count("rms")
-    n_sm = kinds.count("sm")
-    n_ew = kinds.count("ew")
+    dict per 'matmul' in `kinds`); when omitted every matmul reuses `mm_params`.
+    The narrow K/V projections need their own wg_n/sg_n, so the driver passes a
+    list."""
+    n_mm = kinds.count("matmul")
+    n_rms = kinds.count("rmsnorm")
+    n_sm = kinds.count("softmax")
+    n_ew = kinds.count("elementwise")
     if mm_params_list is None:
         mm_params_list = [mm_params] * n_mm
     with schedule_boilerplate() as (schedule, named_seq):
@@ -346,7 +368,7 @@ def _bundle(
     rss = ln_params["reduction_step_size"]
     wg_rows = ln_params["wg_rows"]
     nkernels = len(kinds)
-    n_fa = kinds.count("fa")
+    n_fa = kinds.count("fused_attention")
     n_rope = kinds.count("rope")
     if mm_params_list is None:
         mm_params_list = [mm_params] * n_mm
@@ -359,46 +381,46 @@ def _bundle(
     # generic is still matched (just nested), so the remaining bare generics can't
     # be re-matched by count. Split all generic handles once up front (their build
     # order is deterministic), then tile each using its preserved handle. A handle
-    # to op X stays valid across tiling of other ops. Tile the simple ew generics
-    # first (no fusion/cleanup, so rms handles survive), then the rmsnorms (which
-    # fuse + cleanup).
+    # to op X stays valid across tiling of other ops. Tile the simple elementwise
+    # generics first (no fusion/cleanup, so rmsnorm handles survive), then the
+    # rmsnorms (which fuse + cleanup).
     #
     # Generic build order: each rmsnorm contributes [ss_sum, normed] (2), each
     # elementwise contributes 1, each RoPE contributes 1 (one multi-output generic),
     # and each fused-attention contributes [QK^T, @V] (2) -- the GQA QK^T and @V
     # contractions are linalg.generic ops (not batch_matmul) indexing the narrow
     # K/V by the outer kv dim, emitted right after the q/k/v cast ews. The slices are
-    # reconstructed from `kinds`. 'fa' softmax generics do not exist yet (fa is
-    # tiled last, softmax still un-decomposed). The fa core's linalg.mul (scale) is a
-    # named op, not a generic, so excluded. (The head reshape is a pure memref view
-    # -- no generic, no kernel; see Builder.heads_view.)
+    # reconstructed from `kinds`. 'fused_attention' softmax generics do not exist
+    # yet (it is tiled last, softmax still un-decomposed). The attention core's
+    # linalg.mul (scale) is a named op, not a generic, so excluded. (The head reshape
+    # is a pure memref view -- no generic, no kernel; see Builder.heads_view.)
     ngen_total = 2 * n_rms + n_ew + n_rope + 2 * n_fa
-    gen_handles = transform.split_handle(
-        (anytype,) * ngen_total, match(mod, ops={"linalg.generic"})
-    )
-    # Walk kinds to assign generic handles to ops. 'fa's kinds entry follows its
-    # four q/k/v/x cast ews, so gi has advanced past them and lands on (QK^T, @V).
+    gen_handles = match_and_split(mod, ops={"linalg.generic"}, nhandles=ngen_total)
+    # Walk kinds to assign generic handles to ops. The 'fused_attention' kinds entry
+    # follows its four q/k/v/x cast ews, so gi has advanced past them and lands on
+    # (QK^T, @V).
     rms_slices, ew_handles, rope_handles, fa_slices = [], [], [], []
     gi = 0
     for k in kinds:
-        if k == "rms":
+        if k == "rmsnorm":
             rms_slices.append((gen_handles[gi], gen_handles[gi + 1]))
             gi += 2
-        elif k == "ew":
+        elif k == "elementwise":
             ew_handles.append(gen_handles[gi])
             gi += 1
         elif k == "rope":
             rope_handles.append(gen_handles[gi])
             gi += 1
-        elif k == "fa":
+        elif k == "fused_attention":
             fa_slices.append((gen_handles[gi], gen_handles[gi + 1]))
             gi += 2
-        # mm contributes no bare linalg.generic here
+        # matmul contributes no bare linalg.generic here
 
     # 1) Tile rmsnorms first, using preserved (ss_sum, normed) handles.
-    #    Doing this before ew/matmul tiling keeps the bare linalg.fill pool exactly
-    #    predictable: 1*(untiled rms) + n_mm (matmul accumulator fills). ew tiling
-    #    can introduce its own init fills, so finish rms fill-fusion first.
+    #    Doing this before elementwise/matmul tiling keeps the bare linalg.fill pool
+    #    exactly predictable: 1*(untiled rmsnorm) + n_mm (matmul accumulator fills).
+    #    elementwise tiling can introduce its own init fills, so finish rmsnorm
+    #    fill-fusion first.
     for i, (ss_red, normalize) in enumerate(rms_slices):
         rms_untiled = n_rms - i
         _tile_one_rmsnorm(
@@ -413,7 +435,8 @@ def _bundle(
             ln_params["T"],
         )
 
-    # 2) Tile ew generics into own foralls (handles preserved across rms tiling).
+    # 2) Tile elementwise generics into own foralls (handles preserved across
+    #    rmsnorm tiling).
     for eg in ew_handles:
         structured.structured_tile_using_forall(
             anytype,
@@ -441,10 +464,10 @@ def _bundle(
     #    its own params (narrow K/V projections tile differently from wide matmuls).
     mms = match_and_split(mod, ops={"linalg.matmul"}, nhandles=n_mm)
     for mm, mmp in zip(mms, mm_params_list):
-        _tile_one_matmul(mm, anytype, mmp)
+        _tile_one_matmul(mm, mmp)
 
     # 5) Fused-attention regions. Done last so the generic pre-split above ran while
-    #    each fa softmax was still one linalg.softmax (its decomposition generics
+    #    each fused_attention softmax was still one linalg.softmax (its decomposition generics
     #    don't exist yet, so they can't inflate ngen_total). The QK^T/@V generics
     #    use their preserved (pre-split) handles; the softmaxes still match by count.
     #    Tile+fuse each region into one forall (softmax decompose happens in-region).
@@ -452,7 +475,7 @@ def _bundle(
         fa_softmaxes = match_and_split(mod, ops={"linalg.softmax"}, nhandles=n_fa)
         for r, (qkt_gen, pv_gen) in enumerate(fa_slices):
             _tile_one_fused_attention_region(
-                anytype, qkt_gen, pv_gen, fa_softmaxes[r], fa_params
+                qkt_gen, pv_gen, fa_softmaxes[r], fa_params
             )
 
     func = match(mod, ops={"func.func"})
@@ -508,7 +531,7 @@ def _bundle(
     if n_fa:
         all_foralls = match_and_split(mod, ops={"scf.forall"}, nhandles=nkernels)
         for idx, kind in enumerate(kinds):
-            if kind == "fa":
+            if kind == "fused_attention":
                 _fuse_attention_in_region(anytype, all_foralls[idx], fa_params)
         func = match(mod, ops={"func.func"})
         transform.apply_cse(func)
@@ -535,11 +558,11 @@ def _bundle(
     )
     mi = 0  # matmul index into mm_params_list (narrow K/V need their own threads)
     for launch, kind in zip(launches, kinds):
-        if kind == "mm":
+        if kind == "matmul":
             nt = mm_thread_count(mm_params_list[mi])
             mi += 1
         else:
-            nt = {"fa": fa_threads}.get(kind, sm_threads)
+            nt = {"fused_attention": fa_threads}.get(kind, sm_threads)
         xegpu.set_gpu_launch_threads(launch, threads=[nt, 1, 1])
 
     func = apply_registered_pass(func, "lower-affine")
@@ -554,17 +577,17 @@ def _bundle(
         mod, "xevm-attach-target", options={"O": "3", "chip": "pvc"}
     )
 
-    # per-gpu.module convert-vector-to-xegpu. Only rms needs SLM allocas (its
+    # per-gpu.module convert-vector-to-xegpu. Only rmsnorm needs SLM allocas (its
     # cross-lane reduction goes through shared local memory -> store_matrix). The
-    # ew kernels (cast/silu/mul/residual) are pure row-parallel: forcing their
-    # allocas to SLM creates store_matrix paths that fail to lower. So SLM-ify rms
-    # only; leave ew (and mm) as store_nd.
+    # elementwise kernels (cast/silu/mul/residual) are pure row-parallel: forcing
+    # their allocas to SLM creates store_matrix paths that fail to lower. So SLM-ify
+    # rmsnorm only; leave elementwise (and matmul) as store_nd.
     gpu_mods = match_and_split(mod, ops={"gpu.module"}, nhandles=nkernels)
     sg_layout = [ln_params["sg_rows"], 1]
     sg_data = [ln_params["sg_rows"], rss]
     for gm, kind in zip(gpu_mods, kinds):
         gf = match(gm, ops={"gpu.func"})
-        if kind == "rms":
+        if kind == "rmsnorm":
             allocas = match(gf, ops={"memref.alloca"})
             transform_ext.update_address_space(allocas, address_space=3)
         gf = apply_registered_pass(gf, "convert-vector-to-xegpu")
@@ -582,28 +605,28 @@ def _bundle(
         raise PipelineInterrupt()
 
     # ===== Per-kernel annotation =====
-    #   mm   -> full mlp wg annotation
-    #   rms  -> store_nd (1) + store_matrix (the SLM reduction stores)
-    #   ew   -> store_nd (1) only (pure row-parallel, no SLM)
-    #   rope -> store_nd (2, the two rotated half-blocks) only, no SLM
+    #   matmul      -> full mlp wg annotation
+    #   rmsnorm     -> store_nd (1) + store_matrix (the SLM reduction stores)
+    #   elementwise -> store_nd (1) only (pure row-parallel, no SLM)
+    #   rope        -> store_nd (2, the two rotated half-blocks) only, no SLM
     gpu_mods = match_and_split(mod, ops={"gpu.module"}, nhandles=nkernels)
     mi = 0  # matmul index into mm_params_list (narrow K/V need their own layout)
     for gm, kind in zip(gpu_mods, kinds):
         gf = match(gm, ops={"gpu.func"})
-        if kind == "mm":
+        if kind == "matmul":
             xegpu_wg_annotation_for_mlp_layer(gf, **mm_params_list[mi])
             mi += 1
-        elif kind == "fa":
+        elif kind == "fused_attention":
             xegpu_fa_annotation(gf, anytype, fa_params)
         else:
-            # rms/ew/rope: anchor-layout their store_nd(s), and (rms) its SLM
-            # store_matrix. Pass the whole match handle to set_anchor_layout (it
-            # accepts a multi-handle) -- avoids guessing exact store counts (rope
-            # has 2 store_nd, one per rotated half).
+            # rmsnorm/elementwise/rope: anchor-layout their store_nd(s), and
+            # (rmsnorm) its SLM store_matrix. Pass the whole match handle to
+            # set_anchor_layout (it accepts a multi-handle) -- avoids guessing exact
+            # store counts (rope has 2 store_nd, one per rotated half).
             xegpu.set_anchor_layout(
                 match(gf, ops={"xegpu.store_nd"}), sg_layout=sg_layout, sg_data=sg_data
             )
-            if kind == "rms":
+            if kind == "rmsnorm":
                 xegpu.set_anchor_layout(
                     match(gf, ops={"xegpu.store_matrix"}),
                     sg_layout=sg_layout,
@@ -652,12 +675,11 @@ def _tile_one_rmsnorm(
     )
     # Fusion leaves the full-size original fill DEAD at func scope (fusion only
     # slices a copy inside the forall). It must be removed or the next rms finds too
-    # many. canonicalize (DCE) at func scope, but never apply_cse at func scope --
-    # CSE would merge the identical live zero-fills ACROSS rmsnorms. CSE the
-    # duplicate generics inside the forall only (scoped), so the re-match below
-    # finds exactly 2.
+    # many. Apply plain DCE at func scope -- never apply_cse at func scope, which
+    # would merge the identical live zero-fills ACROSS rmsnorms. CSE the duplicate
+    # generics inside the forall only (scoped), so the re-match below finds exactly 2.
     transform.apply_cse(rms_forall)
-    canonicalize(rms_func)
+    transform.apply_dce(rms_func)
     # Re-match the 2 generics INSIDE the forall (scoped, so unambiguous: exactly 2),
     # then tile the normalize and the sum-of-squares reduction by rss.
     g2 = match_and_split(rms_forall, ops={"linalg.generic"}, nhandles=2)

--- a/lighthouse/dialects/transform/transform_ext/ops/replace_with_fused_attention.py
+++ b/lighthouse/dialects/transform/transform_ext/ops/replace_with_fused_attention.py
@@ -100,6 +100,62 @@ def compute_qkt_chunks(
     return qkt_chunks
 
 
+def apply_causal_mask(
+    qkt_chunks,
+    q_row_offset,
+    loop_idx,
+    k_tile_offsets,
+    wg_rows,
+    k_subtile_size,
+    num_k_tiles,
+    element_type,
+):
+    """Mask future keys in each Q@K^T chunk for causal attention.
+
+    Chunk `tile_idx` entry [r, c] holds score(query row, key col) where the global
+    positions are query_row = q_row_offset + r and key_col = loop_idx +
+    k_tile_offsets[tile_idx] + c. A key is in the future when key_col > query_row;
+    such entries are overwritten with -6e4 (f16-safe "-inf") so their exp() is 0 and
+    they drop out of the online softmax. Returns the masked chunk list.
+
+    q_row_offset is the Q load's row index (the forall query-block offset); the query
+    dim is tiled (wg_rows < seq_len), so masking uses global, not tile-local, rows.
+    """
+    index_type = ir.IndexType.get()
+
+    # Global query rows [wg_rows]: iota + q_row_offset, broadcast to [wg_rows, k_sub]
+    # (broadcast to [k_sub, wg_rows] then transpose, matching the m_ij pattern).
+    row_iota = vector.step(ir.VectorType.get([wg_rows], index_type))
+    row_off = vector.broadcast(ir.VectorType.get([wg_rows], index_type), q_row_offset)
+    row_global = arith.addi(row_iota, row_off)
+    row_bcast = vector.broadcast(
+        ir.VectorType.get([k_subtile_size, wg_rows], index_type), row_global
+    )
+    row_2d = vector.transpose(
+        ir.VectorType.get([wg_rows, k_subtile_size], index_type), row_bcast, [1, 0]
+    )
+
+    neg_inf = emit_vector_constant((wg_rows, k_subtile_size), -6e4, element_type)
+    col_iota = vector.step(ir.VectorType.get([k_subtile_size], index_type))
+
+    masked_chunks = []
+    for tile_idx in range(num_k_tiles):
+        # Global key columns [k_sub] for this tile: loop_idx + tile_offset + iota.
+        k_tile_offset = arith.addi(loop_idx, k_tile_offsets[tile_idx])
+        col_off = vector.broadcast(
+            ir.VectorType.get([k_subtile_size], index_type), k_tile_offset
+        )
+        col_global = arith.addi(col_iota, col_off)
+        col_2d = vector.broadcast(
+            ir.VectorType.get([wg_rows, k_subtile_size], index_type), col_global
+        )
+        # future key when col_global > row_global -> select -6e4, else keep score.
+        is_future = arith.cmpi(arith.CmpIPredicate.sgt, col_2d, row_2d)
+        masked_chunks.append(arith.select(is_future, neg_inf, qkt_chunks[tile_idx]))
+
+    return masked_chunks
+
+
 def compute_qkt_max_scaled(qkt_chunks, num_k_tiles, m_i_init, scale_vector):
     """Reduce Q@K^T chunks to a row-wise scaled max.
 
@@ -298,6 +354,7 @@ class ReplaceWithFusedAttentionOp(
     scale: ext.Operand[transform.AnyOpType]
     output: ext.Operand[transform.AnyOpType]
     tile_size: ir.IntegerAttr
+    causal: ir.IntegerAttr  # 0/1 flag (ext op attrs don't support BoolAttr)
     new_output: ext.Result[transform.AnyOpType[()]] = ext.infer_result()
 
     @classmethod
@@ -374,6 +431,17 @@ class ReplaceWithFusedAttentionOp(
             # Get tile size
             tile_size_value = ir.IntegerAttr(op.tile_size).value
 
+            # Causal masking flag (opt-in; default 0 leaves IR unchanged)
+            causal = bool(ir.IntegerAttr(op.causal).value)
+
+            # Query-row block offset: the Q load's sequence-row index. Indices are
+            # operands[1:-1] (drop the memref and the trailing padding); the row is
+            # the second-to-last index (same convention as the K load in
+            # compute_qkt_chunks), with the head-dim column index last. When the
+            # query dim is tiled this is the forall block offset, so causal masking
+            # can compare global query rows against global key columns.
+            q_row_offset = list(q_load_op.operands[1:-1])[-2]
+
             # Get element type from q_load result
             element_type = q_vector_type.element_type
 
@@ -446,6 +514,21 @@ class ReplaceWithFusedAttentionOp(
                         num_k_tiles,
                         element_type,
                     )
+
+                    # Causal mask: overwrite future-key scores with -6e4 before the
+                    # running max/exp so they vanish from the online softmax. Masking
+                    # the chunks here covers both the max-reduce and the exp below.
+                    if causal:
+                        qkt_chunks = apply_causal_mask(
+                            qkt_chunks,
+                            q_row_offset,
+                            loop_idx,
+                            k_tile_offsets,
+                            wg_rows,
+                            k_subtile_size,
+                            num_k_tiles,
+                            element_type,
+                        )
 
                     # Reduce Q@K^T chunks to row-wise scaled max: [wg_rows]
                     qkt_max_scaled = compute_qkt_max_scaled(
@@ -541,6 +624,7 @@ def replace_with_fused_attention(
     scale: ir.Value,
     output: ir.Value,
     tile_size: int | ir.IntegerAttr,
+    causal: bool | ir.IntegerAttr = False,
 ) -> ir.Value:
     """Replace a given (standard) attention output with an equivalent output
     that is computed in a fused fashion (fused attention optimization).
@@ -552,13 +636,17 @@ def replace_with_fused_attention(
         scale: Handle to scale constant operation (arith.constant)
         output: Handle to output operation to replace (vector.contract)
         tile_size: Tile size for the reduction dimension tiling (K/V sequence length)
+        causal: When True, mask future keys (key_col > query_row) so attention is
+            causal/autoregressive. Default False (non-causal, IR unchanged).
 
     Returns:
         Handle to the new output operation
     """
     if not isinstance(tile_size, ir.IntegerAttr):
         tile_size = ir.IntegerAttr.get(ir.IntegerType.get_signless(64), tile_size)
+    if not isinstance(causal, ir.IntegerAttr):
+        causal = ir.IntegerAttr.get(ir.IntegerType.get_signless(64), int(causal))
 
     return ReplaceWithFusedAttentionOp(
-        q_load, k_load, v_load, scale, output, tile_size=tile_size
+        q_load, k_load, v_load, scale, output, tile_size=tile_size, causal=causal
     ).new_output


### PR DESCRIPTION
This PR adds a Llama-3 model script under examples/xegpu, a full Llama-3-style transformer forward pass (6 layers, C=256, H=4 query heads / n_kv=2 KV heads, head_size=64, hidden=1024, T=256) running end-to-end on the Intel GPU via the XeGPU lowering path.

Assisted by Claude