### PR TITLE
[dialects][transform] Tile'n'Fuse - tile size analysis and query ops

### DIFF
--- a/lighthouse/dialects/transform/transform_ext/ops/assign_tile_sizes.py
+++ b/lighthouse/dialects/transform/transform_ext/ops/assign_tile_sizes.py
@@ -1,0 +1,102 @@
+from mlir import ir
+from mlir.dialects import ext, transform
+from mlir.dialects.transform import DiagnosedSilenceableFailure
+
+from lighthouse.dialects.transform.transform_ext import TransformExtensionDialect
+from lighthouse.dialects.transform.transform_ext.utils import tile_size_analysis as tsa
+
+
+class AssignTileSizesOp(TransformExtensionDialect.Operation, name="assign_tile_sizes"):
+    """
+    Assign target tile sizes to anchor ops as IR attribute annotations.
+
+    Each `target` op is analysed and annotated with an attribute holding one tile size
+    per iteration dimension (in loop order).
+
+    Statically small parallel dimensions are left untiled.
+
+    Targets for which no tile sizes can be computed are skipped (left unannotated).
+    The original `target` handle is returned for chaining.
+
+    Args:
+        target: Handle to anchor op(s).
+        tile_size: Optional size for tiled dimensions (default: 32).
+            Acts as a user hint, e.g. tile by 64 instead of the default 32.
+    Return:
+        Pass-through handle to the (now annotated) target ops.
+    """
+
+    target: ext.Operand[transform.AnyOpType]
+    tile_size: ext.Operand[transform.AnyParamType] | None = None
+    annotated: ext.Result[transform.AnyOpType[()]] = ext.infer_result()
+
+    @classmethod
+    def attach_interface_impls(cls, ctx=None):
+        cls.TransformOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+        cls.MemoryEffectsOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+
+    class TransformOpInterfaceModel(transform.TransformOpInterface):
+        @staticmethod
+        def apply(
+            op: "AssignTileSizesOp",
+            _rewriter: transform.TransformRewriter,
+            results: transform.TransformResults,
+            state: transform.TransformState,
+        ) -> DiagnosedSilenceableFailure:
+            target_ops = state.get_payload_ops(op.target)
+
+            tile_size = tsa.DEFAULT_TILE_SIZE
+            if op.tile_size is not None:
+                tile_attr = state.get_params(op.tile_size)
+                if len(tile_attr) == 1 and isinstance(tile_attr[0], ir.IntegerAttr):
+                    tile_size = tile_attr[0].value
+
+            annotated = []
+            for target_op in target_ops:
+                # Respect existing annotations so earlier (e.g. GEMM-derived)
+                # tile sizes take precedence over later default assignments.
+                if tsa.get_tile_sizes_attr(target_op) is not None:
+                    annotated.append(target_op)
+                    continue
+                sizes = tsa.compute_tile_sizes(target_op, tile_size=tile_size)
+                if sizes is None:
+                    continue
+                tsa.set_tile_sizes_attr(target_op, sizes)
+                annotated.append(target_op)
+
+            results.set_ops(op.annotated, annotated)
+            return DiagnosedSilenceableFailure.Success
+
+        @staticmethod
+        def allow_repeated_handle_operands(_op: "AssignTileSizesOp") -> bool:
+            return False
+
+    class MemoryEffectsOpInterfaceModel(ir.MemoryEffectsOpInterface):
+        @staticmethod
+        def get_effects(op: ir.Operation, effects):
+            transform.only_reads_handle(op.op_operands, effects)
+            transform.produces_handle(op.results, effects)
+            transform.modifies_payload(effects)
+
+
+def assign_tile_sizes(
+    target: ir.Value[transform.AnyOpType],
+    tile_size: int | ir.Value | None = None,
+) -> ir.Value:
+    """
+    snake_case wrapper to create an AssignTileSizesOp.
+
+    Args:
+        target: Handle to anchor op(s).
+        tile_size: Optional size for tiled dimensions (default: 32).
+    Returns:
+        Pass-through handle to the (now annotated) target ops.
+    """
+    if isinstance(tile_size, int):
+        param_attr = ir.IntegerAttr.get(ir.IntegerType.get_signless(64), tile_size)
+        tile_size = transform.ParamConstantOp(transform.AnyParamType.get(), param_attr)
+
+    return AssignTileSizesOp(
+        target=target,
+        tile_size=tile_size,
+    ).annotated

