### PR TITLE
[schedule][x86] Generalize pack/unpack lowering

### DIFF
--- a/lighthouse/dialects/transform/transform_ext/__init__.py
+++ b/lighthouse/dialects/transform/transform_ext/__init__.py
@@ -2,7 +2,9 @@ from .dialect import register_and_load
 from .dialect import TransformExtensionDialect
 
 from .ops.wrap_in_benching_func import wrap_in_benching_func
+from .ops.assign_tile_sizes import assign_tile_sizes
 from .ops.get_named_attribute import get_named_attribute
+from .ops.get_tile_sizes import get_tile_sizes
 from .ops.param_cmp_eq import param_cmp_eq
 from .ops.replace import replace
 from .ops.convert_func_results_to_args import convert_func_results_to_args
@@ -12,15 +14,19 @@ from .ops.get_tiling_sizes import get_tiling_sizes
 from .ops.update_address_space import update_address_space
 from .ops.replace_with_fused_attention import replace_with_fused_attention
 from .ops.filter_num_loops import filter_num_loops
+from .ops.get_leading_unit_tile_sizes import get_leading_unit_tile_sizes
 from .ops.move_offsets_to_subview import move_offsets_to_subview
 
 __all__ = [
     "TransformExtensionDialect",
+    "assign_tile_sizes",
     "convert_func_results_to_args",
     "extract_handle",
     "filter_num_loops",
+    "get_leading_unit_tile_sizes",
     "get_named_attribute",
     "get_named_attribute",
+    "get_tile_sizes",
     "get_tileable_consumers",
     "get_tiling_sizes",
     "move_offsets_to_subview",

--- a/lighthouse/pipeline/descriptors/x86_64/amx_bf16/batch_matmul/bf16.yaml
+++ b/lighthouse/pipeline/descriptors/x86_64/amx_bf16/batch_matmul/bf16.yaml
@@ -14,5 +14,4 @@ Pipeline:
                                 fill_tiling=[1]
                                 generic_tiling=[1,1,1,1,8]
                                 2D_generic_tiling=[1,8]
-                                leading_batch_dims=1
                               }

--- a/lighthouse/pipeline/descriptors/x86_64/amx_bf16/matmul/bf16.yaml
+++ b/lighthouse/pipeline/descriptors/x86_64/amx_bf16/matmul/bf16.yaml
@@ -14,5 +14,4 @@ Pipeline:
                                 fill_tiling=[1]
                                 generic_tiling=[1,1,1,8]
                                 2D_generic_tiling=[1,8]
-                                leading_batch_dims=0
                               }

--- a/lighthouse/pipeline/descriptors/x86_64/batch_matmul/f32.yaml
+++ b/lighthouse/pipeline/descriptors/x86_64/batch_matmul/f32.yaml
@@ -14,5 +14,4 @@ Pipeline:
                                 fill_tiling=[1]
                                 generic_tiling=[1,1,1,1,8]
                                 2D_generic_tiling=[1,8]
-                                leading_batch_dims=1
                               }

--- a/lighthouse/pipeline/descriptors/x86_64/matmul-like.yaml
+++ b/lighthouse/pipeline/descriptors/x86_64/matmul-like.yaml
@@ -3,7 +3,6 @@ Pipeline:
   - include: pack-and-tile.yaml {
                                   block_factors=$block_factors
                                   tile_size=$tile_size
-                                  leading_batch_dims=$leading_batch_dims
                                 }
 
   ## CPU specific register tiling (depends on uArch & data type)

--- a/lighthouse/pipeline/descriptors/x86_64/matmul/f32.yaml
+++ b/lighthouse/pipeline/descriptors/x86_64/matmul/f32.yaml
@@ -14,5 +14,4 @@ Pipeline:
                                 fill_tiling=[1]
                                 generic_tiling=[1,1,1,8]
                                 2D_generic_tiling=[1,8]
-                                leading_batch_dims=0
                               }

--- a/lighthouse/pipeline/descriptors/x86_64/pack-and-tile.yaml
+++ b/lighthouse/pipeline/descriptors/x86_64/pack-and-tile.yaml
@@ -4,7 +4,7 @@ Pipeline:
   ## Packing & Cache tiling (CPU generic)
   - pass: "linalg-fuse-elementwise-ops"
   - schedule: "packing.py[gen=block_pack_matmuls]{block_factors=$block_factors rhs_transpose_outer_block=True rhs_transpose_inner_block=False}"
