### PR TITLE
[schedule][transform] Tile'n'Fuse framework

### DIFF
--- a/lighthouse/dialects/transform/transform_ext/__init__.py
+++ b/lighthouse/dialects/transform/transform_ext/__init__.py
@@ -22,10 +22,14 @@ from .ops.filter_reduction_ops import filter_reduction_ops
 from .ops.get_leading_unit_tile_sizes import get_leading_unit_tile_sizes
 from .ops.move_offsets_to_subview import move_offsets_to_subview
 from .ops.fold_singleton_extract_slice import fold_singleton_extract_slice
+from .ops.clear_tile_and_fuse_annotations import clear_tile_and_fuse_annotations
+from .ops.get_fusion_roots import get_fusion_roots
+from .ops.propagate_tile_sizes import propagate_tile_sizes
 
 __all__ = [
     "TransformExtensionDialect",
     "assign_tile_sizes",
+    "clear_tile_and_fuse_annotations",
     "convert_func_results_to_args",
     "extract_handle",
     "filter_by_name",
@@ -33,6 +37,7 @@ __all__ = [
     "filter_num_loops",
     "filter_reduction_ops",
     "fold_singleton_extract_slice",
+    "get_fusion_roots",
     "get_leading_unit_tile_sizes",
     "get_named_attribute",
     "get_named_attribute",
@@ -41,6 +46,7 @@ __all__ = [
     "get_tiling_sizes",
     "move_offsets_to_subview",
     "param_cmp_eq",
+    "propagate_tile_sizes",
     "register_and_load",
     "replace",
     "replace_with_fused_attention",

--- a/lighthouse/dialects/transform/transform_ext/ops/clear_tile_and_fuse_annotations.py
+++ b/lighthouse/dialects/transform/transform_ext/ops/clear_tile_and_fuse_annotations.py
@@ -1,0 +1,86 @@
+from mlir import ir
+from mlir.dialects import ext, transform
+from mlir.dialects.transform import DiagnosedSilenceableFailure
+
+from lighthouse.dialects.transform.transform_ext import TransformExtensionDialect
+from lighthouse.dialects.transform.transform_ext.utils import tile_size_analysis as tsa
+from lighthouse.dialects.transform.transform_ext.utils import fusion_analysis as fa
+
+
+class ClearTileAndFuseAnnotationsOp(
+    TransformExtensionDialect.Operation, name="clear_tile_and_fuse_annotations"
+):
+    """
+    Remove the tile-and-fuse annotations from the target ops and their nested ops.
+
+    Each target op is walked, so passing a container handle (e.g. the `scf.for` loops
+    produced by fusion) clears the annotations of every op inside it.
+
+    Ops without the annotations are left untouched. The original `target` handle
+    is returned for chaining.
+
+    Args:
+        target: Handle to op(s) whose subtree(s) to clear.
+    Return:
+        Pass-through handle to the target ops.
+    """
+
+    target: ext.Operand[transform.AnyOpType]
+    cleared: ext.Result[transform.AnyOpType[()]] = ext.infer_result()
+
+    @classmethod
+    def attach_interface_impls(cls, ctx=None):
+        cls.TransformOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+        cls.MemoryEffectsOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+
+    @staticmethod
+    def _clear(visited: ir.Operation) -> ir.WalkResult:
+        tsa.clear_tile_sizes_attr(visited)
+        fa.clear_fusion_boundary(visited)
+        return ir.WalkResult.ADVANCE
+
+    class TransformOpInterfaceModel(transform.TransformOpInterface):
+        @staticmethod
+        def apply(
+            op: "ClearTileAndFuseAnnotationsOp",
+            _rewriter: transform.TransformRewriter,
+            results: transform.TransformResults,
+            state: transform.TransformState,
+        ) -> DiagnosedSilenceableFailure:
+            target_ops = list(state.get_payload_ops(op.target))
+            for target_op in target_ops:
+                # Walk the whole subtree so a container handle (e.g. a fused
+                # loop) clears the annotations of the ops nested inside it.
+                target_op.walk(
+                    ClearTileAndFuseAnnotationsOp._clear, ir.WalkOrder.PRE_ORDER
+                )
+
+            results.set_ops(op.cleared, target_ops)
+            return DiagnosedSilenceableFailure.Success
+
+        @staticmethod
+        def allow_repeated_handle_operands(
+            _op: "ClearTileAndFuseAnnotationsOp",
+        ) -> bool:
+            return False
+
+    class MemoryEffectsOpInterfaceModel(ir.MemoryEffectsOpInterface):
+        @staticmethod
+        def get_effects(op: ir.Operation, effects):
+            transform.only_reads_handle(op.op_operands, effects)
+            transform.produces_handle(op.results, effects)
+            transform.modifies_payload(effects)
+
+
+def clear_tile_and_fuse_annotations(
+    target: ir.Value[transform.AnyOpType],
+) -> ir.Value:
+    """
+    snake_case wrapper to create a ClearTileAndFuseAnnotationsOp.
+
+    Args:
+        target: Handle to op(s) to clear.
+    Returns:
+        Pass-through handle to the target ops.
+    """
+    return ClearTileAndFuseAnnotationsOp(target=target).cleared

--- a/lighthouse/dialects/transform/transform_ext/ops/get_fusion_roots.py
+++ b/lighthouse/dialects/transform/transform_ext/ops/get_fusion_roots.py
@@ -1,0 +1,169 @@
+from mlir import ir
+from mlir.dialects import ext, transform
+from mlir.dialects.transform import DiagnosedSilenceableFailure
+
+from lighthouse.dialects.transform.transform_ext import TransformExtensionDialect
+from lighthouse.dialects.transform.transform_ext.utils import tile_size_analysis as tsa
+from lighthouse.dialects.transform.transform_ext.utils import fusion_analysis as fa
+from lighthouse.dialects.transform.transform_ext.utils import tile_propagation as tp
+from lighthouse.utils.mlir import op_users
+
+
+class GetFusionRootsOp(TransformExtensionDialect.Operation, name="get_fusion_roots"):
+    """
+    Select the fusion root of each group among tile-size annotated ops.
+
+    A group is a barrier op (e.g. a GEMM / pack) with its elementwise prologue
+    (producers, e.g. a fill) and epilogue (consumers, e.g. a bias-add / relu).
+
+    A consumer only joins the group when it tiles the shared tensor the same way.
+    An op whose annotation conflicts (e.g. 32x32 vs 64x64) or that was marked explicitly
+    as a boundary starts its own group.
+
+    The root is a group's downstream terminal: an annotated op with no same-group
+    non-barrier consumer that is not itself a pure prologue feeding a barrier.
+
+    It is assumed that the caller tiles each root and greedily fuses its producers.
+    Roots are returned in program (top-down) order to help with greedy fusion. That is
+    fusing an upstream group first blocks a downstream one from pulling it back in.
+
+    Args:
+        target: Handle to candidate op(s) (e.g. all linalg ops).
+    Return:
+        Handle to the fusion roots, one per group, in program (top-down) order.
+    """
+
+    target: ext.Operand[transform.AnyOpType]
+    roots: ext.Result[transform.AnyOpType[()]] = ext.infer_result()
+
+    @classmethod
+    def attach_interface_impls(cls, ctx=None):
+        cls.TransformOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+        cls.MemoryEffectsOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+
+    @staticmethod
+    def _same_group_consumer(
+        producer: ir.Operation, shared: ir.Value, consumer: ir.Operation
+    ) -> bool:
+        """Check whether `consumer` shares `producer`'s fusion group across `shared` tensor."""
+        if fa.is_fusion_boundary(consumer):
+            return False
+        return tp.compatible_on_value(
+            producer,
+            tsa.get_tile_sizes_attr(producer),
+            consumer,
+            tsa.get_tile_sizes_attr(consumer),
+            shared,
+        )
+
+    @staticmethod
+    def _is_fusion_root(target_op: ir.Operation) -> bool:
+        annotated_consumers = [
+            (result, user)
+            for result in target_op.opview.results
+            for user in op_users(result)
+            if tsa.get_tile_sizes_attr(user) is not None
+        ]
+        # Still inside its own elementwise chain: a non-barrier consumer that
+        # shares this op's tiling (compatible and not marked as a boundary) is
+        # downstream in the same group, so this op is not the group's root. A
+        # consumer with a conflicting tiling is a different group and is ignored.
+        if any(
+            not fa.is_fusion_barrier(user)
+            and GetFusionRootsOp._same_group_consumer(target_op, result, user)
+            for result, user in annotated_consumers
+        ):
+            return False
+        # A fusion barrier (e.g. a GEMM) with no elementwise epilogue is its own root.
+        if fa.is_fusion_barrier(target_op):
+            return True
+        # An epilogue op (downstream of a barrier) is the group's terminal root.
+        if fa.has_barrier_ancestor(target_op):
+            return True
+        # A pure prologue op feeding a barrier (e.g. a fill) is fused as a
+        # producer of the barrier's root, not on its own.
+        if any(fa.is_fusion_barrier(user) for _, user in annotated_consumers):
+            return False
+        # A terminal op of a barrier-free group (or one that only feeds a
+        # different group across a boundary) is its own root.
+        return True
+
+    @staticmethod
+    def _in_program_order(ops: list[ir.Operation]) -> list[ir.Operation]:
+        """Return `ops` sorted top-down by their position in the payload IR.
+
+        A pre-order walk of the enclosing payload visits ops top-down;
+        only the given `ops` are collected (matched by identity) and the walk stops
+        once all of them have been seen, so other payload ops are ignored.
+
+        NOTE: this is a workaround for `DominanceInfo` not being exposed in the
+        MLIR Python bindings. Dominance information would be sufficient here
+        since a fusable group never spans control flow.
+        """
+        if not ops:
+            return ops
+        remaining = {o.operation.__hash__(): o for o in ops}
+        top = ops[0]
+        while top.parent is not None:
+            top = top.parent
+
+        ordered: list[ir.Operation] = []
+
+        def collect(visited: ir.Operation) -> ir.WalkResult:
+            found = remaining.pop(visited.operation.__hash__(), None)
+            if found is not None:
+                ordered.append(found)
+                if not remaining:
+                    return ir.WalkResult.INTERRUPT
+            return ir.WalkResult.ADVANCE
+
+        top.walk(collect, ir.WalkOrder.PRE_ORDER)
+        return ordered
+
+    class TransformOpInterfaceModel(transform.TransformOpInterface):
+        @staticmethod
+        def apply(
+            op: "GetFusionRootsOp",
+            _rewriter: transform.TransformRewriter,
+            results: transform.TransformResults,
+            state: transform.TransformState,
+        ) -> DiagnosedSilenceableFailure:
+            target_ops = state.get_payload_ops(op.target)
+
+            roots = []
+            for target_op in target_ops:
+                if tsa.get_tile_sizes_attr(target_op) is None:
+                    continue
+                if GetFusionRootsOp._is_fusion_root(target_op):
+                    roots.append(target_op)
+
+            # Order roots to allow easy use of greedy producer fusion.
+            roots = GetFusionRootsOp._in_program_order(roots)
+
+            results.set_ops(op.roots, roots)
+            return DiagnosedSilenceableFailure.Success
+
+        @staticmethod
+        def allow_repeated_handle_operands(_op: "GetFusionRootsOp") -> bool:
+            return False
+
+    class MemoryEffectsOpInterfaceModel(ir.MemoryEffectsOpInterface):
+        @staticmethod
+        def get_effects(op: ir.Operation, effects):
+            transform.only_reads_handle(op.op_operands, effects)
+            transform.produces_handle(op.results, effects)
+            transform.only_reads_payload(effects)
+
+
+def get_fusion_roots(
+    target: ir.Value[transform.AnyOpType],
+) -> ir.Value:
+    """
+    snake_case wrapper to create a GetFusionRootsOp.
+
+    Args:
+        target: Handle to candidate op(s).
+    Returns:
+        Handle to the fusion roots (one per fusable group, in program order).
+    """
+    return GetFusionRootsOp(target=target).roots

--- a/lighthouse/dialects/transform/transform_ext/ops/propagate_tile_sizes.py
+++ b/lighthouse/dialects/transform/transform_ext/ops/propagate_tile_sizes.py
@@ -1,0 +1,155 @@
+from mlir import ir
+from mlir.dialects import ext, transform
+from mlir.dialects.transform import DiagnosedSilenceableFailure
+
+from lighthouse.dialects.transform.transform_ext import TransformExtensionDialect
+from lighthouse.dialects.transform.transform_ext.utils import tile_size_analysis as tsa
+from lighthouse.dialects.transform.transform_ext.utils import tile_propagation as tp
+from lighthouse.dialects.transform.transform_ext.utils import fusion_analysis as fa
+from lighthouse.utils.mlir import op_users, defining_op
+
+
+class PropagateTileSizesOp(
+    TransformExtensionDialect.Operation, name="propagate_tile_sizes"
+):
+    """
+    Propagate tile-size annotations from anchor ops to their neighbors.
+
+    Starting from the annotated `root` ops, tile sizes are spread to surrounding
+    non-barrier ops that share a tensor, translating sizes across each op's indexing
+    maps so a shared tensor is tiled consistently on both sides.
+
+    Two phases, so a barrier's epilogue wins over a downstream barrier's prologue
+    for a shared op:
+
+      1. forward (epilogue): follow consumers from the anchors, stopping at the
+         next barrier. An op between two barriers is tiled to match its producer.
+      2. backward (prologue): follow producers from all annotated ops to claim the
+         remaining prologue ops (e.g. fills, and producers behind epilogue inputs).
+
+    Barriers are never re-tiled. Reduction dimensions are never tiled, and already-annotated
+    ops keep their sizes.
+
+    Args:
+        root: Handle to annotated anchor op(s).
+    Return:
+        Handle to all annotated ops after propagation (roots plus newly annotated).
+    """
+
+    root: ext.Operand[transform.AnyOpType]
+    annotated: ext.Result[transform.AnyOpType[()]] = ext.infer_result()
+
+    @classmethod
+    def attach_interface_impls(cls, ctx=None):
+        cls.TransformOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+        cls.MemoryEffectsOpInterfaceModel.attach(cls.OPERATION_NAME, context=ctx)
+
+    class TransformOpInterfaceModel(transform.TransformOpInterface):
+        @staticmethod
+        def apply(
+            op: "PropagateTileSizesOp",
+            _rewriter: transform.TransformRewriter,
+            results: transform.TransformResults,
+            state: transform.TransformState,
+        ) -> DiagnosedSilenceableFailure:
+            root_ops = list(state.get_payload_ops(op.root))
+
+            # An op is "visited" once it carries an annotation, which prevents
+            # re-processing and acts as a barrier. Track ordered, de-duplicated
+            # annotated ops for the result handle.
+            annotated: list[ir.Operation] = []
+            seen: set = set()
+
+            def remember(target_op: ir.Operation) -> None:
+                key = target_op.operation.__hash__()
+                if key not in seen:
+                    seen.add(key)
+                    annotated.append(target_op)
+
+            def claim(
+                src: ir.Operation, src_sizes, shared: ir.Value, dst: ir.Operation
+            ) -> ir.Operation | None:
+                dst_sizes = tsa.get_tile_sizes_attr(dst)
+                if dst_sizes is not None:
+                    # `dst` already carries a tiling. If it disagrees with `src`
+                    # on how the shared tensor is tiled, they belong to different
+                    # fusion groups; mark the consumer side (the op reading the
+                    # shared tensor) as a boundary so grouping can split them
+                    # cheaply without recomputing compatibility.
+                    if not tp.compatible_on_value(
+                        src, src_sizes, dst, dst_sizes, shared
+                    ):
+                        consumer = src if any(r == shared for r in dst.results) else dst
+                        fa.mark_fusion_boundary(consumer)
+                    return None
+                if not tp.is_propagatable(dst):
+                    return None
+                dst_sizes = tp.propagate_through_value(src, src_sizes, shared, dst)
+                if dst_sizes is None or not any(dst_sizes):
+                    return None
+                tsa.set_tile_sizes_attr(dst, dst_sizes)
+                remember(dst)
+                return dst
+
+            seeds = [r for r in root_ops if tsa.get_tile_sizes_attr(r) is not None]
+            for seed in seeds:
+                remember(seed)
+
+            # Phase 1: forward (epilogue) propagation from the anchors.
+            forward: list[ir.Operation] = list(seeds)
+            idx = 0
+            while idx < len(forward):
+                src = forward[idx]
+                idx += 1
+                src_sizes = tsa.get_tile_sizes_attr(src)
+                for result in src.opview.results:
+                    for user in op_users(result):
+                        dst = claim(src, src_sizes, result, user)
+                        if dst is not None:
+                            forward.append(dst)
+
+            # Phase 2: backward (prologue) propagation from all annotated ops.
+            # Seeding from every annotated op to reach other epilogue producers.
+            # Propagation still stops at barriers, so it never leaks into upstream
+            # groups.
+            backward: list[ir.Operation] = list(annotated)
+            idx = 0
+            while idx < len(backward):
+                src = backward[idx]
+                idx += 1
+                src_sizes = tsa.get_tile_sizes_attr(src)
+                for operand in src.opview.operands:
+                    producer = defining_op(operand)
+                    if producer is None:
+                        continue
+                    dst = claim(src, src_sizes, operand, producer)
+                    if dst is not None:
+                        backward.append(dst)
+
+            results.set_ops(op.annotated, annotated)
+            return DiagnosedSilenceableFailure.Success
+
+        @staticmethod
+        def allow_repeated_handle_operands(_op: "PropagateTileSizesOp") -> bool:
+            return False
+
+    class MemoryEffectsOpInterfaceModel(ir.MemoryEffectsOpInterface):
+        @staticmethod
+        def get_effects(op: ir.Operation, effects):
+            transform.only_reads_handle(op.op_operands, effects)
+            transform.produces_handle(op.results, effects)
+            transform.modifies_payload(effects)
+
+
+def propagate_tile_sizes(
+    root: ir.Value[transform.AnyOpType],
+) -> ir.Value:
+    """
+    snake_case wrapper to create a PropagateTileSizesOp.
+
+    Args:
+        root: Handle to annotated anchor op(s).
+    Returns:
+        Handle to all ops carrying a tile-size annotation after propagation.
+    """
+    return PropagateTileSizesOp(root=root).annotated

--- a/lighthouse/dialects/transform/transform_ext/utils/fusion_analysis.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/fusion_analysis.py
@@ -1,0 +1,69 @@
+from mlir import ir
+from mlir.dialects import linalg
+
+from lighthouse.utils.mlir import opview, defining_op
+from lighthouse.dialects.transform.transform_ext.utils import tile_size_analysis as tsa
+
+# Attribute used to annotate an op as a new fusion separator.
+FUSION_BOUNDARY_ATTR_NAME = "transform_ext.fusion_boundary"
+
+
+def is_fusion_boundary(op: ir.Operation | ir.OpView) -> bool:
+    """Whether the op is marked as a fusion-group boundary (new group start)."""
+    return FUSION_BOUNDARY_ATTR_NAME in opview(op).operation.attributes
+
+
+def mark_fusion_boundary(op: ir.Operation | ir.OpView) -> None:
+    """Mark the op as a fusion-group boundary (the start of a new group)."""
+    opview(op).operation.attributes[FUSION_BOUNDARY_ATTR_NAME] = ir.UnitAttr.get()
+
+
+def clear_fusion_boundary(op: ir.Operation | ir.OpView) -> None:
+    """Remove the fusion-group boundary marker from an op, if present."""
+    attrs = opview(op).operation.attributes
+    if FUSION_BOUNDARY_ATTR_NAME in attrs:
+        del attrs[FUSION_BOUNDARY_ATTR_NAME]
+
+
+def is_fusion_barrier(op: ir.Operation | ir.OpView) -> bool:
+    """Check whether the op acts as a fusion barrier (groups are not fused across it).
+
+    Barriers are:
+      * heavy compute ops: contractions and convolutions / pooling: kept in
+        their own fused loop (with elementwise prologue / epilogue) and used as
+        tiling anchors rather than propagation targets.
+      * pack / unpack ops: layout changes that stay as materialization boundaries.
+    """
+    ov = opview(op)
+    if isinstance(ov, (linalg.PackOp, linalg.UnPackOp)):
+        return True
+    return linalg.isa_contraction_op(ov) or linalg.isa_convolution_op(ov)
+
+
+def has_barrier_ancestor(op: ir.Operation | ir.OpView) -> bool:
+    """Check whether a fusion barrier is reachable backward through annotated producers.
+
+    Used to tell an epilogue op (consumer of a barrier, e.g. a bias/relu after
+    a matmul) apart from a pure prologue op (producer of a barrier, e.g. a fill).
+    Only annotated ops are traversed; the barrier itself is not crossed.
+    """
+    visited: set = set()
+    stack: list = []
+
+    def push_producers(cur: ir.Operation | ir.OpView) -> None:
+        for operand in opview(cur).operands:
+            producer = defining_op(operand)
+            if producer is not None and tsa.get_tile_sizes_attr(producer) is not None:
+                stack.append(producer)
+
+    push_producers(op)
+    while stack:
+        cur = stack.pop()
+        key = cur.operation.__hash__()
+        if key in visited:
+            continue
+        visited.add(key)
+        if is_fusion_barrier(cur):
+            return True
+        push_producers(cur)
+    return False

--- a/lighthouse/dialects/transform/transform_ext/utils/tile_propagation.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/tile_propagation.py
@@ -1,0 +1,140 @@
+from collections.abc import Sequence
+
+from mlir import ir
+
+from lighthouse.utils.mlir import (
+    opview,
+    indexing_maps,
+    dim_position,
+    linalg_inputs,
+    linalg_outputs,
+)
+from lighthouse.dialects.transform.transform_ext.utils import fusion_analysis as fa
+
+
+def is_propagatable(op: ir.Operation | ir.OpView) -> bool:
+    """Check whether tile sizes may be propagated onto this op.
+
+    True for any structured linalg op that is not a fusion barrier; non-linalg
+    ops have no indexing maps to translate tiles through and are excluded.
+    """
+    return indexing_maps(op) is not None and not fa.is_fusion_barrier(op)
+
+
+def _map_for_value(
+    op: ir.OpView, value: ir.Value, maps: Sequence[ir.AffineMap]
+) -> ir.AffineMap | None:
+    """Return the indexing map associated with `value` on `op`."""
+    inputs = linalg_inputs(op)
+    outputs = linalg_outputs(op)
+    if inputs is None or outputs is None:
+        return None
+    for i, operand in enumerate(inputs):
+        if operand == value:
+            return maps[i]
+    for k, operand in enumerate(outputs):
+        if operand == value:
+            return maps[len(inputs) + k]
+    # A result corresponds (positionally) to an output operand of a DPS op.
+    for r, result in enumerate(op.results):
+        if result == value:
+            return maps[len(inputs) + r]
+    return None
+
+
+def tiles_on_value(
+    op: ir.Operation | ir.OpView,
+    sizes: Sequence[int],
+    value: ir.Value,
+) -> list[int] | None:
+    """Per-dimension tiles that `op`, tiled by `sizes`, induces on `value`.
+
+    Returns one entry per dimension of `value` (tensor-dim order); 0 means the
+    dimension is left untiled / not constrained by `op`. Returns None when `op`
+    is not a structured linalg op or does not touch `value`.
+
+    Projecting both a producer's and a consumer's sizes onto the shared tensor
+    this way makes tile comparisons robust to transposition: differently ordered
+    iteration spaces still agree when they tile the shared tensor identically.
+    """
+    ov = opview(op)
+    maps = indexing_maps(ov)
+    if maps is None:
+        return None
+    value_map = _map_for_value(ov, value, maps)
+    if value_map is None:
+        return None
+    tiles = [0] * ir.ShapedType(value.type).rank
+    for tensor_dim, expr in enumerate(value_map.results):
+        pos = dim_position(expr)
+        if pos is not None and pos < len(sizes):
+            tiles[tensor_dim] = sizes[pos]
+    return tiles
+
+
+def compatible_on_value(
+    src_op: ir.Operation | ir.OpView,
+    src_sizes: Sequence[int],
+    dst_op: ir.Operation | ir.OpView,
+    dst_sizes: Sequence[int],
+    shared: ir.Value,
+) -> bool:
+    """Check whether two ops tile a shared tensor compatibly.
+
+    The tiles each op induces on `shared` are compared per tensor dimension. A
+    dimension only conflicts when both ops tile it with *different* non-zero
+    sizes; a zero (untiled / broadcast / unconstrained) side is a wildcard and
+    never conflicts.
+
+    Returns True when the tiles cannot be determined, so grouping errs toward
+    fusion rather than over-splitting.
+    """
+    a = tiles_on_value(src_op, src_sizes, shared)
+    b = tiles_on_value(dst_op, dst_sizes, shared)
+    if a is None or b is None:
+        return True
+    return all(x == y for x, y in zip(a, b) if x != 0 and y != 0)
+
+
+def propagate_through_value(
+    src_op: ir.Operation | ir.OpView,
+    src_sizes: Sequence[int],
+    shared: ir.Value,
+    dst_op: ir.Operation | ir.OpView,
+) -> list[int] | None:
+    """Propagate tile sizes from `src_op` to `dst_op` via a shared tensor.
+
+    The shared tensor's per-dimension tiles are derived from `src_op`'s sizes and
+    mapped onto `dst_op`'s iteration space; reduction dims of `dst_op` stay untiled.
+
+    Returns `dst_op`'s tile sizes (loop order), or None if not possible.
+    """
+    src = opview(src_op)
+    dst = opview(dst_op)
+
+    dst_maps = indexing_maps(dst)
+    if dst_maps is None:
+        return None
+
+    # Tile size per dimension of the shared tensor, as induced by the source.
+    tensor_tiles = tiles_on_value(src, src_sizes, shared)
+    dst_map = _map_for_value(dst, shared, dst_maps)
+    if tensor_tiles is None or dst_map is None:
+        return None
+
+    if len(list(dst.results)) != 1:
+        return None
+    dst_out_map = dst_maps[-1]
+    dst_parallel = {
+        pos for pos in (dim_position(e) for e in dst_out_map.results) if pos is not None
+    }
+
+    dst_sizes = [0] * dst_out_map.n_dims
+    for tensor_dim, expr in enumerate(dst_map.results):
+        pos = dim_position(expr)
+        if pos is None:
+            continue
+        # Only tile parallel dims of the consumer; leave reductions untiled.
+        if pos in dst_parallel:
+            dst_sizes[pos] = tensor_tiles[tensor_dim]
+    return dst_sizes

--- a/lighthouse/schedule/tile_and_fuse.py
+++ b/lighthouse/schedule/tile_and_fuse.py
@@ -21,7 +21,7 @@ import lighthouse.transform as lh_transform
 
 # Op names treated as GEMM anchors. Their tiles take precedence and drive the
 # tiling of surrounding elementwise ops via propagation.
-GEMM_OPS = [
+_GEMM_ANCHOR_OPS = [
     "linalg.matmul",
     "linalg.matmul_transpose_a",
     "linalg.matmul_transpose_b",
@@ -53,7 +53,7 @@ def assign_and_propagate_tile_sizes(
         Schedule module.
     """
     if anchor_op is None:
-        anchor_op = GEMM_OPS
+        anchor_op = _GEMM_ANCHOR_OPS
 
     with schedule_boilerplate() as (sched, named_seq):
         anchors = lh_transform.match_op(named_seq.bodyTarget, anchor_op)

--- a/lighthouse/schedule/tile_and_fuse.py
+++ b/lighthouse/schedule/tile_and_fuse.py
@@ -1,16 +1,3 @@
-"""Generic tile-and-fuse schedules.
-
-These schedules generalise the matmul-specific cache tiling to arbitrary
-workloads: they assign target tile sizes to anchor ops, propagate
-those sizes to neighboring ops, and tile and fuse using the annotations as
-fusion hints. Sizes are recorded as ``transform_ext.tile_sizes`` attributes, so
-the assignment / propagation policy is decoupled from the tiling.
-
-Tiling decisions are dominated by GEMMs: their tiles take precedence and define
-the tiling of elementwise consumers. Kernels without a GEMM fall back to
-anchoring an elementwise op and propagating from there.
-"""
-
 from mlir import ir
 from mlir.dialects import transform
 from mlir.dialects.transform import structured
@@ -19,8 +6,8 @@ from lighthouse.dialects.transform import transform_ext
 from lighthouse.schedule.builders import schedule_boilerplate
 import lighthouse.transform as lh_transform
 
-# Op names treated as GEMM anchors. Their tiles take precedence and drive the
-# tiling of surrounding elementwise ops via propagation.
+# Named GEMM ops treated as default anchors.
+# Their tiles take precedence and drive the tiling of surrounding ops.
 _GEMM_ANCHOR_OPS = [
     "linalg.matmul",
     "linalg.matmul_transpose_a",
@@ -41,16 +28,16 @@ def assign_and_propagate_tile_sizes(
     """
     Assign tile sizes to anchor ops and propagate them to their neighbors.
 
-    Anchors matched by `anchor_op` are annotated and their sizes propagated to
-    neighboring ops so a fusable group shares one tiling. Can be applied repeatedly
-    with different anchors (e.g. GEMMs first, then leftover elementwise ops);
-    already-annotated ops keep their sizes, so earlier assignments win.
+    Anchors ops are annotated and their sizes propagated to neighboring ops
+    so a fusable group shares one tiling. Can be applied repeatedly with different
+    anchors (e.g. GEMMs first, then leftover elementwise ops); already-annotated
+    ops keep their sizes, so earlier assignments win.
 
     Args:
         anchor_op: Op(s) to anchor tiling on. Defaults to the GEMM op family.
         tile_size: Size used for tiled dimensions. User hint, default 32.
     Returns:
-        Schedule module.
+        Schedule
     """
     if anchor_op is None:
         anchor_op = _GEMM_ANCHOR_OPS
@@ -67,14 +54,13 @@ def assign_elementwise_tile_sizes(tile_size: int = 32) -> ir.Module:
     """
     Anchor tiling on elementwise ops only.
 
-    For kernels without a GEMM: all linalg ops are matched, filtered to the
-    genuinely elementwise ones, annotated, and propagated from. Already-annotated
-    ops (e.g. from a preceding GEMM assignment) are kept.
+    Selects all elementwise linalg ops then performs tile size selection and
+    propagation. Already-annotated ops are kept.
 
     Args:
         tile_size: Size used for tiled dimensions. User hint, default 32.
     Returns:
-        Schedule module.
+        Schedule
     """
     with schedule_boilerplate() as (sched, named_seq):
         candidates = lh_transform.match_op(
@@ -93,19 +79,18 @@ def tile_and_fuse_annotated(
     clear_annotations: bool = True,
 ) -> ir.Module:
     """
-    Tile and fuse annotated groups using their tile-size annotations.
+    Tile and fuse annotated groups.
 
     Fusion roots are selected among the candidates, each is tiled with its
-    annotated `transform_ext.tile_sizes`, and its producers are greedily fused into
-    the tiled loop -- pulling a barrier (e.g. a GEMM) and its elementwise neighbors
-    into one loop. The annotations act as fusion hints.
+    annotated tile sizes, and its producers are greedily fused into the tiled loop.
+    The annotations act as fusion hints.
 
     Args:
         target_op: Candidate op(s) to consider. Defaults to all linalg ops.
         use_forall: Generate `scf.forall` loops (parallel) when tiling.
         clear_annotations: Clear the annotations from the fused ops.
     Returns:
-        Schedule module.
+        Schedule
     """
     if target_op is None:
         target_op = structured.MatchInterfaceEnum.LinalgOp

--- a/lighthouse/schedule/tile_and_fuse.py
+++ b/lighthouse/schedule/tile_and_fuse.py
@@ -1,0 +1,132 @@
+"""Generic tile-and-fuse schedules.
+
+These schedules generalise the matmul-specific cache tiling to arbitrary
+workloads: they assign target tile sizes to anchor ops, propagate
+those sizes to neighboring ops, and tile and fuse using the annotations as
+fusion hints. Sizes are recorded as ``transform_ext.tile_sizes`` attributes, so
+the assignment / propagation policy is decoupled from the tiling.
+
+Tiling decisions are dominated by GEMMs: their tiles take precedence and define
+the tiling of elementwise consumers. Kernels without a GEMM fall back to
+anchoring an elementwise op and propagating from there.
+"""
+
+from mlir import ir
+from mlir.dialects import transform
+from mlir.dialects.transform import structured
+
+from lighthouse.dialects.transform import transform_ext
+from lighthouse.schedule.builders import schedule_boilerplate
+import lighthouse.transform as lh_transform
+
+# Op names treated as GEMM anchors. Their tiles take precedence and drive the
+# tiling of surrounding elementwise ops via propagation.
+GEMM_OPS = [
+    "linalg.matmul",
+    "linalg.matmul_transpose_a",
+    "linalg.matmul_transpose_b",
+    "linalg.batch_matmul",
+    "linalg.batch_reduce_matmul",
+    "linalg.contract",
+    "linalg.matvec",
+    "linalg.vecmat",
+    "linalg.batch_matvec",
+]
+
+
+def assign_and_propagate_tile_sizes(
+    anchor_op: str | list[str] | None = None,
+    tile_size: int = 32,
+) -> ir.Module:
+    """
+    Assign tile sizes to anchor ops and propagate them to their neighbors.
+
+    Anchors matched by `anchor_op` are annotated and their sizes propagated to
+    neighboring ops so a fusable group shares one tiling. Can be applied repeatedly
+    with different anchors (e.g. GEMMs first, then leftover elementwise ops);
+    already-annotated ops keep their sizes, so earlier assignments win.
+
+    Args:
+        anchor_op: Op(s) to anchor tiling on. Defaults to the GEMM op family.
+        tile_size: Size used for tiled dimensions. User hint, default 32.
+    Returns:
+        Schedule module.
+    """
+    if anchor_op is None:
+        anchor_op = GEMM_OPS
+
+    with schedule_boilerplate() as (sched, named_seq):
+        anchors = lh_transform.match_op(named_seq.bodyTarget, anchor_op)
+        annotated = transform_ext.assign_tile_sizes(anchors, tile_size=tile_size)
+        transform_ext.propagate_tile_sizes(annotated)
+        transform.yield_()
+    return sched
+
+
+def assign_elementwise_tile_sizes(tile_size: int = 32) -> ir.Module:
+    """
+    Anchor tiling on elementwise ops only.
+
+    For kernels without a GEMM: all linalg ops are matched, filtered to the
+    genuinely elementwise ones, annotated, and propagated from. Already-annotated
+    ops (e.g. from a preceding GEMM assignment) are kept.
+
+    Args:
+        tile_size: Size used for tiled dimensions. User hint, default 32.
+    Returns:
+        Schedule module.
+    """
+    with schedule_boilerplate() as (sched, named_seq):
+        candidates = lh_transform.match_op(
+            named_seq.bodyTarget, structured.MatchInterfaceEnum.LinalgOp
+        )
+        elementwise = transform_ext.filter_elementwise(candidates)
+        annotated = transform_ext.assign_tile_sizes(elementwise, tile_size=tile_size)
+        transform_ext.propagate_tile_sizes(annotated)
+        transform.yield_()
+    return sched
+
+
+def tile_and_fuse_annotated(
+    target_op: str | list[str] | None = None,
+    use_forall: bool = True,
+    clear_annotations: bool = True,
+) -> ir.Module:
+    """
+    Tile and fuse annotated groups using their tile-size annotations.
+
+    Fusion roots are selected among the candidates, each is tiled with its
+    annotated `transform_ext.tile_sizes`, and its producers are greedily fused into
+    the tiled loop -- pulling a barrier (e.g. a GEMM) and its elementwise neighbors
+    into one loop. The annotations act as fusion hints.
+
+    Args:
+        target_op: Candidate op(s) to consider. Defaults to all linalg ops.
+        use_forall: Generate `scf.forall` loops (parallel) when tiling.
+        clear_annotations: Clear the annotations from the fused ops.
+    Returns:
+        Schedule module.
+    """
+    if target_op is None:
+        target_op = structured.MatchInterfaceEnum.LinalgOp
+
+    with schedule_boilerplate() as (sched, named_seq):
+        candidates = lh_transform.match_op(named_seq.bodyTarget, target_op)
+        roots = transform_ext.get_fusion_roots(candidates)
+        with lh_transform.foreach(roots) as op:
+            tiles = transform_ext.get_tile_sizes(op)
+            fused = structured.FuseOp(
+                op,
+                tile_sizes=tiles,
+                apply_cleanup=True,
+                use_forall=use_forall,
+            )
+            # Fusion has consumed the annotations of this group. Clear them from
+            # the ops now inside the generated loop(s).
+            if clear_annotations:
+                loops = transform.merge_handles(list(fused.loops))
+                transform_ext.clear_tile_and_fuse_annotations(loops)
+            transform.yield_()
+        lh_transform.cleanup(named_seq.bodyTarget)
+        transform.yield_()
+    return sched

--- a/test/transform/test_get_fusion_roots.py
+++ b/test/transform/test_get_fusion_roots.py
@@ -1,0 +1,241 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from mlir import ir
+from mlir.dialects import transform
+from mlir.dialects.transform import structured
+
+import lighthouse.dialects as lh_dialects
+from lighthouse import transform as lh_transform
+from lighthouse.dialects.transform import transform_ext
+from lighthouse.schedule.builders import schedule_boilerplate
+
+
+def apply_schedule(payload_str, build_roots, name):
+    """Parse a payload, build a `get_fusion_roots` schedule and print the roots."""
+    with ir.Context(), ir.Location.unknown():
+        lh_dialects.register_and_load()
+        payload = ir.Module.parse(payload_str)
+        with schedule_boilerplate() as (sched, named_seq):
+            roots = build_roots(named_seq)
+            transform.print_(target=roots, name=name)
+            transform.yield_()
+        sched.body.operations[0].apply(payload.operation)
+
+
+# Four independent elementwise ops, each its own fusion root, alternating
+# linalg.generic / linalg.add in program order and each with a unique shape so
+# it can be identified in the printed output.
+SCRAMBLED = """
+#id = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%a: tensor<10x10xf32>, %b: tensor<11x11xf32>, %c: tensor<12x12xf32>,
+        %d: tensor<13x13xf32>)
+        -> (tensor<10x10xf32>, tensor<11x11xf32>, tensor<12x12xf32>, tensor<13x13xf32>) {
+    %e0 = tensor.empty() : tensor<10x10xf32>
+    %gA = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"],
+        transform_ext.tile_sizes = array<i64: 32, 32>}
+        ins(%a : tensor<10x10xf32>)
+        outs(%e0 : tensor<10x10xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      linalg.yield %i : f32
+    } -> tensor<10x10xf32>
+    %e1 = tensor.empty() : tensor<11x11xf32>
+    %addB = linalg.add {transform_ext.tile_sizes = array<i64: 32, 32>}
+        ins(%b, %b : tensor<11x11xf32>, tensor<11x11xf32>)
+        outs(%e1 : tensor<11x11xf32>) -> tensor<11x11xf32>
+    %e2 = tensor.empty() : tensor<12x12xf32>
+    %gC = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"],
+        transform_ext.tile_sizes = array<i64: 32, 32>}
+        ins(%c : tensor<12x12xf32>)
+        outs(%e2 : tensor<12x12xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      linalg.yield %i : f32
+    } -> tensor<12x12xf32>
+    %e3 = tensor.empty() : tensor<13x13xf32>
+    %addD = linalg.add {transform_ext.tile_sizes = array<i64: 32, 32>}
+        ins(%d, %d : tensor<13x13xf32>, tensor<13x13xf32>)
+        outs(%e3 : tensor<13x13xf32>) -> tensor<13x13xf32>
+    return %gA, %addB, %gC, %addD
+        : tensor<10x10xf32>, tensor<11x11xf32>, tensor<12x12xf32>, tensor<13x13xf32>
+  }
+}
+"""
+
+# A GEMM group: fill (prologue) -> matmul (barrier) -> relu (epilogue). Only the
+# epilogue relu is a root: the fill is fused as a producer and the matmul is a
+# barrier that still has an elementwise epilogue.
+GEMM_GROUP = """
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%a: tensor<32x32xf32>, %w: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e = tensor.empty() : tensor<32x32xf32>
+    %f = linalg.fill {transform_ext.tile_sizes = array<i64: 32, 32>}
+        ins(%cst : f32)
+        outs(%e : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %mm = linalg.matmul {transform_ext.tile_sizes = array<i64: 32, 32, 0>}
+        ins(%a, %w : tensor<32x32xf32>, tensor<32x32xf32>)
+        outs(%f : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %relu = linalg.generic {indexing_maps = [#map, #map],
+        iterator_types = ["parallel", "parallel"],
+        transform_ext.tile_sizes = array<i64: 32, 32>}
+        ins(%mm : tensor<32x32xf32>)
+        outs(%e : tensor<32x32xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %c = arith.cmpf ugt, %i, %cst : f32
+      %s = arith.select %c, %i, %cst : f32
+      linalg.yield %s : f32
+    } -> tensor<32x32xf32>
+    return %relu : tensor<32x32xf32>
+  }
+}
+"""
+
+# A GEMM barrier with no epilogue: fill (prologue) -> matmul (barrier), whose
+# result is returned directly. The matmul is its own root; the fill is fused.
+BARRIER_ONLY = """
+module {
+  func.func @main(%a: tensor<32x32xf32>, %w: tensor<32x32xf32>) -> tensor<32x32xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e = tensor.empty() : tensor<32x32xf32>
+    %f = linalg.fill {transform_ext.tile_sizes = array<i64: 32, 32>}
+        ins(%cst : f32)
+        outs(%e : tensor<32x32xf32>) -> tensor<32x32xf32>
+    %mm = linalg.matmul {transform_ext.tile_sizes = array<i64: 32, 32, 0>}
+        ins(%a, %w : tensor<32x32xf32>, tensor<32x32xf32>)
+        outs(%f : tensor<32x32xf32>) -> tensor<32x32xf32>
+    return %mm : tensor<32x32xf32>
+  }
+}
+"""
+
+# Two chained elementwise ops pre-annotated with conflicting tile sizes:
+#   producer 32x32 -> consumer 64x64 sharing a tensor.
+# Because the tilings conflict on the shared tensor, they are different groups:
+#   both are roots (each is tiled on its own).
+# With compatible sizes only the downstream consumer would be a root.
+INCOMPATIBLE_CHAIN = """
+#id = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%a: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e0 = tensor.empty() : tensor<128x128xf32>
+    %p = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"],
+        transform_ext.tile_sizes = array<i64: 32, 32>}
+        ins(%a : tensor<128x128xf32>)
+        outs(%e0 : tensor<128x128xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %e = math.exp %i : f32
+      linalg.yield %e : f32
+    } -> tensor<128x128xf32>
+    %e1 = tensor.empty() : tensor<128x128xf32>
+    %c = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"],
+        transform_ext.tile_sizes = array<i64: 64, 64>}
+        ins(%p : tensor<128x128xf32>)
+        outs(%e1 : tensor<128x128xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %s = math.sqrt %i : f32
+      linalg.yield %s : f32
+    } -> tensor<128x128xf32>
+    return %c : tensor<128x128xf32>
+  }
+}
+"""
+
+# The same chain with matching tile sizes (both 32x32): the two ops form a single
+# group, so only the downstream consumer (the sqrt) is a root.
+COMPATIBLE_CHAIN = """
+#id = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%a: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e0 = tensor.empty() : tensor<128x128xf32>
+    %p = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"],
+        transform_ext.tile_sizes = array<i64: 32, 32>}
+        ins(%a : tensor<128x128xf32>)
+        outs(%e0 : tensor<128x128xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %e = math.exp %i : f32
+      linalg.yield %e : f32
+    } -> tensor<128x128xf32>
+    %e1 = tensor.empty() : tensor<128x128xf32>
+    %c = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"],
+        transform_ext.tile_sizes = array<i64: 32, 32>}
+        ins(%p : tensor<128x128xf32>)
+        outs(%e1 : tensor<128x128xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %s = math.sqrt %i : f32
+      linalg.yield %s : f32
+    } -> tensor<128x128xf32>
+    return %c : tensor<128x128xf32>
+  }
+}
+"""
+
+
+def scrambled_roots(named_seq):
+    # Match the two op kinds separately and merge them: the handle lists all
+    # generics first, then all adds, so it is deliberately *not* in program
+    # order. get_fusion_roots must still return the roots top-down.
+    gens = lh_transform.match_op(named_seq.bodyTarget, "linalg.generic")
+    adds = lh_transform.match_op(named_seq.bodyTarget, "linalg.add")
+    merged = transform.merge_handles([gens, adds])
+    return transform_ext.get_fusion_roots(merged)
+
+
+def all_linalg_roots(named_seq):
+    candidates = lh_transform.match_op(
+        named_seq.bodyTarget, structured.MatchInterfaceEnum.LinalgOp
+    )
+    return transform_ext.get_fusion_roots(candidates)
+
+
+# The input handle is scrambled (generics [10, 12] then adds [11, 13]); the roots
+# must come back in program order regardless: 10, 11, 12, 13.
+# CHECK: IR printer: PROGRAM_ORDER
+# CHECK: tensor<10x10xf32>
+# CHECK: tensor<11x11xf32>
+# CHECK: tensor<12x12xf32>
+# CHECK: tensor<13x13xf32>
+apply_schedule(SCRAMBLED, scrambled_roots, "PROGRAM_ORDER")
+
+
+# Only the epilogue relu (a linalg.generic) is a root; the prologue fill and the
+# matmul barrier are not returned.
+# CHECK: IR printer: GEMM_GROUP
+# CHECK: linalg.generic
+# CHECK-NOT: linalg.matmul
+# CHECK-NOT: linalg.fill
+apply_schedule(GEMM_GROUP, all_linalg_roots, "GEMM_GROUP")
+
+
+# A barrier with no epilogue is its own root: the matmul is returned, the fill is
+# not.
+# CHECK: IR printer: BARRIER_ONLY
+# CHECK: linalg.matmul
+# CHECK-NOT: linalg.fill
+apply_schedule(BARRIER_ONLY, all_linalg_roots, "BARRIER_ONLY")
+
+
+# Conflicting hand-annotated tile sizes split the chain: the producer (32x32) and
+# the consumer (64x64) are separate groups, so both are returned as roots, in
+# program order (producer first).
+# CHECK: IR printer: INCOMPATIBLE_CHAIN
+# CHECK: tile_sizes = array<i64: 32, 32>
+# CHECK: tile_sizes = array<i64: 64, 64>
+apply_schedule(INCOMPATIBLE_CHAIN, all_linalg_roots, "INCOMPATIBLE_CHAIN")
+
+
+# Matching tile sizes keep the chain in one group: only the downstream consumer
+# (sqrt) is a root; the producer (exp) is fused as its producer, so it is not
+# printed.
+# CHECK: IR printer: COMPATIBLE_CHAIN
+# CHECK-NOT: math.exp
+# CHECK: math.sqrt
+apply_schedule(COMPATIBLE_CHAIN, all_linalg_roots, "COMPATIBLE_CHAIN")

--- a/test/transform/test_tile_and_fuse.py
+++ b/test/transform/test_tile_and_fuse.py
@@ -1,0 +1,852 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+"""Tests for the generic tile-and-fuse transform ops and schedules.
+
+Exercises the three-step strategy on linalg payloads:
+    1. assign tile sizes to anchor ops (GEMMs / elementwise)
+    2. propagate them to neighboring ops
+    3. tile and fuse using the annotations
+"""
+
+from mlir import ir
+
+import lighthouse.dialects as lh_dialects
+from lighthouse.schedule import tile_and_fuse as tf
+
+
+def run(name: str, payload_str: str, *schedules):
+    """Parse a payload, apply the given schedules in order and print it."""
+    print(f"Test: {name}", flush=True)
+    with ir.Context(), ir.Location.unknown():
+        lh_dialects.register_and_load()
+        payload = ir.Module.parse(payload_str)
+        # Keep schedule modules alive while applying them.
+        modules = []
+        for make_schedule in schedules:
+            sched = make_schedule()
+            modules.append(sched)
+            sched.body.operations[0].apply(payload.operation)
+        print(payload)
+
+
+def assign_gemm():
+    return tf.assign_and_propagate_tile_sizes(tile_size=32)
+
+
+def assign_elementwise():
+    return tf.assign_elementwise_tile_sizes(tile_size=32)
+
+
+def assign_elementwise64():
+    return tf.assign_elementwise_tile_sizes(tile_size=64)
+
+
+def tile_and_fuse():
+    return tf.tile_and_fuse_annotated()
+
+
+def tile_and_fuse_keep():
+    # Opt out of post-fusion annotation clearing so a test can still inspect the
+    # propagated tile sizes on the fused ops.
+    return tf.tile_and_fuse_annotated(clear_annotations=False)
+
+
+def tile_and_fuse_for():
+    # Tile with sequential scf.for loops (a nested loop nest) instead of a single
+    # multi-dim scf.forall.
+    return tf.tile_and_fuse_annotated(use_forall=False)
+
+
+MLP = """
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d1)>
+module {
+  func.func @main(%arg0: tensor<32x64xf32>, %w: tensor<64x128xf32>, %b: tensor<128xf32>)
+        -> tensor<32x128xf32> {
+    %cst = arith.constant 0.000000e+00 : f32
+    %1 = tensor.empty() : tensor<32x128xf32>
+    %2 = linalg.fill ins(%cst : f32) outs(%1 : tensor<32x128xf32>) -> tensor<32x128xf32>
+    %3 = linalg.matmul ins(%arg0, %w : tensor<32x64xf32>, tensor<64x128xf32>)
+        outs(%2 : tensor<32x128xf32>) -> tensor<32x128xf32>
+    %4 = linalg.generic {indexing_maps = [#map, #map1, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%3, %b : tensor<32x128xf32>, tensor<128xf32>)
+        outs(%1 : tensor<32x128xf32>) {
+    ^bb0(%in: f32, %in_2: f32, %out: f32):
+      %6 = arith.addf %in, %in_2 : f32
+      linalg.yield %6 : f32
+    } -> tensor<32x128xf32>
+    %5 = linalg.generic {indexing_maps = [#map, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%4 : tensor<32x128xf32>)
+        outs(%1 : tensor<32x128xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %6 = arith.cmpf ugt, %in, %cst : f32
+      %7 = arith.select %6, %in, %cst : f32
+      linalg.yield %7 : f32
+    } -> tensor<32x128xf32>
+    return %5 : tensor<32x128xf32>
+  }
+}
+"""
+
+ELTWISE = """
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%a: tensor<64x256xf32>) -> tensor<64x256xf32> {
+    %cst = arith.constant 0.0 : f32
+    %0 = tensor.empty() : tensor<64x256xf32>
+    %1 = linalg.generic {indexing_maps = [#map, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%a : tensor<64x256xf32>)
+        outs(%0 : tensor<64x256xf32>) {
+    ^bb0(%in: f32, %o: f32):
+      %e = math.exp %in : f32
+      linalg.yield %e : f32
+    } -> tensor<64x256xf32>
+    %2 = linalg.generic {indexing_maps = [#map, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%1 : tensor<64x256xf32>)
+        outs(%0 : tensor<64x256xf32>) {
+    ^bb0(%in: f32, %o: f32):
+      %c = arith.cmpf ugt, %in, %cst : f32
+      %s = arith.select %c, %in, %cst : f32
+      linalg.yield %s : f32
+    } -> tensor<64x256xf32>
+    return %2 : tensor<64x256xf32>
+  }
+}
+"""
+
+BMM = """
+module {
+  func.func @main(%a: tensor<8x64x96xf32>, %b: tensor<8x96x128xf32>) -> tensor<8x64x128xf32> {
+    %cst = arith.constant 0.0 : f32
+    %0 = tensor.empty() : tensor<8x64x128xf32>
+    %1 = linalg.fill ins(%cst: f32) outs(%0: tensor<8x64x128xf32>) -> tensor<8x64x128xf32>
+    %2 = linalg.batch_matmul ins(%a, %b : tensor<8x64x96xf32>, tensor<8x96x128xf32>)
+        outs(%1 : tensor<8x64x128xf32>) -> tensor<8x64x128xf32>
+    return %2 : tensor<8x64x128xf32>
+  }
+}
+"""
+
+# A named elementwise op (linalg.add) followed by a relu generic.
+# The elementwise anchor schedule must cover named variants, not just linalg.generic.
+NAMED_ELTWISE = """
+#id = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%a: tensor<64x256xf32>, %b: tensor<64x256xf32>) -> tensor<64x256xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e = tensor.empty() : tensor<64x256xf32>
+    %add = linalg.add ins(%a, %b : tensor<64x256xf32>, tensor<64x256xf32>)
+        outs(%e : tensor<64x256xf32>) -> tensor<64x256xf32>
+    %relu = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%add : tensor<64x256xf32>)
+        outs(%e : tensor<64x256xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %c = arith.cmpf ugt, %i, %cst : f32
+      %s = arith.select %c, %i, %cst : f32
+      linalg.yield %s : f32
+    } -> tensor<64x256xf32>
+    return %relu : tensor<64x256xf32>
+  }
+}
+"""
+
+REDUCE = """
+#id = affine_map<(d0, d1) -> (d0, d1)>
+#out = affine_map<(d0, d1) -> (d0)>
+module {
+  func.func @main(%a: tensor<64x256xf32>) -> tensor<64xf32> {
+    %cst = arith.constant 0.0 : f32
+    %ein = tensor.empty() : tensor<64x256xf32>
+    %relu = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%a : tensor<64x256xf32>)
+        outs(%ein : tensor<64x256xf32>) {
+    ^bb0(%in: f32, %o: f32):
+      %c = arith.cmpf ugt, %in, %cst : f32
+      %s = arith.select %c, %in, %cst : f32
+      linalg.yield %s : f32
+    } -> tensor<64x256xf32>
+    %e = tensor.empty() : tensor<64xf32>
+    %f = linalg.fill ins(%cst: f32) outs(%e: tensor<64xf32>) -> tensor<64xf32>
+    %r = linalg.generic {indexing_maps = [#id, #out],
+        iterator_types = ["parallel", "reduction"]}
+        ins(%relu : tensor<64x256xf32>)
+        outs(%f : tensor<64xf32>) {
+    ^bb0(%in: f32, %o: f32):
+      %s = arith.addf %in, %o : f32
+      linalg.yield %s : f32
+    } -> tensor<64xf32>
+    return %r : tensor<64xf32>
+  }
+}
+"""
+
+# Two GEMMs chained through a relu. The relu is the epilogue of the first matmul
+# and the prologue of the second: it must be tiled to match its producer GEMM.
+TWO_GEMM = """
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%a: tensor<64x64xf32>, %w0: tensor<64x64xf32>, %w1: tensor<64x64xf32>)
+        -> tensor<64x64xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e0 = tensor.empty() : tensor<64x64xf32>
+    %f0 = linalg.fill ins(%cst: f32) outs(%e0: tensor<64x64xf32>) -> tensor<64x64xf32>
+    %mm0 = linalg.matmul ins(%a, %w0 : tensor<64x64xf32>, tensor<64x64xf32>)
+        outs(%f0 : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %relu0 = linalg.generic {indexing_maps = [#map, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%mm0 : tensor<64x64xf32>)
+        outs(%e0 : tensor<64x64xf32>) {
+    ^bb0(%in: f32, %o: f32):
+      %c = arith.cmpf ugt, %in, %cst : f32
+      %s = arith.select %c, %in, %cst : f32
+      linalg.yield %s : f32
+    } -> tensor<64x64xf32>
+    %f1 = linalg.fill ins(%cst: f32) outs(%e0: tensor<64x64xf32>) -> tensor<64x64xf32>
+    %mm1 = linalg.matmul ins(%relu0, %w1 : tensor<64x64xf32>, tensor<64x64xf32>)
+        outs(%f1 : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %relu1 = linalg.generic {indexing_maps = [#map, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%mm1 : tensor<64x64xf32>)
+        outs(%e0 : tensor<64x64xf32>) {
+    ^bb0(%in: f32, %o: f32):
+      %c = arith.cmpf ugt, %in, %cst : f32
+      %s = arith.select %c, %in, %cst : f32
+      linalg.yield %s : f32
+    } -> tensor<64x64xf32>
+    return %relu1 : tensor<64x64xf32>
+  }
+}
+"""
+
+# A 3-layer MLP: each layer is matmul + bias-add + relu (last layer bias only).
+MLP3 = """
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d1)>
+module {
+  func.func @main(%x: tensor<64x64xf32>, %w0: tensor<64x64xf32>, %b0: tensor<64xf32>,
+        %w1: tensor<64x64xf32>, %b1: tensor<64xf32>, %w2: tensor<64x64xf32>,
+        %b2: tensor<64xf32>) -> tensor<64x64xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e = tensor.empty() : tensor<64x64xf32>
+    %f0 = linalg.fill ins(%cst: f32) outs(%e: tensor<64x64xf32>) -> tensor<64x64xf32>
+    %mm0 = linalg.matmul ins(%x, %w0 : tensor<64x64xf32>, tensor<64x64xf32>)
+        outs(%f0 : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %a0 = linalg.generic {indexing_maps = [#map, #map1, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%mm0, %b0 : tensor<64x64xf32>, tensor<64xf32>)
+        outs(%e : tensor<64x64xf32>) {
+    ^bb0(%in: f32, %ib: f32, %o: f32):
+      %s = arith.addf %in, %ib : f32
+      %c = arith.cmpf ugt, %s, %cst : f32
+      %r = arith.select %c, %s, %cst : f32
+      linalg.yield %r : f32
+    } -> tensor<64x64xf32>
+    %mm1 = linalg.matmul ins(%a0, %w1 : tensor<64x64xf32>, tensor<64x64xf32>)
+        outs(%f0 : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %a1 = linalg.generic {indexing_maps = [#map, #map1, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%mm1, %b1 : tensor<64x64xf32>, tensor<64xf32>)
+        outs(%e : tensor<64x64xf32>) {
+    ^bb0(%in: f32, %ib: f32, %o: f32):
+      %s = arith.addf %in, %ib : f32
+      %c = arith.cmpf ugt, %s, %cst : f32
+      %r = arith.select %c, %s, %cst : f32
+      linalg.yield %r : f32
+    } -> tensor<64x64xf32>
+    %mm2 = linalg.matmul ins(%a1, %w2 : tensor<64x64xf32>, tensor<64x64xf32>)
+        outs(%f0 : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %a2 = linalg.generic {indexing_maps = [#map, #map1, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%mm2, %b2 : tensor<64x64xf32>, tensor<64xf32>)
+        outs(%e : tensor<64x64xf32>) {
+    ^bb0(%in: f32, %ib: f32, %o: f32):
+      %s = arith.addf %in, %ib : f32
+      linalg.yield %s : f32
+    } -> tensor<64x64xf32>
+    return %a2 : tensor<64x64xf32>
+  }
+}
+"""
+
+# A matmul + relu with dynamic M and N dimensions.
+DYN = """
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%a: tensor<?x64xf32>, %w: tensor<64x?xf32>, %init: tensor<?x?xf32>)
+        -> tensor<?x?xf32> {
+    %cst = arith.constant 0.0 : f32
+    %f = linalg.fill ins(%cst: f32) outs(%init: tensor<?x?xf32>) -> tensor<?x?xf32>
+    %mm = linalg.matmul ins(%a, %w : tensor<?x64xf32>, tensor<64x?xf32>)
+        outs(%f : tensor<?x?xf32>) -> tensor<?x?xf32>
+    %relu = linalg.generic {indexing_maps = [#map, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%mm : tensor<?x?xf32>)
+        outs(%init : tensor<?x?xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %c = arith.cmpf ugt, %i, %cst : f32
+      %s = arith.select %c, %i, %cst : f32
+      linalg.yield %s : f32
+    } -> tensor<?x?xf32>
+    return %relu : tensor<?x?xf32>
+  }
+}
+"""
+
+# A high-dimensional contraction.
+HIGH_DIM_CONTRACT = """
+#mapA = affine_map<(b, m0, m1, n, k) -> (b, m0, m1, k)>
+#mapB = affine_map<(b, m0, m1, n, k) -> (b, k, n)>
+#mapC = affine_map<(b, m0, m1, n, k) -> (b, m0, m1, n)>
+module {
+  func.func @main(%a: tensor<2x4x64x64xf32>, %b: tensor<2x64x64xf32>)
+        -> tensor<2x4x64x64xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e = tensor.empty() : tensor<2x4x64x64xf32>
+    %f = linalg.fill ins(%cst: f32) outs(%e: tensor<2x4x64x64xf32>) -> tensor<2x4x64x64xf32>
+    %c = linalg.contract indexing_maps = [#mapA, #mapB, #mapC]
+        ins(%a, %b : tensor<2x4x64x64xf32>, tensor<2x64x64xf32>)
+        outs(%f : tensor<2x4x64x64xf32>) -> tensor<2x4x64x64xf32>
+    return %c : tensor<2x4x64x64xf32>
+  }
+}
+"""
+
+# A matvec (C[m] = A[m, k] * B[k]) with a relu epilogue: a GEMM whose result is 1D.
+# Its single parallel (M) dim must still be tiled under the default 2D tile.
+MATVEC = """
+#map = affine_map<(d0) -> (d0)>
+module {
+  func.func @main(%m: tensor<128x64xf32>, %v: tensor<64xf32>) -> tensor<128xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e = tensor.empty() : tensor<128xf32>
+    %f = linalg.fill ins(%cst: f32) outs(%e: tensor<128xf32>) -> tensor<128xf32>
+    %mv = linalg.matvec ins(%m, %v : tensor<128x64xf32>, tensor<64xf32>)
+        outs(%f : tensor<128xf32>) -> tensor<128xf32>
+    %relu = linalg.generic {indexing_maps = [#map, #map],
+        iterator_types = ["parallel"]}
+        ins(%mv : tensor<128xf32>)
+        outs(%e : tensor<128xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %c = arith.cmpf ugt, %i, %cst : f32
+      %s = arith.select %c, %i, %cst : f32
+      linalg.yield %s : f32
+    } -> tensor<128xf32>
+    return %relu : tensor<128xf32>
+  }
+}
+"""
+
+# A batch matmul feeding a transposing consumer. The batch matmul is tiled
+# [1, 32, 32, 0] (batch -> 1, M/N -> 32); the consumer reads the result with a
+# permuted map (D[m, b, n] = C[b, m, n]), so tile-size propagation must remap the
+# per-dimension tiles through the transpose: the batch unit tile has to land on
+# the consumer's transposed batch dim, giving [32, 1, 32] (not a positional copy
+# [1, 32, 32]).
+PERMUTED = """
+#cin = affine_map<(d0, d1, d2) -> (d1, d0, d2)>
+#cout = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+module {
+  func.func @main(%a: tensor<2x64x96xf32>, %b: tensor<2x96x128xf32>) -> tensor<64x2x128xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e = tensor.empty() : tensor<2x64x128xf32>
+    %f = linalg.fill ins(%cst: f32) outs(%e: tensor<2x64x128xf32>) -> tensor<2x64x128xf32>
+    %mm = linalg.batch_matmul ins(%a, %b : tensor<2x64x96xf32>, tensor<2x96x128xf32>)
+        outs(%f : tensor<2x64x128xf32>) -> tensor<2x64x128xf32>
+    %eo = tensor.empty() : tensor<64x2x128xf32>
+    %t = linalg.generic {indexing_maps = [#cin, #cout],
+        iterator_types = ["parallel", "parallel", "parallel"]}
+        ins(%mm : tensor<2x64x128xf32>)
+        outs(%eo : tensor<64x2x128xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      linalg.yield %i : f32
+    } -> tensor<64x2x128xf32>
+    return %t : tensor<64x2x128xf32>
+  }
+}
+"""
+
+# A pack -> elementwise -> unpack chain. pack / unpack are fusion barriers: they
+# stay as materialization boundaries (outside the tiled loop) while the
+# elementwise op in between is tiled and fused on its own.
+PACK_UNPACK = """
+#id4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+module {
+  func.func @main(%a: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %cst = arith.constant 0.0 : f32
+    %d = tensor.empty() : tensor<4x4x32x32xf32>
+    %packed = linalg.pack %a inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %d
+        : tensor<128x128xf32> -> tensor<4x4x32x32xf32>
+    %e2 = tensor.empty() : tensor<4x4x32x32xf32>
+    %r = linalg.generic {indexing_maps = [#id4, #id4],
+        iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+        ins(%packed : tensor<4x4x32x32xf32>)
+        outs(%e2 : tensor<4x4x32x32xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %c = arith.cmpf ugt, %i, %cst : f32
+      %s = arith.select %c, %i, %cst : f32
+      linalg.yield %s : f32
+    } -> tensor<4x4x32x32xf32>
+    %out = tensor.empty() : tensor<128x128xf32>
+    %u = linalg.unpack %r inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %out
+        : tensor<4x4x32x32xf32> -> tensor<128x128xf32>
+    return %u : tensor<128x128xf32>
+  }
+}
+"""
+
+
+# Two chained elementwise ops annotated with conflicting tile sizes:
+#   producer 32x32 -> consumer 64x64.
+# Their tilings disagree on the shared tensor, so they are separate groups and
+# must not be fused into one loop.
+INCOMPAT_SPLIT = """
+#id = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%a: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e0 = tensor.empty() : tensor<128x128xf32>
+    %p = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"],
+        transform_ext.tile_sizes = array<i64: 32, 32>}
+        ins(%a : tensor<128x128xf32>)
+        outs(%e0 : tensor<128x128xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %e = math.exp %i : f32
+      linalg.yield %e : f32
+    } -> tensor<128x128xf32>
+    %e1 = tensor.empty() : tensor<128x128xf32>
+    %c = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"],
+        transform_ext.tile_sizes = array<i64: 64, 64>}
+        ins(%p : tensor<128x128xf32>)
+        outs(%e1 : tensor<128x128xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %s = math.sqrt %i : f32
+      linalg.yield %s : f32
+    } -> tensor<128x128xf32>
+    return %c : tensor<128x128xf32>
+  }
+}
+"""
+
+# A chain whose downstream op is pre-annotated with a conflicting tile size (64x64).
+# Assigning + propagating from the upstream op (32x32) reaches the pre-annotated op
+# and records a fusion boundary on it.
+PRE_ANNOTATED = """
+#id = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%a: tensor<128x128xf32>) -> tensor<128x128xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e0 = tensor.empty() : tensor<128x128xf32>
+    %p = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%a : tensor<128x128xf32>)
+        outs(%e0 : tensor<128x128xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %e = math.exp %i : f32
+      linalg.yield %e : f32
+    } -> tensor<128x128xf32>
+    %e1 = tensor.empty() : tensor<128x128xf32>
+    %c = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"],
+        transform_ext.tile_sizes = array<i64: 64, 64>}
+        ins(%p : tensor<128x128xf32>)
+        outs(%e1 : tensor<128x128xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %s = math.sqrt %i : f32
+      linalg.yield %s : f32
+    } -> tensor<128x128xf32>
+    return %c : tensor<128x128xf32>
+  }
+}
+"""
+
+# A broadcasting generic (bias[128] -> [64x128], input map drops the leading dim)
+# feeding a relu.
+BROADCAST = """
+#bc_in = affine_map<(d0, d1) -> (d1)>
+#id = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%bias: tensor<128xf32>) -> tensor<64x128xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e0 = tensor.empty() : tensor<64x128xf32>
+    %bc = linalg.generic {indexing_maps = [#bc_in, #id],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%bias : tensor<128xf32>)
+        outs(%e0 : tensor<64x128xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      linalg.yield %i : f32
+    } -> tensor<64x128xf32>
+    %e1 = tensor.empty() : tensor<64x128xf32>
+    %relu = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%bc : tensor<64x128xf32>)
+        outs(%e1 : tensor<64x128xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %c = arith.cmpf ugt, %i, %cst : f32
+      %s = arith.select %c, %i, %cst : f32
+      linalg.yield %s : f32
+    } -> tensor<64x128xf32>
+    return %relu : tensor<64x128xf32>
+  }
+}
+"""
+
+# Named linalg ops (broadcast, transpose) do not expose the .inputs / .outputs
+# accessors, only .input / .init. Selecting / computing / propagating tile sizes
+# must go through linalg_inputs / linalg_outputs so these ops do not crash the
+# analysis: bias[128] --broadcast--> relu --transpose.
+NAMED_BROADCAST_TRANSPOSE = """
+#id = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%bias: tensor<128xf32>) -> tensor<128x64xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e0 = tensor.empty() : tensor<64x128xf32>
+    %bc = linalg.broadcast ins(%bias : tensor<128xf32>) outs(%e0 : tensor<64x128xf32>)
+        dimensions = [0]
+    %e1 = tensor.empty() : tensor<64x128xf32>
+    %relu = linalg.generic {indexing_maps = [#id, #id],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%bc : tensor<64x128xf32>)
+        outs(%e1 : tensor<64x128xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      %c = arith.cmpf ugt, %i, %cst : f32
+      %s = arith.select %c, %i, %cst : f32
+      linalg.yield %s : f32
+    } -> tensor<64x128xf32>
+    %e2 = tensor.empty() : tensor<128x64xf32>
+    %t = linalg.transpose ins(%relu : tensor<64x128xf32>) outs(%e2 : tensor<128x64xf32>)
+        permutation = [1, 0]
+    return %t : tensor<128x64xf32>
+  }
+}
+"""
+
+# A GEMM anchor whose result feeds a named linalg.transpose: tile sizes propagate
+# from the matmul onto the named op, so propagation (propagate_through_value ->
+# _map_for_value) must handle a named op without crashing.
+GEMM_NAMED_TRANSPOSE = """
+module {
+  func.func @main(%a: tensor<64x64xf32>, %w: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e = tensor.empty() : tensor<64x64xf32>
+    %f = linalg.fill ins(%cst: f32) outs(%e: tensor<64x64xf32>) -> tensor<64x64xf32>
+    %mm = linalg.matmul ins(%a, %w : tensor<64x64xf32>, tensor<64x64xf32>)
+        outs(%f : tensor<64x64xf32>) -> tensor<64x64xf32>
+    %e2 = tensor.empty() : tensor<64x64xf32>
+    %t = linalg.transpose ins(%mm : tensor<64x64xf32>) outs(%e2 : tensor<64x64xf32>)
+        permutation = [1, 0]
+    return %t : tensor<64x64xf32>
+  }
+}
+"""
+
+
+# A GEMM anchors tiling; its tile sizes are propagated to the fill producer and
+# the elementwise (bias, relu) consumers, then the whole group is fused.
+# CHECK-LABEL: Test: mlp_assign_propagate
+# CHECK: linalg.fill {transform_ext.tile_sizes = array<i64: 32, 32>}
+# CHECK: linalg.matmul {transform_ext.tile_sizes = array<i64: 32, 32, 0>}
+# CHECK: linalg.generic
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 32>
+# CHECK: linalg.generic
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 32>
+run("mlp_assign_propagate", MLP, assign_gemm)
+
+
+# Tiling the fusion root (relu) and fusing producers pulls the fill, matmul and
+# both elementwise ops into a single tiled scf.forall loop.
+# CHECK-LABEL: Test: mlp_tile_and_fuse
+# CHECK: scf.forall
+# CHECK: linalg.fill
+# CHECK: linalg.matmul
+# CHECK: linalg.generic
+# CHECK: linalg.generic
+# CHECK: scf.forall.in_parallel
+run("mlp_tile_and_fuse", MLP, assign_gemm, tile_and_fuse)
+
+
+# No GEMM: an elementwise op is anchored and its sizes propagated; the chain is
+# tiled into 2D tiles and fused.
+# CHECK-LABEL: Test: elementwise_tile_and_fuse
+# CHECK: scf.forall ({{.*}}) = (0, 0) to (64, 256) step (32, 32)
+# CHECK: linalg.generic
+# CHECK: linalg.generic
+# CHECK: scf.forall.in_parallel
+run("elementwise_tile_and_fuse", ELTWISE, assign_elementwise, tile_and_fuse)
+
+
+# Batch matmul: the batch dim is tiled by 1, M/N by the tile size, K untiled.
+# CHECK-LABEL: Test: batch_matmul
+# CHECK: linalg.batch_matmul {transform_ext.tile_sizes = array<i64: 1, 32, 32, 0>}
+run("batch_matmul", BMM, assign_gemm)
+
+
+# Reduction: an elementwise op anchors the group and propagation reaches the
+# reduction consumer, tiling its parallel dim and leaving the reduction dim
+# untiled (0). A standalone reduction is not an elementwise anchor.
+# CHECK-LABEL: Test: reduction
+# CHECK: iterator_types = ["parallel", "reduction"]
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 0>
+run("reduction", REDUCE, assign_elementwise)
+
+
+# The elementwise anchor schedule covers named variants: a linalg.add anchor is
+# annotated and its tiles propagate to the relu generic epilogue.
+# CHECK-LABEL: Test: named_elementwise_anchor
+# CHECK: linalg.add {transform_ext.tile_sizes = array<i64: 32, 32>}
+# CHECK: linalg.generic
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 32>
+run("named_elementwise_anchor", NAMED_ELTWISE, assign_elementwise)
+
+
+# Two consecutive GEMMs: the shared relu is the epilogue of the first matmul, so
+# it must be tiled to match that matmul's M/N tiles (2D, not the second matmul's
+# M/K prologue tiles). The first matmul is followed by a fully-tiled relu.
+# CHECK-LABEL: Test: two_consecutive_gemms_assign
+# CHECK: linalg.matmul {transform_ext.tile_sizes = array<i64: 32, 32, 0>}
+# CHECK: linalg.generic
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 32>
+run("two_consecutive_gemms_assign", TWO_GEMM, assign_gemm)
+
+
+# GEMMs act as fusion barriers: two consecutive GEMMs are NOT fused together.
+# Each GEMM + its epilogue forms its own scf.forall; the second reads the first
+# loop's result through a slice (proving they are separate).
+# CHECK-LABEL: Test: two_consecutive_gemms_fuse
+# CHECK: %[[F0:.+]] = scf.forall
+# CHECK: linalg.matmul
+# CHECK: scf.forall.in_parallel
+# CHECK: scf.forall
+# CHECK: tensor.extract_slice %[[F0]]
+# CHECK: linalg.matmul
+# CHECK: scf.forall.in_parallel
+run("two_consecutive_gemms_fuse", TWO_GEMM, assign_gemm, tile_and_fuse)
+
+
+# A 3-layer MLP: each layer (GEMM + epilogue) becomes its own fused scf.forall,
+# chained through the loop results. Each forall fuses its own (shared) fill.
+# CHECK-LABEL: Test: mlp_three_layers
+# CHECK: %[[L0:.+]] = scf.forall
+# CHECK: linalg.fill
+# CHECK: linalg.matmul
+# CHECK: linalg.generic
+# CHECK: scf.forall.in_parallel
+# CHECK: %[[L1:.+]] = scf.forall
+# CHECK: tensor.extract_slice %[[L0]]
+# CHECK: linalg.fill
+# CHECK: linalg.matmul
+# CHECK: linalg.generic
+# CHECK: scf.forall.in_parallel
+# CHECK: scf.forall
+# CHECK: tensor.extract_slice %[[L1]]
+# CHECK: linalg.fill
+# CHECK: linalg.matmul
+# CHECK: linalg.generic
+# CHECK: scf.forall.in_parallel
+run("mlp_three_layers", MLP3, assign_gemm, tile_and_fuse)
+
+
+# Dynamic shapes: the matmul + relu group is tiled and fused into a single
+# scf.forall whose bounds come from the runtime extents (tensor.dim).
+# CHECK-LABEL: Test: dynamic_tile_and_fuse
+# CHECK: %[[D0:.+]] = tensor.dim
+# CHECK: %[[D1:.+]] = tensor.dim
+# CHECK: scf.forall ({{.*}}) = (0, 0) to (%[[D0]], %[[D1]]) step (32, 32)
+# CHECK: linalg.fill
+# CHECK: linalg.matmul
+# CHECK: linalg.generic
+# CHECK: scf.forall.in_parallel
+run("dynamic_tile_and_fuse", DYN, assign_gemm, tile_and_fuse)
+
+
+# High-dimensional contraction: only the innermost two parallel (M, N) output
+# dims are tiled with the tile size; the outer parallel dims (batch and the
+# outer M dim) get a unit tile and the reduction (K) dim is left untiled, just
+# like GetTilingSizesOp.contract_tiles.
+# CHECK-LABEL: Test: high_dim_contract
+# CHECK: linalg.contract
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 1, 1, 32, 32, 0>
+run("high_dim_contract", HIGH_DIM_CONTRACT, assign_gemm)
+
+
+# 1D results: the matvec's single parallel (M) dim is tiled with the full tile size
+# (its reduction K stays untiled) under the default 2D tile, and the group fuses into
+# a single 1D scf.forall.
+# CHECK-LABEL: Test: matvec_1d_tile_and_fuse
+# CHECK: scf.forall ({{.*}}) = (0) to (128) step (32)
+# CHECK: linalg.fill
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32>
+# CHECK: linalg.matvec
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 0>
+# CHECK: linalg.generic
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32>
+# CHECK: scf.forall.in_parallel
+run("matvec_1d_tile_and_fuse", MATVEC, assign_gemm, tile_and_fuse_keep)
+
+
+# Propagation across a permuted (transposed) shared tensor: the batch matmul is
+# tiled [1, 32, 32, 0] and the consumer, which reads the result transposed, must
+# receive the per-dimension tiles remapped through its indexing map -> the batch
+# unit tile lands on the consumer's transposed batch dim, giving [32, 1, 32].
+# CHECK-LABEL: Test: permuted_propagation
+# CHECK: linalg.batch_matmul
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 1, 32, 32, 0>
+# CHECK: linalg.generic
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 1, 32>
+run("permuted_propagation", PERMUTED, assign_gemm)
+
+
+# pack / unpack are fusion barriers: they are not propagation anchors and are not
+# fused into the tiled loop. The elementwise op between them is tiled on its own,
+# with the pack left before and the unpack after the resulting scf.forall.
+# CHECK-LABEL: Test: pack_unpack_barrier
+# CHECK: linalg.pack
+# CHECK: scf.forall
+# CHECK: linalg.generic
+# CHECK: scf.forall.in_parallel
+# CHECK: linalg.unpack
+run("pack_unpack_barrier", PACK_UNPACK, assign_elementwise, tile_and_fuse)
+
+
+# Conflicting pre-annotated tile sizes (32x32 producer, 64x64 consumer) are kept
+# apart: each op is tiled in its own loop (32-step and 64-step).
+# CHECK-LABEL: Test: incompatible_annotations_split
+# CHECK: %[[L0:.+]] = scf.forall ({{.*}}) = (0, 0) to (128, 128) step (32, 32)
+# CHECK: math.exp
+# CHECK: scf.forall.in_parallel
+# CHECK: scf.forall ({{.*}}) = (0, 0) to (128, 128) step (64, 64)
+# CHECK: tensor.extract_slice %[[L0]]
+# CHECK: math.sqrt
+# CHECK: scf.forall.in_parallel
+run("incompatible_annotations_split", INCOMPAT_SPLIT, tile_and_fuse)
+
+
+# A downstream op pre-annotated (64x64) conflicts with the propagated tiling
+# (32x32). Propagation records the split by marking the conflicting op with a
+# fusion attribute.
+# CHECK-LABEL: Test: boundary_marked_during_propagation
+# CHECK: tile_sizes = array<i64: 32, 32>
+# CHECK: transform_ext.fusion_boundary
+# CHECK-SAME: tile_sizes = array<i64: 64, 64>
+run("boundary_marked_during_propagation", PRE_ANNOTATED, assign_elementwise)
+
+
+# The pre-annotated conflict is honored end-to-end: the two ops are tiled into
+# separate loops (32-step then 64-step) rather than fused.
+# CHECK-LABEL: Test: boundary_split_tile_and_fuse
+# CHECK: %[[B0:.+]] = scf.forall ({{.*}}) step (32, 32)
+# CHECK: math.exp
+# CHECK: scf.forall.in_parallel
+# CHECK: scf.forall ({{.*}}) step (64, 64)
+# CHECK: tensor.extract_slice %[[B0]]
+# CHECK: math.sqrt
+# CHECK: scf.forall.in_parallel
+run("boundary_split_tile_and_fuse", PRE_ANNOTATED, assign_elementwise, tile_and_fuse)
+
+
+# A broadcasting generic producer stays fused with its consumer: both land in a
+# single scf.forall (the broadcast reads a 1D slice of the bias), consistent with
+# FuseOp fusing broadcast producers. The untiled/broadcast dim is treated as a
+# wildcard by the compatibility check, so it never forces a split.
+# CHECK-LABEL: Test: broadcast_stays_fused
+# CHECK: scf.forall ({{.*}}) = (0, 0) to (64, 128) step (32, 32)
+# CHECK: tensor.extract_slice %arg0[%{{.*}}] [32] [1]
+# CHECK: linalg.generic
+# CHECK: linalg.generic
+# CHECK: scf.forall.in_parallel
+# CHECK-NOT: scf.forall
+run("broadcast_stays_fused", BROADCAST, assign_elementwise, tile_and_fuse)
+
+
+# Named linalg ops annotation.
+# CHECK-LABEL: Test: named_broadcast_transpose_anchor
+# CHECK: linalg.broadcast
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 32>
+# CHECK: linalg.generic
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 32>
+# CHECK: linalg.transpose
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 32>
+run("named_broadcast_transpose_anchor", NAMED_BROADCAST_TRANSPOSE, assign_elementwise)
+
+
+# Propagation onto a named op.
+# CHECK-LABEL: Test: gemm_named_transpose_propagate
+# CHECK: linalg.matmul {transform_ext.tile_sizes = array<i64: 32, 32, 0>}
+# CHECK: linalg.transpose
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 32>
+run("gemm_named_transpose_propagate", GEMM_NAMED_TRANSPOSE, assign_gemm)
+
+
+# A larger elementwise payload for demonstrating repeated tiling rounds.
+RETILE = """
+#map = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%a: tensor<128x256xf32>) -> tensor<128x256xf32> {
+    %0 = tensor.empty() : tensor<128x256xf32>
+    %1 = linalg.generic {indexing_maps = [#map, #map],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%a : tensor<128x256xf32>)
+        outs(%0 : tensor<128x256xf32>) {
+    ^bb0(%in: f32, %o: f32):
+      %e = math.exp %in : f32
+      linalg.yield %e : f32
+    } -> tensor<128x256xf32>
+    return %1 : tensor<128x256xf32>
+  }
+}
+"""
+
+
+# Fusion consumes the annotations, so by default they are cleared from the ops
+# now inside the generated loop, leaving no stale tile and fuse annotations.
+# CHECK-LABEL: Test: clears_annotations_after_fuse
+# CHECK: scf.forall
+# CHECK-NOT: transform_ext.tile_sizes
+# CHECK-NOT: transform_ext.fusion_boundary
+# CHECK: scf.forall.in_parallel
+run("clears_annotations_after_fuse", MLP, assign_gemm, tile_and_fuse)
+
+
+# Clearing the annotations after each round leaves a clean slate, so a second
+# assign + tile-and-fuse round tiles the already-tiled ops again: a 64-wide outer
+# loop from round one, a 32-wide inner loop from round two, and no leftover
+# annotations that could confuse the second assignment.
+# CHECK-LABEL: Test: retile_after_clear
+# CHECK: scf.forall ({{.*}}) = (0, 0) to (128, 256) step (64, 64)
+# CHECK: scf.forall ({{.*}}) = (0, 0) to (64, 64) step (32, 32)
+# CHECK-NOT: transform_ext.tile_sizes
+# CHECK-NOT: transform_ext.fusion_boundary
+# CHECK: scf.forall.in_parallel
+run(
+    "retile_after_clear",
+    RETILE,
+    assign_elementwise64,
+    tile_and_fuse,
+    assign_elementwise,
+    tile_and_fuse,
+)
+
+
+# Non-forall tiling: the elementwise chain tiled with use_forall=False produces
+# two NESTED scf.for loops instead of one scf.forall. Both ops are fused into the
+# innermost loop, and post-fusion clearing must still reach them -- the fusion
+# loop handle covers the whole nest -- so no stale annotations remain anywhere in
+# the loop nest.
+# CHECK-LABEL: Test: elementwise_scf_for_nested_clears
+# CHECK: scf.for
+# CHECK-NOT: transform_ext
+# CHECK: scf.for
+# CHECK-NOT: transform_ext
+# CHECK: math.exp
+# CHECK-NOT: transform_ext
+# CHECK: arith.select
+# CHECK-NOT: transform_ext
+# CHECK: scf.yield
+run("elementwise_scf_for_nested_clears", ELTWISE, assign_elementwise, tile_and_fuse_for)


### PR DESCRIPTION
Completes the IR annotation phase of the Tile'n'Fuse workflow, bridging tile size assignment and the actual tiling step.
Adds schedules that apply the new tiling framework.

Tile-size propagation spreads barrier annotations to the surrounding elementwise subgraph so every op in a group is annotated before tiling begins. Supporting utilities provide fusion-boundary detection and tile-size translation across indexing maps.

Fusion-group analysis identifies one fusion root per group of ops that share a tiling and can be fused in a single tiling step. Roots are returned in program order, primarily targeting greedy producer fusion where each root is tiled and its producers are fused in turn.

Additionally, a utility transform op is added to clear remaining annotations to prepare for next round of tiling.

Assisted-by: Claude