--- a/lighthouse/dialects/transform/transform_ext/ops/get_leading_unit_tile_sizes.py
+++ b/lighthouse/dialects/transform/transform_ext/ops/get_leading_unit_tile_sizes.py
@@ -1,0 +1,77 @@
+from mlir import ir
+from mlir.dialects import ext, transform
+from mlir.dialects.transform import DiagnosedSilenceableFailure
+
+from lighthouse.dialects.transform.transform_ext import TransformExtensionDialect
+from lighthouse.utils.mlir import num_loops
+
+
+class GetLeadingUnitTileSizesOp(
+    TransformExtensionDialect.Operation, name="get_leading_unit_tile_sizes"
+):
+    """
+    Return unit tile sizes for all but the innermost loop of an op.
+
+    For an op with N iteration dims, returns a param of N-1 ones. Tiling by these
+    turns the leading dims into loops and leaves the innermost dim whole, which is
+    a rank-agnostic way to prepare an op for innermost-dimension vectorization.
+
+    Args:
+        target: Handle to a single structured linalg op.
+    Return:
+        Param of N-1 unit tile sizes (empty for a 0/1-dim op).
+    """
+
+    target: ext.Operand[transform.AnyOpType]
+    tile_sizes_param: ext.Result[transform.AnyParamType[()]] = ext.infer_result()
+
+    @classmethod
+    def attach_interface_impls(cls, ctx=None):
+        cls.TransformOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+        cls.MemoryEffectsOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+
+    class TransformOpInterfaceModel(transform.TransformOpInterface):
+        @staticmethod
+        def apply(
+            op: "GetLeadingUnitTileSizesOp",
+            _rewriter: transform.TransformRewriter,
+            results: transform.TransformResults,
+            state: transform.TransformState,
+        ) -> DiagnosedSilenceableFailure:
+            target_ops = state.get_payload_ops(op.target)
+            if len(target_ops) != 1:
+                return DiagnosedSilenceableFailure.SilenceableFailure
+
+            loops = num_loops(target_ops[0])
+            if loops is None:
+                return DiagnosedSilenceableFailure.SilenceableFailure
+
+            i64 = ir.IntegerType.get_signless(64)
+            params = [ir.IntegerAttr.get(i64, 1) for _ in range(max(0, loops - 1))]
+            results.set_params(op.tile_sizes_param, params)
+            return DiagnosedSilenceableFailure.Success
+
+        @staticmethod
+        def allow_repeated_handle_operands(_op: "GetLeadingUnitTileSizesOp") -> bool:
+            return False
+
+    class MemoryEffectsOpInterfaceModel(ir.MemoryEffectsOpInterface):
+        @staticmethod
+        def get_effects(op: ir.Operation, effects):
+            transform.only_reads_handle(op.op_operands, effects)
+            transform.produces_handle(op.results, effects)
+            transform.only_reads_payload(effects)
+
+
+def get_leading_unit_tile_sizes(
+    target: ir.Value[transform.AnyOpType],
+) -> ir.Value:
+    """
+    snake_case wrapper to create a GetLeadingUnitTileSizesOp.
+
+    Args:
+        target: Handle to a single structured linalg op.
+    Returns:
+        Param of N-1 unit tile sizes for an N-dim op.
+    """
+    return GetLeadingUnitTileSizesOp(target=target).tile_sizes_param