-  - schedule: "x86/pack_lowering.py[gen=lower_packs_unpacks]{tile_size=$tile_size leading_batch_dims=$leading_batch_dims}"
+  - schedule: "x86/pack_lowering.py[gen=lower_packs_unpacks]{tile_size=$tile_size}"
   - pass: "linalg-morph-ops{named-to-category generic-to-category}"
   - schedule: "x86/cache_tiling.py[gen=matmul_cache_tiling]{target=linalg.contract fuse_producers}"
   - schedule: "linalg.py[gen=linalg_contract_fold_unit_dims]"

--- a/lighthouse/schedule/x86/pack_lowering.py
+++ b/lighthouse/schedule/x86/pack_lowering.py
@@ -1,122 +1,105 @@
 from mlir import ir
 from mlir.dialects import transform
 from mlir.dialects.transform import structured
-from mlir.dialects.transform import loop
 from mlir.dialects.transform import vector
 from mlir.dialects.transform import tensor
 
 from lighthouse.schedule import schedule_boilerplate
 from lighthouse import transform as lh_transform
+from lighthouse.dialects.transform import transform_ext
 
 
-def lower_packs_for_vectorization(
-    pack_ops, pack_tile_sizes, vector_tile_sizes=None, vector_unroll_factors=[]
-):
+def _vectorize_innermost(ops):
     """
-    Lower packs into hardware-friendly operations.
+    Tile each op's leading dims into unit loops and vectorize the innermost dim.
+
+    Rank-agnostic: yields N-1 unit sizes for an N-dim op, so the outer dims
+    become loops and the innermost dim is vectorized to a 1-D vector.
 
     Args:
-        pack_ops: Handle to pack operations
-        pack_tile_sizes: Pack sub-tiling sizes
-        vector_tile_sizes: Target vector shapes
-        vector_unroll_factors: Unroll factors for each vector loop.
+        ops: Handle to structured linalg ops (e.g. transposes / copies).
+    """
+    with lh_transform.foreach(ops) as op:
+        sizes = transform_ext.get_leading_unit_tile_sizes(op)
+        # Tiling with scf.forall as scf.for tiling API does not accept a single
+        # handle with all sizes.
+        # Ultimately, the behavior is the same. Leaving it as is for now.
+        tiled = structured.TileUsingForallOp(op, tile_sizes=sizes).tiled_op
+        structured.structured_vectorize(tiled, [])
+        transform.yield_()
+
+
+def lower_packs(pack_ops):
+    """
+    Tile, lower and vectorize pack ops.
+
+    Tiling adapts to arbitrary pack dimensionality.
+    Ops produced by the lowering are vectorized in place.
+
+    Args:
+        pack_ops: Handle to (tile-size annotated) pack operations.
     """
     with lh_transform.foreach(pack_ops) as pack_op:
+        tile_sizes = transform_ext.get_tile_sizes(pack_op)
         tiled_pack = structured.TileUsingForallOp(
-            pack_op, tile_sizes=pack_tile_sizes
+            pack_op, tile_sizes=tile_sizes
         ).tiled_op
