### PR TITLE
[infra] Host target detection and general tweaks

### DIFF
--- a/examples/KernelBench/test-kernel-bench.py
+++ b/examples/KernelBench/test-kernel-bench.py
@@ -1,7 +1,8 @@
-# RUN: python %s --ci | FileCheck %s
-# RUN: python %s --ci --no-torch-compile | FileCheck %s
+# RUN: %PYTHON %s --ci | FileCheck %s
+# RUN: %PYTHON %s --ci --no-torch-compile | FileCheck %s
 
 # REQUIRES: torch
+# REQUIRES: torch_mlir
 # REQUIRES: kernel_bench
 
 import argparse
@@ -10,12 +11,17 @@ import subprocess
 from pathlib import Path
 
 import yaml
+import sys
 
 from lighthouse.execution.target import TargetInfo
 from lighthouse.pipeline import find_pipeline_file
 
-script_path = Path(__file__).parent
+script_path = Path(__file__).resolve().parent
 project_root = script_path.parent.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+
 kb_program = project_root / "tools" / "kernel-bench"
 kb_path = project_root / "third_party" / "KernelBench" / "KernelBench"
 yaml_files = [
@@ -165,6 +171,7 @@ if __name__ == "__main__":
         command_line = []
 
         command_line += [
+            sys.executable,
             str(kb_program),
             str(kb_kernel),
             "--dtype",

--- a/lighthouse/execution/runner.py
+++ b/lighthouse/execution/runner.py
@@ -55,7 +55,7 @@ class Runner:
         target: TargetInfo = None,
     ):
         self.payload = module
-        self.target = target if target else TargetInfo()
+        self.target = target if target else TargetInfo.host()
         self.mem_manager_cls = mem_manager_cls
         if shared_libs is None:
             shared_libs = []

--- a/lighthouse/execution/target.py
+++ b/lighthouse/execution/target.py
@@ -1,5 +1,13 @@
 import platform
 import subprocess
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RegisterInfo:
+    width_bits: int
+    count: int
 
 
 class TargetInfo:
@@ -14,17 +22,63 @@ class TargetInfo:
         filter (list[str]): The list of allowed features, if any (subset of `features`).
     """
 
+    _cached_host: "TargetInfo | None" = None
+    _override_features_stack: list[list[str] | None] = []
+    _override_arch_stack: list[str | None] = []
+
     def __init__(
         self,
         arch: str | None = None,
         features: list[str] | None = None,
         filter: list[str] | None = None,
     ):
+        if arch is None and self.__class__._override_arch_stack:
+            arch = self.__class__._override_arch_stack[-1]
+        if features is None and self.__class__._override_features_stack:
+            override = self.__class__._override_features_stack[-1]
+            if override is not None:
+                features = list(override)
+
         self.arch = arch if arch is not None else platform.machine()
         self.features = features if features is not None else self._get_feature_list()
         # Pre-filter, if requested.
         if filter is not None:
             self.features = self.has_features(filter)
+
+    @classmethod
+    def host(cls) -> "TargetInfo":
+        """Return a cached host TargetInfo honoring active test overrides."""
+        if cls._override_features_stack or cls._override_arch_stack:
+            return cls()
+        if cls._cached_host is None:
+            cls._cached_host = cls()
+        return cls._cached_host
+
+    @classmethod
+    def reset_host_cache(cls) -> None:
+        """Clear cached host target information."""
+        cls._cached_host = None
+
+    @classmethod
+    @contextmanager
+    def override(
+        cls,
+        *,
+        features: list[str] | None = None,
+        arch: str | None = None,
+    ):
+        """Temporarily override auto-detected host target info for tests."""
+        cls._override_features_stack.append(
+            None if features is None else list(features)
+        )
+        cls._override_arch_stack.append(arch)
+        cls.reset_host_cache()
+        try:
+            yield
+        finally:
+            cls._override_features_stack.pop()
+            cls._override_arch_stack.pop()
+            cls.reset_host_cache()
 
     def _get_feature_list(self) -> list[str]:
         """Get features from lscpu program"""
@@ -59,3 +113,20 @@ class TargetInfo:
         """
         hw_extension = hw_extension.lower()
         return any(feature.startswith(hw_extension) for feature in self.features)
+
+    def vector_register_info(self) -> RegisterInfo | None:
+        """Infer SIMD register info from target features."""
+        if "avx512f" in self.features:
+            return RegisterInfo(width_bits=512, count=32)
+        if "avx2" in self.features or "avx" in self.features:
+            return RegisterInfo(width_bits=256, count=16)
+        if any(feature.startswith("sse") for feature in self.features):
+            return RegisterInfo(width_bits=128, count=16)
+        return None
+
+    @property
+    def vector_register_width_bits(self) -> int | None:
+        info = self.vector_register_info()
+        if info is None:
+            return None
+        return info.width_bits

--- a/lit.cfg.py
+++ b/lit.cfg.py
@@ -3,6 +3,7 @@ import shlex
 import importlib.util
 import shutil
 import platform
+import sys
 
 import lit.formats
 from lit.TestingConfig import TestingConfig
@@ -46,7 +47,7 @@ config.substitutions.append(("FileCheck", find_filecheck()))
 config.substitutions.append(("%TEST", project_root + "/test"))
 config.substitutions.append(("%CACHE", project_root + "/cache"))
 config.substitutions.append(("%VIRTUAL_ENV", os.environ.get("VIRTUAL_ENV", "")))
-python = os.environ.get("PYTHON", "python")
+python = os.environ.get("PYTHON", sys.executable)
 config.substitutions.append(("%PYTHON", python))
 if pythonpath := os.environ.get("PYTHONPATH"):
     config.substitutions[-1] = (
@@ -61,7 +62,7 @@ for tool_dir, _, files in os.walk(project_root + "/tools"):
             config.substitutions.append((file, tool_path))
 
 # Set available features based on the presence of Python packages and git submodules.
-for pkg in ["torch", "mpi4py", "mpich", "impi-rt"]:
+for pkg in ["torch", "torch_mlir", "mpi4py", "mpich", "impi-rt"]:
     if importlib.util.find_spec(pkg):
         config.available_features.add(pkg)
 

--- a/test/execution/target_info_host_override.py
+++ b/test/execution/target_info_host_override.py
@@ -1,0 +1,69 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from lighthouse.execution.target import TargetInfo
+
+
+TargetInfo.reset_host_cache()
+host_before_overrides = TargetInfo.host()
+
+source_features = ["amx_tile"]
+with TargetInfo.override(features=source_features, arch="x86_64"):
+    # Mutating the caller list after entering the context should not affect
+    # the active override (it must snapshot/copy features on entry).
+    source_features.append("unexpected")
+    overridden_first = TargetInfo.host()
+    overridden_second = TargetInfo.host()
+    print(
+        "override_values="
+        f"{overridden_first.arch} "
+        f"{','.join(overridden_first.features)} "
+        f"same_obj={overridden_first is overridden_second}"
+    )
+    # Override should apply explicit arch/features and return fresh host objects.
+    # CHECK: override_values=x86_64 amx_tile same_obj=False
+
+    with TargetInfo.override(features=["avx2"], arch="aarch64"):
+        nested = TargetInfo.host()
+        print(f"nested_values={nested.arch} {','.join(nested.features)}")
+        # Inner override should take precedence over outer override.
+        # CHECK: nested_values=aarch64 avx2
+
+    restored = TargetInfo.host()
+    print(f"outer_restored={restored.arch} {','.join(restored.features)}")
+    # After inner override exits, outer override values should be restored.
+    # CHECK: outer_restored=x86_64 amx_tile
+
+with TargetInfo.override(features=["sse4_2"], arch="x86_64"):
+    fresh = TargetInfo.host()
+    print(f"fresh_override_values={fresh.arch} {','.join(fresh.features)}")
+    # A new override scope should be independent and use its own explicit values.
+    # CHECK: fresh_override_values=x86_64 sse4_2
+
+# Partial override with features only should keep host arch.
+with TargetInfo.override(features=["avx512f"]):
+    features_only = TargetInfo.host()
+    print(
+        "features_only="
+        f"arch_same={features_only.arch == host_before_overrides.arch} "
+        f"features={','.join(features_only.features)}"
+    )
+    # CHECK: features_only=arch_same=True features=avx512f
+
+# Partial override with arch only should keep host features.
+with TargetInfo.override(arch="x86_64"):
+    arch_only = TargetInfo.host()
+    print(
+        "arch_only="
+        f"arch={arch_only.arch} "
+        f"features_same={arch_only.features == host_before_overrides.features}"
+    )
+    # CHECK: arch_only=arch=x86_64 features_same=True
+
+host_after_overrides = TargetInfo.host()
+same_info = (
+    host_before_overrides.arch == host_after_overrides.arch
+    and host_before_overrides.features == host_after_overrides.features
+)
+print(f"before_after_same_info={same_info}")
+# Override scopes should not permanently change host arch/features.
+# CHECK: before_after_same_info=True

--- a/test/transform/test_filter_num_loops.py
+++ b/test/transform/test_filter_num_loops.py
@@ -1,0 +1,63 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from mlir import ir
+from mlir.dialects import transform
+from mlir.dialects.transform import structured
+
+import lighthouse.dialects as lh_dialects
+from lighthouse import transform as lh_transform
+from lighthouse.dialects.transform import transform_ext
+from lighthouse.schedule.builders import schedule_boilerplate
+
+
+def apply_filter(payload: str, num_loops: int, name: str):
+    with ir.Context(), ir.Location.unknown():
+        lh_dialects.register_and_load()
+        module = ir.Module.parse(payload)
+        with schedule_boilerplate() as (sched, named_seq):
+            candidates = lh_transform.match_op(
+                named_seq.bodyTarget, structured.MatchInterfaceEnum.LinalgOp
+            )
+            filtered = transform_ext.filter_num_loops(
+                candidates,
+                num_loops,
+            )
+            transform.print_(target=filtered, name=name)
+            transform.yield_()
+        sched.body.operations[0].apply(module.operation)
+
+
+PAYLOAD = """
+#id = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(
+      %a: tensor<64xf32>,
+      %b: tensor<8x8xf32>,
+      %x: tensor<2x4x8xf32>,
+      %y: tensor<2x8x4xf32>) -> (tensor<64xf32>, tensor<8x8xf32>, tensor<2x4x4xf32>) {
+    %e1 = tensor.empty() : tensor<64xf32>
+    %add = linalg.add ins(%a, %a : tensor<64xf32>, tensor<64xf32>)
+        outs(%e1 : tensor<64xf32>) -> tensor<64xf32>
+
+    %e2 = tensor.empty() : tensor<8x8xf32>
+    %gen = linalg.generic {indexing_maps = [#id, #id], iterator_types = ["parallel", "parallel"]}
+        ins(%b : tensor<8x8xf32>)
+        outs(%e2 : tensor<8x8xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      linalg.yield %i : f32
+    } -> tensor<8x8xf32>
+
+    %e3 = tensor.empty() : tensor<2x4x4xf32>
+    %bm = linalg.batch_matmul ins(%x, %y : tensor<2x4x8xf32>, tensor<2x8x4xf32>)
+        outs(%e3 : tensor<2x4x4xf32>) -> tensor<2x4x4xf32>
+    return %add, %gen, %bm : tensor<64xf32>, tensor<8x8xf32>, tensor<2x4x4xf32>
+  }
+}
+"""
+
+
+# CHECK-LABEL: IR printer: AT_LEAST_2
+# CHECK: linalg.generic
+# CHECK: linalg.batch_matmul
+# CHECK-NOT: linalg.add
+apply_filter(PAYLOAD, num_loops=2, name="AT_LEAST_2")


### PR DESCRIPTION
General infrastructure improvements:
- Adds host target information helpers and allows temporary overriding for testing.
- Improves lit test python finder to make test execution more robust.
- Adds basic test coverage for filter_num_loops op.

Assisted-by: Claude