--- a/lighthouse/dialects/transform/transform_ext/ops/get_tile_sizes.py
+++ b/lighthouse/dialects/transform/transform_ext/ops/get_tile_sizes.py
@@ -1,0 +1,79 @@
+from mlir import ir
+from mlir.dialects import ext, transform
+from mlir.dialects.transform import DiagnosedSilenceableFailure
+
+from lighthouse.dialects.transform.transform_ext import TransformExtensionDialect
+from lighthouse.dialects.transform.transform_ext.utils import tile_size_analysis as tsa
+
+
+class GetTileSizesOp(TransformExtensionDialect.Operation, name="get_tile_sizes"):
+    """
+    Read the tile sizes annotated on an op as a transform param.
+
+    Reads the annotation of a single op and returns its entries as a param,
+    one integer per iteration dimension (loop order).
+
+    `target` must resolve to a single annotated op.
+
+    Args:
+        target: Handle to a single annotated op.
+    Return:
+        Param holding the op's tile sizes. Empty if the op is not annotated.
+    """
+
+    target: ext.Operand[transform.AnyOpType]
+    tile_sizes_param: ext.Result[transform.AnyParamType[()]] = ext.infer_result()
+
+    @classmethod
+    def attach_interface_impls(cls, ctx=None):
+        cls.TransformOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+        cls.MemoryEffectsOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+
+    @staticmethod
+    def _size_attr(value: int) -> ir.IntegerAttr:
+        return ir.IntegerAttr.get(ir.IntegerType.get_signless(64), value)
+
+    class TransformOpInterfaceModel(transform.TransformOpInterface):
+        @staticmethod
+        def apply(
+            op: "GetTileSizesOp",
+            _rewriter: transform.TransformRewriter,
+            results: transform.TransformResults,
+            state: transform.TransformState,
+        ) -> DiagnosedSilenceableFailure:
+            target_ops = state.get_payload_ops(op.target)
+            if len(target_ops) != 1:
+                return DiagnosedSilenceableFailure.SilenceableFailure
+
+            sizes = tsa.get_tile_sizes_attr(target_ops[0])
+            if sizes is None:
+                sizes = []
+
+            params = [GetTileSizesOp._size_attr(size) for size in sizes]
+            results.set_params(op.tile_sizes_param, params)
+            return DiagnosedSilenceableFailure.Success
+
+        @staticmethod
+        def allow_repeated_handle_operands(_op: "GetTileSizesOp") -> bool:
+            return False
+
+    class MemoryEffectsOpInterfaceModel(ir.MemoryEffectsOpInterface):
+        @staticmethod
+        def get_effects(op: ir.Operation, effects):
+            transform.only_reads_handle(op.op_operands, effects)
+            transform.produces_handle(op.results, effects)
+            transform.only_reads_payload(effects)
+
+
+def get_tile_sizes(
+    target: ir.Value[transform.AnyOpType],
+) -> ir.Value:
+    """
+    snake_case wrapper to create a GetTileSizesOp.
+
+    Args:
+        target: Handle to a single annotated op.
+    Returns:
+        Param holding the op's tile sizes.
+    """
+    return GetTileSizesOp(target=target).tile_sizes_param

--- a/lighthouse/dialects/transform/transform_ext/utils/__init__.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Analysis helpers for the transform_ext dialect extension."""

--- a/lighthouse/dialects/transform/transform_ext/utils/tile_size_analysis.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/tile_size_analysis.py
@@ -31,7 +31,7 @@ def _disable_small_tiles(
     op: ir.OpView,
     out_map: ir.AffineMap,
     sizes: list[int],
-    tile_size: int,
+    tile_size: int = DEFAULT_TILE_SIZE,
 ) -> None:
     """Disable tiling for parallel dims whose static extent is below tile_size.
 