-        _, _, transpose = structured.structured_lower_pack(
+        lowered = structured.LowerPackOp(
             transform.OperationType.get("tensor.pad"),
             transform.OperationType.get("tensor.expand_shape"),
             transform.OperationType.get("linalg.transpose"),
             tiled_pack,
-            lower_pad_like_with_insert_slice=False,
+            lowerPadLikeWithInsertSlice=False,
         )
-        if vector_tile_sizes:
-            _, *loops = structured.TileUsingForOp(
-                transpose, sizes=vector_tile_sizes
-            ).results
-            for idx, factor in enumerate(reversed(vector_unroll_factors)):
-                loop.loop_unroll(loops[-1 - idx], factor)
+        _vectorize_innermost(lowered.transpose_op)
         transform.yield_()
 
 
-def lower_unpacks_for_vectorization(
-    unpack_ops, unpack_tile_sizes, vector_tile_sizes=None
-):
+def lower_unpacks(unpack_ops):
     """
-    Lower unpacks into hardware-friendly operations.
+    Tile, lower and vectorize unpack ops.
+
+    Tiling adapts to arbitrary unpack dimensionality.
+    Ops produced by the lowering are vectorized in place.
 
     Args:
-        unpack_ops: Handle to unpack operations
-        unpack_tile_sizes: Unpack sub-tiling sizes
-        vector_tile_sizes: Target vector shapes
+        unpack_ops: Handle to (tile-size annotated) unpack operations.
     """
     with lh_transform.foreach(unpack_ops) as unpack_op:
+        tile_sizes = transform_ext.get_tile_sizes(unpack_op)
         tiled_unpack = structured.TileUsingForallOp(
-            unpack_op, tile_sizes=unpack_tile_sizes
+            unpack_op, tile_sizes=tile_sizes
         ).tiled_op
-        for size in vector_tile_sizes:
-            tiled_unpack = structured.TileUsingForOp(
-                tiled_unpack, sizes=[size]
-            ).tiled_linalg_op
-        structured.structured_lower_unpack(
+        lowered = structured.LowerUnPackOp(
             transform.OperationType.get("tensor.empty"),
             transform.OperationType.get("linalg.transpose"),
             transform.OperationType.get("tensor.collapse_shape"),
             transform.OperationType.get("tensor.extract_slice"),
             transform.OperationType.get("linalg.copy"),
             tiled_unpack,
-            lower_unpad_like_with_extract_slice=True,
+            lowerUnpadLikeWithExtractSlice=True,
         )
+        _vectorize_innermost(lowered.transpose_op)
+        _vectorize_innermost(lowered.copy_op)
         transform.yield_()
 
 
-def lower_packs_unpacks(tile_size: int, leading_batch_dims: int = 0) -> ir.Module:
+def lower_packs_unpacks(tile_size: int = 32) -> ir.Module:
     """
-    Lower pack and unpack ops into hardware-friendly shapes.
+    Lower pack and unpack ops into hardware-friendly, vectorized ops.
 
     Args:
-        tile_size: Target shape for sub-tiling pack and unpack ops' inner tiles
-        leading_batch_dims: Number of leading batch dimensions for extra tiling
+        tile_size: Target size for sub-tiling pack and unpack ops' inner tiles
     Returns:
         Schedule
     """
-    batch_tile_sizes = [1] * leading_batch_dims
     with schedule_boilerplate() as (schedule, named_seq):
-        pack_unpack_vector_m = max(8, tile_size)
-        pack_unpack_vector_n = min(64, tile_size)
         packs = lh_transform.match_op(named_seq.bodyTarget, "linalg.pack")
-        lower_packs_for_vectorization(
-            pack_ops=packs,
-            pack_tile_sizes=batch_tile_sizes + [1, 1],
-            vector_tile_sizes=batch_tile_sizes
-            + [1, 1, pack_unpack_vector_m, pack_unpack_vector_n],
-            vector_unroll_factors=batch_tile_sizes
-            + [tile_size // pack_unpack_vector_n],
-        )
+        lower_packs(transform_ext.assign_tile_sizes(packs, tile_size=tile_size))
         lh_transform.cleanup(named_seq.bodyTarget)
 
         unpacks = lh_transform.match_op(named_seq.bodyTarget, "linalg.unpack")
-        lower_unpacks_for_vectorization(
-            unpack_ops=unpacks,
-            unpack_tile_sizes=batch_tile_sizes + [tile_size, tile_size],
-            vector_tile_sizes=batch_tile_sizes + [1],
-        )
-        transposes = lh_transform.match_op(named_seq.bodyTarget, "linalg.transpose")
-        with lh_transform.foreach(transposes) as tranpose:
-            tranpose = structured.TileUsingForOp(
-                tranpose, sizes=batch_tile_sizes + [1, 1, 1]
-            ).tiled_linalg_op
-            structured.structured_vectorize(tranpose, [])
-            transform.yield_()
-        copies = lh_transform.match_op(named_seq.bodyTarget, "linalg.copy")
-        with lh_transform.foreach(copies) as copy:
-            copy = structured.TileUsingForOp(
-                copy, sizes=batch_tile_sizes + [1]
-            ).tiled_linalg_op
-            structured.structured_vectorize(copy, [])
-            transform.yield_()
+        lower_unpacks(transform_ext.assign_tile_sizes(unpacks, tile_size=tile_size))
 
         # Cleanup.
         with ir.InsertionPoint(

--- a/test/transform/test_pack_lowering.py
+++ b/test/transform/test_pack_lowering.py
@@ -1,0 +1,192 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from mlir import ir
+from mlir.dialects import transform
+
+import lighthouse.dialects as lh_dialects
+from lighthouse import transform as lh_transform
+from lighthouse.dialects.transform import transform_ext
+from lighthouse.schedule.builders import schedule_boilerplate
+from lighthouse.schedule.x86 import lower_packs_unpacks
+
+
+def run(name, payload_str, make_schedule):
+    print(f"Test: {name}", flush=True)
+    with ir.Context(), ir.Location.unknown():
+        lh_dialects.register_and_load(reload=True)
+        payload = ir.Module.parse(payload_str)
+        # Keep the schedule module alive while it is applied.
+        sched = make_schedule()
+        sched.body.operations[0].apply(payload.operation)
+        print(payload)
+
+
+PACK_ASSIGN = """
+module {
+  func.func @main(%a: tensor<128x256xf32>) -> tensor<128x256xf32> {
+    %d = tensor.empty() : tensor<4x8x32x32xf32>
+    %p = linalg.pack %a inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %d
+        : tensor<128x256xf32> -> tensor<4x8x32x32xf32>
+    %o = tensor.empty() : tensor<128x256xf32>
+    %u = linalg.unpack %p inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %o
+        : tensor<4x8x32x32xf32> -> tensor<128x256xf32>
+    return %u : tensor<128x256xf32>
+  }
+}
+"""
+
+PACK_UNPACK_2D = """
+module {
+  func.func @main(%a: tensor<128x256xf32>) -> tensor<128x256xf32> {
+    %d = tensor.empty() : tensor<4x8x32x32xf32>
+    %packed = linalg.pack %a inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %d
+        : tensor<128x256xf32> -> tensor<4x8x32x32xf32>
+    %e = tensor.empty() : tensor<4x8x32x32xf32>
+    %r = linalg.exp ins(%packed : tensor<4x8x32x32xf32>)
+        outs(%e : tensor<4x8x32x32xf32>) -> tensor<4x8x32x32xf32>
+    %o = tensor.empty() : tensor<128x256xf32>
+    %u = linalg.unpack %r inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %o
+        : tensor<4x8x32x32xf32> -> tensor<128x256xf32>
+    return %u : tensor<128x256xf32>
+  }
+}
+"""
+
+# A higher-rank (batched) pack / unpack: the leading batch dim is handled
+# automatically by the per-op tiling.
+PACK_UNPACK_3D = """
+module {
+  func.func @main(%a: tensor<2x128x256xf32>) -> tensor<2x128x256xf32> {
+    %d = tensor.empty() : tensor<2x4x8x32x32xf32>
+    %packed = linalg.pack %a inner_dims_pos = [1, 2] inner_tiles = [32, 32] into %d
+        : tensor<2x128x256xf32> -> tensor<2x4x8x32x32xf32>
+    %e = tensor.empty() : tensor<2x4x8x32x32xf32>
+    %r = linalg.exp ins(%packed : tensor<2x4x8x32x32xf32>)
+        outs(%e : tensor<2x4x8x32x32xf32>) -> tensor<2x4x8x32x32xf32>
+    %o = tensor.empty() : tensor<2x128x256xf32>
+    %u = linalg.unpack %r inner_dims_pos = [1, 2] inner_tiles = [32, 32] into %o
+        : tensor<2x4x8x32x32xf32> -> tensor<2x128x256xf32>
+    return %u : tensor<2x128x256xf32>
+  }
+}
+"""
+
+# Mixed dimensionality in one payload: a 1-D bias pack (1-D -> 2-D) alongside a
+# 2-D matrix pack / unpack (2-D -> 4-D -> 2-D). Exercises the generalization to
+# heterogeneous pack ranks in a single schedule application.
+MIXED = """
+module {
+  func.func @main(%bias: tensor<512xf32>, %mat: tensor<128x1024xf32>)
+        -> (tensor<16x32xf32>, tensor<128x1024xf32>) {
+    %db = tensor.empty() : tensor<16x32xf32>
+    %pbias = linalg.pack %bias inner_dims_pos = [0] inner_tiles = [32] into %db
+        : tensor<512xf32> -> tensor<16x32xf32>
+    %dm = tensor.empty() : tensor<4x32x32x32xf32>
+    %pmat = linalg.pack %mat inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %dm
+        : tensor<128x1024xf32> -> tensor<4x32x32x32xf32>
+    %e = tensor.empty() : tensor<4x32x32x32xf32>
+    %r = linalg.exp ins(%pmat : tensor<4x32x32x32xf32>)
+        outs(%e : tensor<4x32x32x32xf32>) -> tensor<4x32x32x32xf32>
+    %o = tensor.empty() : tensor<128x1024xf32>
+    %u = linalg.unpack %r inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %o
+        : tensor<4x32x32x32xf32> -> tensor<128x1024xf32>
+    return %pbias, %u : tensor<16x32xf32>, tensor<128x1024xf32>
+  }
+}
+"""
+
+# A pack / unpack chain next to ops that are NOT produced by the lowering: an
+# unrelated transpose and the payload copy. Only lowering-produced ops should be
+# vectorized, so both must survive (a blanket re-match would have consumed them).
+UNRELATED_OPS = """
+module {
+  func.func @main(%a: tensor<128x256xf32>, %t: tensor<8x16xf32>)
+        -> (tensor<128x256xf32>, tensor<16x8xf32>) {
+    %te = tensor.empty() : tensor<16x8xf32>
+    %tr = linalg.transpose ins(%t : tensor<8x16xf32>)
+        outs(%te : tensor<16x8xf32>) permutation = [1, 0]
+    %d = tensor.empty() : tensor<4x8x32x32xf32>
+    %packed = linalg.pack %a inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %d
+        : tensor<128x256xf32> -> tensor<4x8x32x32xf32>
+    %e = tensor.empty() : tensor<4x8x32x32xf32>
+    %r = linalg.copy ins(%packed : tensor<4x8x32x32xf32>)
+        outs(%e : tensor<4x8x32x32xf32>) -> tensor<4x8x32x32xf32>
+    %o = tensor.empty() : tensor<128x256xf32>
+    %u = linalg.unpack %r inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %o
+        : tensor<4x8x32x32xf32> -> tensor<128x256xf32>
+    return %u, %tr : tensor<128x256xf32>, tensor<16x8xf32>
+  }
+}
+"""
+
+
+def lower():
+    return lower_packs_unpacks(tile_size=32)
+
+
+def assign_pack_tiles():
+    with schedule_boilerplate() as (sched, named_seq):
+        ops = lh_transform.match_op(
+            named_seq.bodyTarget, ["linalg.pack", "linalg.unpack"]
+        )
+        transform_ext.assign_tile_sizes(ops)
+        transform.yield_()
+    return sched
+
+
+# Tile-size selection: a pack tiles every source dim by 1; an unpack tiles its
+# packed output dims by the inner tile size.
+# CHECK-LABEL: Test: pack_unpack_tile_sizes
+# CHECK: linalg.pack
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 1, 1>
+# CHECK: linalg.unpack
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 32>
+run("pack_unpack_tile_sizes", PACK_ASSIGN, assign_pack_tiles)
+
+
+# A 2-D pack / unpack lowers to 1-D vector transfers. The elementwise op between
+# them is the payload, which the lowering does not produce, so it is left intact.
+# CHECK-LABEL: Test: pack_unpack_2d
+# CHECK-DAG: vector<32xf32>
+# CHECK-DAG: linalg.exp
+# CHECK-NOT: linalg.pack
+# CHECK-NOT: linalg.unpack
+# CHECK-NOT: linalg.transpose
+# CHECK-NOT: linalg.copy
+run("pack_unpack_2d", PACK_UNPACK_2D, lower)
+
+
+# A higher-rank pack / unpack lowers the same way, the batch dim needing no
+# special handling. The payload elementwise op is again preserved.
+# CHECK-LABEL: Test: pack_unpack_3d
+# CHECK-DAG: vector<32xf32>
+# CHECK-DAG: linalg.exp
+# CHECK-NOT: linalg.pack
+# CHECK-NOT: linalg.unpack
+# CHECK-NOT: linalg.transpose
+# CHECK-NOT: linalg.copy
+run("pack_unpack_3d", PACK_UNPACK_3D, lower)
+
+
+# 1-D and 2-D packs in the same payload both lower to 1-D vector transfers, with
+# the payload elementwise op left in place.
+# CHECK-LABEL: Test: mixed
+# CHECK-DAG: vector<32xf32>
+# CHECK-DAG: linalg.exp
+# CHECK-NOT: linalg.pack
+# CHECK-NOT: linalg.unpack
+# CHECK-NOT: linalg.transpose
+# CHECK-NOT: linalg.copy
+run("mixed", MIXED, lower)
+
+
+# Ops not produced by the pack/unpack lowering are left untouched: the unrelated
+# transpose and the payload copy both survive, while pack/unpack are lowered and
+# vectorized. A blanket re-match of transposes/copies would have consumed them.
+# CHECK-LABEL: Test: unrelated_ops_preserved
+# CHECK-DAG: linalg.transpose
+# CHECK-DAG: linalg.copy
+# CHECK-DAG: vector<32xf32>
+# CHECK-NOT: linalg.pack
+# CHECK-NOT: linalg.unpack
+run("unrelated_ops_preserved", UNRELATED_OPS, lower)


### PR DESCRIPTION
Utilizes adaptive tile assignment to make pack/unpack lowering rank agnostic which makes the schedule easier to use and applicable in more kernel motifs.

Pipeline descriptors using pack lowering are simplified accordingly.

Assisted-by: Claude