### PR TITLE
[Ingress] Add pytorch hub importer

### DIFF
--- a/examples/ingress/torch/hub_load.py
+++ b/examples/ingress/torch/hub_load.py
@@ -3,12 +3,10 @@
 """
 Example demonstrating how to load any Hugging Face model to MLIR using Lighthouse
 without initializing the model class on the user's side.
-
-The script loads the model with 'transformers.AutoModel', then uses
-'lighthouse.ingress.torch.import_from_model'.
 """
 
 import argparse
+import sys
 from transformers import AutoModel
 from lighthouse.ingress.torch import import_from_model
 
@@ -39,8 +37,6 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    print(f"Loading model from Hugging Face: {args.model}")
+    print(f"Loading model from Hugging Face: {args.model}", file=sys.stderr)
     mlir_module = load_from_hf(args.model)
-    print(f"Loaded MLIR module for model: {args.model}")
-    print("\n\nModule dump:")
     print(mlir_module)

--- a/examples/ingress/torch/hub_load.py
+++ b/examples/ingress/torch/hub_load.py
@@ -1,0 +1,46 @@
+# RUN: %PYTHON %s > /dev/null
+
+"""
+Example demonstrating how to load any Hugging Face model to MLIR using Lighthouse
+without initializing the model class on the user's side.
+
+The script loads the model with 'transformers.AutoModel', then uses
+'lighthouse.ingress.torch.import_from_model'.
+"""
+
+import argparse
+from transformers import AutoModel
+from lighthouse.ingress.torch import import_from_model
+
+
+def load_from_hf(model_name: str) -> str:
+    model = AutoModel.from_pretrained(model_name)
+    model.eval()
+    # Exporting to a static graph: drop the KV cache so the output is plain tensors.
+    if hasattr(model.config, "use_cache"):
+        model.config.use_cache = False
+    # torch-mlir's importer requires every buffer in the state dict, but Hugging
+    # Face registers some (e.g. 'position_ids') as non-persistent; make them all
+    # persistent so they can be mapped.
+    for submodule in model.modules():
+        submodule._non_persistent_buffers_set.clear()
+    # Each model exposes correctly-typed example inputs, so no per-model handling.
+    return import_from_model(model, sample_args=(), sample_kwargs=model.dummy_inputs)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="hf-internal-testing/tiny-random-BertModel",
+        help="Hugging Face model id (e.g. 'google-bert/bert-base-uncased').",
+    )
+    args = parser.parse_args()
+
+    print(f"Loading model from Hugging Face: {args.model}")
+    mlir_module = load_from_hf(args.model)
+    print(f"Loaded MLIR module for model: {args.model}")
+    print("\n\nModule dump:")
+    print(mlir_module)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
 ingress_torch_mlir = [
     "torch-mlir==20260805.836",
     "ml_dtypes",
+    "transformers",
 ]
 # Additional "targets" which pull in optional dependencies -- use `uv sync --extra TARGET`
 ingress_torch_cpu = [


### PR DESCRIPTION
Add a huggingface HUB importer using transformers.AutoModels [1], avoiding having to track shapes, arguments, etc. The tool prints out MLIR.

[1] https://huggingface.co/transformers/v3.0.2/model_doc/auto.html

Assisted by: Copilot