--- a/lighthouse/dialects/transform/transform_ext/utils/tile_size_analysis.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/tile_size_analysis.py
@@ -1,0 +1,129 @@
+from collections.abc import Sequence
+
+from mlir import ir
+from mlir.dialects import linalg
+
+from lighthouse.utils.mlir import opview, indexing_maps, dim_position, linalg_outputs
+
+# Attribute used to annotate payload ops with their target tile sizes
+# (one entry per iteration dimension, in loop order).
+TILE_SIZES_ATTR_NAME = "transform_ext.tile_sizes"
+
+# Default size used for tiled dimensions when no hint is provided.
+DEFAULT_TILE_SIZE = 32
+
+# Number of innermost parallel dimensions tiled with the full tile size.
+# Other parallel dimensions are tiled with unit size to keep them sequential.
+DEFAULT_PARALLEL_TILE_DIMS = 2
+
+
+def _output_tensor_dim_of_iter_dim(out_map: ir.AffineMap) -> dict[int, int]:
+    """Map each iteration dim to the output tensor dim it indexes (if any)."""
+    mapping: dict[int, int] = {}
+    for tensor_dim, expr in enumerate(out_map.results):
+        pos = dim_position(expr)
+        if pos is not None:
+            mapping[pos] = tensor_dim
+    return mapping
+
+
+def _disable_small_tiles(
+    op: ir.OpView,
+    out_map: ir.AffineMap,
+    sizes: list[int],
+    tile_size: int,
+) -> None:
+    """Disable tiling for parallel dims whose static extent is below tile_size.
+
+    Tiling a dimension that is smaller than the tile size only adds loop
+    overhead, so such dimensions are left untiled (size 0).
+    """
+    out_type = ir.ShapedType(linalg_outputs(op)[0].type)
+    iter_to_tensor = _output_tensor_dim_of_iter_dim(out_map)
+    for iter_dim, tensor_dim in iter_to_tensor.items():
+        if sizes[iter_dim] <= 1:
+            # Unit / untiled dimensions are always fine.
+            continue
+        dim = out_type.shape[tensor_dim]
+        if ir.ShapedType.is_static_size(dim) and dim < tile_size:
+            sizes[iter_dim] = 0
+
+
+def compute_tile_sizes(
+    op: ir.Operation | ir.OpView,
+    tile_size: int = DEFAULT_TILE_SIZE,
+    parallel_tile_dims: int = DEFAULT_PARALLEL_TILE_DIMS,
+) -> list[int] | None:
+    """Compute target tile sizes for an op over its iteration space.
+
+    For structured ops, the innermost `parallel_tile_dims` parallel (output) dims
+    are tiled with `tile_size`, any remaining parallel dims (batch / outer M/N)
+    with a unit size, and reduction dims are left untiled. Statically small
+    parallel dims are also left untiled.
+
+    pack / unpack ops are tiled to a single inner tile per iteration: a pack tiles
+    every source dim by 1; an unpack tiles its packed output dims (`inner_dims_pos`)
+    by the inner tile size and the rest by 1.
+
+    Returns one size per iteration dim (loop order), or None if unsupported.
+    """
+    ov = opview(op)
+
+    # pack / unpack have no affine indexing maps; their tiling follows the pack
+    # structure (they are tiled standalone, not fused into a group).
+    if isinstance(ov, linalg.PackOp):
+        return [1] * ir.ShapedType(ov.source.type).rank
+    if isinstance(ov, linalg.UnPackOp):
+        sizes = [1] * ir.ShapedType(ov.result.type).rank
+        inner_dims = ir.DenseI64ArrayAttr(ov.inner_dims_pos)
+        inner_tiles = ir.DenseI64ArrayAttr(ov.static_inner_tiles)
+        for dim, tile in zip(inner_dims, inner_tiles):
+            sizes[dim] = tile
+        return sizes
+
+    maps = indexing_maps(ov)
+    if maps is None:
+        return None
+    # Only single-output ops are supported for now.
+    if len(linalg_outputs(ov)) != 1:
+        return None
+
+    # The output operand's map is the last one (inputs first, then outputs).
+    out_map = maps[-1]
+    sizes = [0] * out_map.n_dims
+
+    # Tile the innermost parallel dims with the full tile size and
+    # any outer parallel dims (batch, outer M/N) with a unit size.
+    parallel_dims = [
+        pos for pos in (dim_position(e) for e in out_map.results) if pos is not None
+    ]
+    if not parallel_dims:
+        return None
+    for d in parallel_dims[:-parallel_tile_dims]:
+        sizes[d] = 1
+    for d in parallel_dims[-parallel_tile_dims:]:
+        sizes[d] = tile_size
+
+    _disable_small_tiles(ov, out_map, sizes, tile_size)
+    return sizes
+
+
+def get_tile_sizes_attr(op: ir.Operation | ir.OpView) -> list[int] | None:
+    """Return the tile sizes annotated on an op, or None if not annotated."""
+    attr = opview(op).operation.attributes
+    if TILE_SIZES_ATTR_NAME not in attr:
+        return None
+    return list(ir.DenseI64ArrayAttr(attr[TILE_SIZES_ATTR_NAME]))
+
+
+def set_tile_sizes_attr(op: ir.Operation | ir.OpView, sizes: Sequence[int]) -> None:
+    """Annotate an op with its target tile sizes."""
+    operation = opview(op).operation
+    operation.attributes[TILE_SIZES_ATTR_NAME] = ir.DenseI64ArrayAttr.get(list(sizes))
+
+
+def clear_tile_sizes_attr(op: ir.Operation | ir.OpView) -> None:
+    """Remove the tile-size annotation from an op, if present."""
+    attrs = opview(op).operation.attributes
+    if TILE_SIZES_ATTR_NAME in attrs:
+        del attrs[TILE_SIZES_ATTR_NAME]

