### PR TITLE
Bump MLIR bindings

### DIFF
--- a/lighthouse/dialects/dialect_base.py
+++ b/lighthouse/dialects/dialect_base.py
@@ -26,7 +26,7 @@ class DialectExtension(ext.Dialect, name="base_extension"):
         try:
             super().load(*args, **kwargs)
         except ext.DialectAlreadyLoadedError:
-            pass
+            return
 
         # Attach interfaces to just registered/loaded operations.
         for op_cls in cls.operations:

--- a/lighthouse/dialects/dialect_base.py
+++ b/lighthouse/dialects/dialect_base.py
@@ -1,6 +1,3 @@
-import weakref
-
-from mlir import ir
 from mlir.dialects import ext
 
 
@@ -26,34 +23,10 @@ class DialectExtension(ext.Dialect, name="base_extension"):
           dialect stays loaded in every context it was loaded into.
         - Never loaded: perform a fresh load.
         """
-        # Per-subclass registry of the contexts this dialect is loaded in. A
-        # single "last context" is insufficient: a dialect stays loaded in every
-        # context it was loaded into, so interleaving contexts requires tracking
-        # all of them. Contexts are held weakly so they remain garbage
-        # collectable.
-        #
-        # FIXME: It is a workaround to simplify dialect loading.
-        #        Ideally, the `ext.Dialect` base class would handle this automatically.
-        #        See issue: #229
-        loaded_contexts = cls.__dict__.get("_loaded_contexts")
-        if loaded_contexts is None:
-            loaded_contexts = weakref.WeakSet()
-            cls._loaded_contexts = loaded_contexts
-
-        current = ir.Context.current
-        if current in loaded_contexts:
-            # Already present in this context; MLIR cannot load it again here.
-            return
-
-        # If the dialect was loaded before (in any context), its process-global,
-        # context-independent registrations already exist and must be replaced
-        # rather than added again.
-        globals_registered = hasattr(cls, "_mlir_module")
-
-        # Registers the dialect and its op classes and loads them into the context.
-        kwargs["reload"] = globals_registered
-        super().load(*args, **kwargs)
-        loaded_contexts.add(current)
+        try:
+            super().load(*args, **kwargs)
+        except ext.DialectAlreadyLoadedError:
+            pass
 
         # Attach interfaces to just registered/loaded operations.
         for op_cls in cls.operations:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "lighthouse"
 dynamic = ["version"]
 requires-python = ">=3.10,<3.13"  # Bounds are due to torch-mlir's packaging
 dependencies = [
-    "mlir-python-bindings==20260722+373df745f",
+    "mlir-python-bindings==20260728+5e91f5d57",
     "pyyaml>=6.0",
 ]
 

--- a/test/dialects/dialect_loading.py
+++ b/test/dialects/dialect_loading.py
@@ -139,19 +139,5 @@ def test_registry_holds_contexts_weakly():
     print("reload after gc ok:", ctx_c.is_registered_operation(PROBE_OP), flush=True)
 
 
-# CHECK-LABEL: Test: test_explicit_reload_flag_is_safe
-@run
-def test_explicit_reload_flag_is_safe():
-    """Passing reload=True must never abort, even in an already-loaded context."""
-    ctx = ir.Context()
-    with ctx:
-        lh_dialects.register_and_load()
-        # Explicit reload in the same context cannot re-load into MLIR and must
-        # be handled gracefully rather than asserting.
-        lh_dialects.register_and_load(reload=True)
-    # CHECK: explicit reload ok: True
-    print("explicit reload ok:", ctx.is_registered_operation(PROBE_OP), flush=True)
-
-
 # CHECK: All dialect loading tests passed
 print("All dialect loading tests passed", flush=True)

--- a/test/dialects/transform_ext.py
+++ b/test/dialects/transform_ext.py
@@ -12,9 +12,7 @@ from lighthouse.dialects.transform import transform_ext
 def run(f):
     print("Test: ", f.__name__, flush=True)
     with ir.Context(), ir.Location.unknown():
-        lh_dialects.register_and_load(
-            reload=True
-        )  # reload across @run-s to ensure interfaces are registered for new contexts
+        lh_dialects.register_and_load()
 
         mod = ir.Module.create()
         mod.operation.attributes["transform.with_named_sequence"] = ir.UnitAttr.get()

--- a/test/dialects/transform_ext_subview.py
+++ b/test/dialects/transform_ext_subview.py
@@ -13,9 +13,7 @@ def run(payload_fn):
     def decorator(f):
         print("Test: ", f.__name__, flush=True)
         with ir.Context(), ir.Location.unknown():
-            lh_dialects.register_and_load(
-                reload=True
-            )  # reload across @run-s to ensure interfaces are registered for new contexts
+            lh_dialects.register_and_load()
 
             mod = ir.Module.create()
             mod.operation.attributes["transform.with_named_sequence"] = (

--- a/test/transform/test_pack_lowering.py
+++ b/test/transform/test_pack_lowering.py
@@ -13,7 +13,7 @@ from lighthouse.schedule.x86 import lower_packs_unpacks
 def run(name, payload_str, make_schedule):
     print(f"Test: {name}", flush=True)
     with ir.Context(), ir.Location.unknown():
-        lh_dialects.register_and_load(reload=True)
+        lh_dialects.register_and_load()
         payload = ir.Module.parse(payload_str)
         # Keep the schedule module alive while it is applied.
         sched = make_schedule()

--- a/test/transform/test_tile_size_ops.py
+++ b/test/transform/test_tile_size_ops.py
@@ -15,7 +15,7 @@ from lighthouse.schedule.builders import schedule_boilerplate
 def run(name, payload_str, build_schedule):
     print(f"Test: {name}", flush=True)
     with ir.Context(), ir.Location.unknown():
-        lh_dialects.register_and_load(reload=True)
+        lh_dialects.register_and_load()
         payload = ir.Module.parse(payload_str)
         sched = build_schedule()
         sched.body.operations[0].apply(payload.operation)


### PR DESCRIPTION
Removes local changes to dynamic dialect loader.
Reloading dialects is now handled in upstream dialect logic directly.

Fixes #229