--- a/test/transform/test_tile_size_ops.py
+++ b/test/transform/test_tile_size_ops.py
@@ -1,0 +1,194 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from mlir import ir
+from mlir.dialects import transform
+from mlir.dialects.transform import structured
+
+import lighthouse.dialects as lh_dialects
+from lighthouse import transform as lh_transform
+from lighthouse.dialects.transform.transform_ext.ops.assign_tile_sizes import (
+    assign_tile_sizes,
+)
+from lighthouse.dialects.transform.transform_ext.ops.get_leading_unit_tile_sizes import (
+    get_leading_unit_tile_sizes,
+)
+from lighthouse.dialects.transform.transform_ext.ops.get_tile_sizes import (
+    get_tile_sizes,
+)
+from lighthouse.schedule.builders import schedule_boilerplate
+
+
+def run(name, payload_str, build_schedule):
+    print(f"Test: {name}", flush=True)
+    with ir.Context(), ir.Location.unknown():
+        lh_dialects.register_and_load(reload=True)
+        payload = ir.Module.parse(payload_str)
+        sched = build_schedule()
+        sched.body.operations[0].apply(payload.operation)
+        print(payload)
+
+
+MATMUL_PAYLOAD = """
+module {
+  func.func @main(%a: tensor<128x64xf32>, %b: tensor<64x128xf32>) -> tensor<128x128xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e = tensor.empty() : tensor<128x128xf32>
+    %f = linalg.fill ins(%cst : f32) outs(%e : tensor<128x128xf32>) -> tensor<128x128xf32>
+    %mm = linalg.matmul ins(%a, %b : tensor<128x64xf32>, tensor<64x128xf32>)
+        outs(%f : tensor<128x128xf32>) -> tensor<128x128xf32>
+    return %mm : tensor<128x128xf32>
+  }
+}
+"""
+
+
+ANNOTATED_ELTWISE_PAYLOAD = """
+#id = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%a: tensor<16x32xf32>) -> tensor<16x32xf32> {
+    %e = tensor.empty() : tensor<16x32xf32>
+    %g = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"],
+        transform_ext.tile_sizes = array<i64: 4, 8>}
+        ins(%a : tensor<16x32xf32>)
+        outs(%e : tensor<16x32xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      linalg.yield %i : f32
+    } -> tensor<16x32xf32>
+    return %g : tensor<16x32xf32>
+  }
+}
+"""
+
+
+SMALL_DIM_ELTWISE_PAYLOAD = """
+#id = affine_map<(d0, d1) -> (d0, d1)>
+module {
+    func.func @main(%a: tensor<16x64xf32>) -> tensor<16x64xf32> {
+        %e = tensor.empty() : tensor<16x64xf32>
+        %g = linalg.generic {indexing_maps = [#id, #id],
+                iterator_types = ["parallel", "parallel"]}
+                ins(%a : tensor<16x64xf32>)
+                outs(%e : tensor<16x64xf32>) {
+        ^bb0(%i: f32, %o: f32):
+            linalg.yield %i : f32
+        } -> tensor<16x64xf32>
+        return %g : tensor<16x64xf32>
+    }
+}
+"""
+
+
+ADD_1D_PAYLOAD = """
+module {
+    func.func @main(%a: tensor<128xf32>, %b: tensor<128xf32>) -> tensor<128xf32> {
+        %e = tensor.empty() : tensor<128xf32>
+        %r = linalg.add ins(%a, %b : tensor<128xf32>, tensor<128xf32>)
+                outs(%e : tensor<128xf32>) -> tensor<128xf32>
+        return %r : tensor<128xf32>
+    }
+}
+"""
+
+
+BATCH_MATMUL_PAYLOAD = """
+module {
+    func.func @main(%a: tensor<4x64x64xf32>, %b: tensor<4x64x64xf32>) -> tensor<4x64x64xf32> {
+        %cst = arith.constant 0.0 : f32
+        %e = tensor.empty() : tensor<4x64x64xf32>
+        %f = linalg.fill ins(%cst : f32) outs(%e : tensor<4x64x64xf32>) -> tensor<4x64x64xf32>
+        %mm = linalg.batch_matmul ins(%a, %b : tensor<4x64x64xf32>, tensor<4x64x64xf32>)
+                outs(%f : tensor<4x64x64xf32>) -> tensor<4x64x64xf32>
+        return %mm : tensor<4x64x64xf32>
+    }
+}
+"""
+
+
+def build_assign_schedule(op_name: str):
+    with schedule_boilerplate() as (sched, named_seq):
+        ops = lh_transform.match_op(named_seq.bodyTarget, op_name)
+        assign_tile_sizes(ops)
+        transform.yield_()
+    return sched
+
+
+def build_get_tile_sizes_schedule(op_name: str):
+    with schedule_boilerplate() as (sched, named_seq):
+        generic = lh_transform.match_op(named_seq.bodyTarget, op_name)
+        sizes = get_tile_sizes(generic)
+        structured.TileUsingForallOp(generic, num_threads=[], tile_sizes=sizes)
+        transform.yield_()
+    return sched
+
+
+def build_get_leading_unit_tile_sizes_schedule(op_name: str):
+    with schedule_boilerplate() as (sched, named_seq):
+        matmuls = lh_transform.match_op(named_seq.bodyTarget, op_name)
+        sizes = get_leading_unit_tile_sizes(matmuls)
+        structured.TileUsingForallOp(matmuls, num_threads=[], tile_sizes=sizes)
+        transform.yield_()
+    return sched
+
+
+# CHECK-LABEL: Test: assign_tile_sizes
+# CHECK: linalg.matmul {transform_ext.tile_sizes = array<i64: 32, 32, 0>}
+run(
+    "assign_tile_sizes",
+    MATMUL_PAYLOAD,
+    lambda: build_assign_schedule("linalg.matmul"),
+)
+
+
+# CHECK-LABEL: Test: get_tile_sizes
+# CHECK: scf.forall
+# CHECK-SAME: in (4, 4)
+run(
+    "get_tile_sizes",
+    ANNOTATED_ELTWISE_PAYLOAD,
+    lambda: build_get_tile_sizes_schedule("linalg.generic"),
+)
+
+
+# CHECK-LABEL: Test: get_leading_unit_tile_sizes
+# CHECK: scf.forall
+# CHECK-SAME: in (16)
+run(
+    "get_leading_unit_tile_sizes",
+    SMALL_DIM_ELTWISE_PAYLOAD,
+    lambda: build_get_leading_unit_tile_sizes_schedule("linalg.generic"),
+)
+
+
+# First static dim (16) is below default tile size (32), so _disable_small_tiles
+# must disable tiling there while keeping the larger dim tiled.
+# CHECK-LABEL: Test: disable_small_tiles
+# CHECK: linalg.generic
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 0, 32>
+run(
+    "disable_small_tiles",
+    SMALL_DIM_ELTWISE_PAYLOAD,
+    lambda: build_assign_schedule("linalg.generic"),
+)
+
+
+# 1D op with only 1D operands: compute_tile_sizes should tile its only parallel
+# dim with the default tile size.
+# CHECK-LABEL: Test: compute_tile_sizes_1d_op
+# CHECK: linalg.add {transform_ext.tile_sizes = array<i64: 32>}
+run(
+    "compute_tile_sizes_1d_op",
+    ADD_1D_PAYLOAD,
+    lambda: build_assign_schedule("linalg.add"),
+)
+
+
+# 3D operand op (batch_matmul): compute_tile_sizes should tile batch by 1, M/N by
+# full tile size, and keep K untiled.
+# CHECK-LABEL: Test: compute_tile_sizes_3d_operands
+# CHECK: linalg.batch_matmul {transform_ext.tile_sizes = array<i64: 1, 32, 32, 0>}
+run(
+    "compute_tile_sizes_3d_operands",
+    BATCH_MATMUL_PAYLOAD,
+    lambda: build_assign_schedule("linalg.batch_matmul"),
+)


### PR DESCRIPTION
Adds a set of tools and utility transform ops that provide tile size selection logic which automatically adapts to operations and their operands' dimensions.

The tile size analysis aims at generalizing first-level (cache) tiling that exposes parallelism and improves memory hierarchy usage. Tile sizes are selected based on provided operations and annotated directly in IR for later propagation and consumption.

Additionally, a small utility for unit tiling is added to help further sub-tiling in preparation for vectorization.

Assisted-by: Claude