### PR TITLE
Add schedule parameters

### DIFF
--- a/examples/xegpu/kernel_bench.py
+++ b/examples/xegpu/kernel_bench.py
@@ -52,7 +52,6 @@ import warnings
 import torch
 import torch._dynamo as dynamo
 import os
-import json
 import numpy as np
 from mlir import ir
 
@@ -62,6 +61,7 @@ from lighthouse import dialects as lh_dialects
 from lighthouse.utils.mlir import inspect_payload
 from lighthouse.execution.runner import Runner
 from lighthouse.schedule.xegpu import XeGPUParameterSelector
+from lighthouse.schedule.parameters import ScheduleParameters
 from lighthouse.pipeline.driver import TransformDriver
 from lighthouse.schedule.xegpu import (
     mlp_schedule,
@@ -72,9 +72,16 @@ from lighthouse.schedule.xegpu import (
 from lighthouse.pipeline.helper import PipelineInterrupt
 from lighthouse.ingress.torch import gpu_backend, TargetDialect
 from lighthouse.ingress.torch.compile import TorchMemoryManager
-from tune_matmul_costmodel import optimize_payload, dump_configs_json
+from tune_matmul_costmodel import optimize_payload
 from tune_utils import run_with_timeout
 from csv_logger import CSVLogger
+
+
+def dtype_to_torch_dtype(datatype: str) -> torch.dtype:
+    return {
+        "f16": torch.float16,
+        "bf16": torch.bfloat16,
+    }[datatype]
 
 
 def inspect_kb_payload(module: ir.Module) -> tuple[str, dict]:
@@ -90,14 +97,16 @@ def inspect_kb_payload(module: ir.Module) -> tuple[str, dict]:
     return payload_func_name, func_metadata
 
 
-def infer_parameters(mod: ir.Module, verbose: int = 0) -> tuple[dict, str, list[dict]]:
+def infer_parameters(
+    mod: ir.Module, verbose: int = 0
+) -> tuple[dict, str, ScheduleParameters]:
     """
     Inspects payload and selects lowering schedule and tile size parameters.
 
     Returns:
         func_metadata: Payload function metadata dict.
         schedule kind: Name of selected lowering schedule.
-        schedule_parameters: List of parameter dicts, one per layer.
+        schedule_parameters: ScheduleParameters for the lowering schedule.
     """
     payload_func_name, func_metadata = inspect_kb_payload(mod)
     if verbose > 0:
@@ -155,6 +164,7 @@ def infer_parameters(mod: ir.Module, verbose: int = 0) -> tuple[dict, str, list[
 
         # Use fixed tile sizes for now
         layer_params = {
+            "layer_kind": "elemwise",
             "wg_m": 128,
             "wg_n": 256,
             "sg_m": 32,
@@ -163,7 +173,7 @@ def infer_parameters(mod: ir.Module, verbose: int = 0) -> tuple[dict, str, list[
             "load_n": 16,
         }
         # NOTE assume all elemwise layers will be fused to a single layer
-        schedule_params = [layer_params]
+        schedule_params = ScheduleParameters([layer_params])
         schedule_kind = "elemwise"
     elif len(elemwise) > 0 and len(reduction) > 0:
         # elemwise + reduction kernel, e.g. softmax or layer norm
@@ -176,7 +186,7 @@ def infer_parameters(mod: ir.Module, verbose: int = 0) -> tuple[dict, str, list[
         write_bytes = int(np.prod(shape)) * res_bytes
 
         layer_params = {
-            "sizes": shape,
+            "layer_kind": "reduction",
             "wg_rows": 64,
             "sg_rows": 8,
             "subgroup_size": 16,
@@ -193,7 +203,7 @@ def infer_parameters(mod: ir.Module, verbose: int = 0) -> tuple[dict, str, list[
             raise ValueError(
                 f"Shape {shape} dimension 1 not divisible by reduction_step_size={layer_params['reduction_step_size']}"
             )
-        schedule_params = [layer_params]
+        schedule_params = ScheduleParameters([layer_params])
         schedule_kind = "reduction"
     else:
         print("Layers:")
@@ -278,7 +288,8 @@ def tune_matmul_layer(
         final_mod = lower_to_llvm(
             copy_module(mod),
             schedule_kind="mlp",
-            schedule_params=[kwparams],
+            schedule_params=ScheduleParameters([kwparams]),
+            device="B70",
             stop_at_stage=None,
             benchmark=True,
             payload_func_name=payload_func_name,
@@ -364,27 +375,31 @@ def infer_params_and_lower(
         # runtime tuning for matmul kernels
         if os.path.isfile(params_cache_json):
             print(f"Loading cached parameters from {params_cache_json}")
-            with open(params_cache_json) as f:
-                params_dict = json.load(f)
-            schedule_params = [params_dict]
+            schedule_params = ScheduleParameters.from_json(filename=params_cache_json)
         else:
             print(f"Tuning parameters and saving to {params_cache_json}")
+            # construct a buffer for kernel result
+            res_type = kernel_metadata["inputs"][-1]  # result is last input
+            shape = res_type.shape
+            dtype = dtype_to_torch_dtype(str(res_type.element_type))
+            res_buffer = torch.zeros(shape, dtype=dtype).to("xpu")
+            kernel_inputs = [*torch_all_inputs, res_buffer]
             # tune matmul parameters
             configs = tune_matmul_layer(
                 matmuls[0],
                 mod,
                 payload_func_name,
-                torch_all_inputs,
+                kernel_inputs,
                 func_metadata["total_flops"],
                 func_metadata["read_bytes"],
                 func_metadata["write_bytes"],
             )
-            schedule_params = [configs[0][1]]
-            dump_configs_json(
-                schedule_params[0], filename_prefix=params_cache_json.rsplit(".", 1)[0]
-            )
+            schedule_params = ScheduleParameters([configs[0][1]])
+            schedule_params.to_json(filename=params_cache_json, overwrite=True)
     else:
         print(f"Using default parameters for {schedule_kind} schedule")
+        print(f"Saving applied parameters to {params_cache_json}")
+        schedule_params.to_json(filename=params_cache_json, overwrite=True)
 
     if verbose > 2:
         print("Payload module before lowering:")
@@ -392,7 +407,9 @@ def infer_params_and_lower(
     if verbose > 1:
         print(f"Applying '{schedule_kind}' schedule with params:")
         param_list = (
-            schedule_params if isinstance(schedule_params, list) else [schedule_params]
+            schedule_params
+            if isinstance(schedule_params, (list, ScheduleParameters))
+            else [schedule_params]
         )
         for i, param_dict in enumerate(param_list):
             print(f" Parameters for layer {i}:")
@@ -403,6 +420,7 @@ def infer_params_and_lower(
         mod=mod,
         schedule_kind=schedule_kind,
         schedule_params=schedule_params,
+        device="B70" if schedule_kind == "mlp" else None,
         stop_at_stage=stop_at_stage,
         benchmark=benchmark,
         payload_func_name=payload_func_name,
@@ -421,7 +439,8 @@ def infer_params_and_lower(
 def lower_to_llvm(
     mod: ir.Module,
     schedule_kind: str,
-    schedule_params: list[dict],
+    schedule_params: ScheduleParameters,
+    device: str | None,
     stop_at_stage: str | None,
     benchmark: bool,
     payload_func_name: str,
@@ -432,6 +451,7 @@ def lower_to_llvm(
         schedule = mlp_schedule(
             params=schedule_params,
             payload_func_name=payload_func_name,
+            device=device,
             stop_at_stage=stop_at_stage,
         )
     elif schedule_kind == "elemwise":
@@ -441,9 +461,8 @@ def lower_to_llvm(
             stop_at_stage=stop_at_stage,
         )
     elif schedule_kind == "reduction":
-        layer_params = schedule_params[0]
         schedule = reduction_schedule(
-            parameters=layer_params,
+            params=schedule_params,
             payload_func_name=payload_func_name,
             stop_at_stage=stop_at_stage,
         )
@@ -495,10 +514,7 @@ def lower_and_execute_benchmark(
         A dictionary containing benchmark performance metrics.
     """
     assert datatype in ["f16", "bf16"], "Unsupported datatype"
-    model_dtype = {
-        "f16": torch.float16,
-        "bf16": torch.bfloat16,
-    }[datatype]
+    model_dtype = dtype_to_torch_dtype(datatype)
     execute = stop_at_stage is None
 
     # import torch model
@@ -527,7 +543,6 @@ def lower_and_execute_benchmark(
         with torch.no_grad():
             torch_model = torch_model.to("xpu")
             result_ref = torch_model(*torch_inputs).to("cpu")
-        torch.xpu.synchronize()
 
     # compile and execute the model with the MLIR backend
     torch_all_inputs = [*torch_model.parameters(), *torch_inputs]

--- a/examples/xegpu/layer_norm.py
+++ b/examples/xegpu/layer_norm.py
@@ -20,6 +20,7 @@ from lighthouse.ingress.mlir_gen import get_mlir_elem_type
 from lighthouse.ingress.mlir_gen.gpu_layer_norm_payload import (
     generate_gpu_layer_norm_payload,
 )
+from lighthouse.schedule.parameters import ScheduleParameters
 from lighthouse.schedule.xegpu import reduction_schedule, xegpu_to_binary
 
 
@@ -134,7 +135,9 @@ class XeGPULayerNorm:
         return mod
 
     def schedule_modules(
-        self, stop_at_stage: str | None = None, parameters: dict | None = None
+        self,
+        stop_at_stage: str | None = None,
+        parameters: ScheduleParameters | None = None,
     ) -> list[ir.Module]:
         """Generate transform schedule for layer_norm."""
         schedules = []
@@ -144,7 +147,7 @@ class XeGPULayerNorm:
             reduction_schedule(
                 payload_func_name=self.payload_function_name,
                 stop_at_stage=stop_at_stage,
-                parameters=parameters,
+                params=parameters,
             )
         )
 
@@ -253,13 +256,18 @@ def parse_cli():
 if __name__ == "__main__":
     args = parse_cli()
 
-    params = {
-        "sizes": args.sizes,
-        "wg_rows": args.wg_rows,
-        "sg_rows": args.sg_rows,
-        "subgroup_size": args.subgroup_size,
-        "reduction_step_size": args.reduction_step_size,
-    }
+    params = ScheduleParameters(
+        [
+            {
+                "layer_kind": "reduction",
+                "sizes": args.sizes,
+                "wg_rows": args.wg_rows,
+                "sg_rows": args.sg_rows,
+                "subgroup_size": args.subgroup_size,
+                "reduction_step_size": args.reduction_step_size,
+            }
+        ]
+    )
 
     M, N = args.sizes
     dtype = "f32"

--- a/examples/xegpu/matmul.py
+++ b/examples/xegpu/matmul.py
@@ -17,7 +17,6 @@ XeGPU matrix multiplication example.
 """
 
 import argparse
-import json
 import warnings
 from dataclasses import dataclass, field
 from typing import ClassVar
@@ -36,6 +35,7 @@ from lighthouse.schedule.xegpu import mlp_schedule, xegpu_to_binary
 from lighthouse.utils.numpy import mlir_to_numpy_dtype
 from lighthouse.ingress.mlir_gen import generate_gpu_matmul_payload, get_mlir_elem_type
 from lighthouse.schedule.xegpu import XeGPUParameterSelector
+from lighthouse.schedule.parameters import ScheduleParameters
 
 
 def matmul_complexity(
@@ -201,7 +201,10 @@ class XeGPUMatMul:
         return mod
 
     def schedule_modules(
-        self, stop_at_stage: str | None = None, parameters: dict | None = None
+        self,
+        stop_at_stage: str | None = None,
+        parameters: ScheduleParameters | None = None,
+        device: str | None = None,
     ) -> list[ir.Module]:
         assert parameters is not None, "Schedule parameters must be provided"
         schedules = []
@@ -210,8 +213,9 @@ class XeGPUMatMul:
         schedules.append(
             mlp_schedule(
                 payload_func_name=self.payload_function_name,
+                device=device,
                 stop_at_stage=stop_at_stage,
-                params=[parameters],
+                params=parameters,
             )
         )
 
@@ -464,13 +468,18 @@ enabled via CLI arguments.
     transpose_b = args.transpose_b
 
     # Set required parameters
-    params = {
-        "m": m,
-        "n": n,
-        "k": k,
-        "transpose_a": transpose_a,
-        "transpose_b": transpose_b,
-    }
+    params = ScheduleParameters(
+        [
+            {
+                "layer_kind": "matmul",
+                "m": m,
+                "n": n,
+                "k": k,
+                "transpose_a": transpose_a,
+                "transpose_b": transpose_b,
+            }
+        ]
+    )
 
     # Collect parameters from CLI arguments
     cli_params = {}
@@ -494,31 +503,31 @@ enabled via CLI arguments.
         cli_params["prefetch_b_nb"] = args.prefetch_b_nb
 
     # By default the tile size parameters are left undefined
+    layer_params = params[0]
     if args.json:
         # Override parameters with values from JSON file if provided
-        with open(args.json) as f:
-            json_params = json.load(f)
-        params.update(json_params)
+        json_params = ScheduleParameters.from_json(args.json)
+        layer_params.update(json_params[0] if json_params else {})
         # Override with CLI params
-        params.update(cli_params)
+        layer_params.update(cli_params)
     elif cli_params:
         # Get default parameters from selector
         param_selector = XeGPUParameterSelector(device=args.target)
         def_params = param_selector.get_parameters((m, n, k), transpose_a, transpose_b)
-        params.update(def_params)
+        layer_params.update(def_params[0])
         # Override with CLI params
-        params.update(cli_params)
+        layer_params.update(cli_params)
 
     with ir.Context(), ir.Location.unknown():
         lh_dialects.register_and_load()
 
         wload = XeGPUMatMul(
-            M=params["m"],
-            N=params["n"],
-            K=params["k"],
+            M=m,
+            N=n,
+            K=k,
             ab_type=args.ab_type,
-            transpose_a=params["transpose_a"],
-            transpose_b=params["transpose_b"],
+            transpose_a=transpose_a,
+            transpose_b=transpose_b,
             has_bias=args.bias,
             has_relu=args.relu,
             accumulate_c=not args.no_accumulate_c,
@@ -537,16 +546,22 @@ enabled via CLI arguments.
             if args.dump_kernel:
                 pipeline = TransformDriver(
                     wload.schedule_modules(
-                        stop_at_stage=args.dump_kernel, parameters=params
+                        stop_at_stage=args.dump_kernel,
+                        parameters=params,
+                        device=args.target,
                     )
                 )
                 payload = pipeline.apply(wload.payload_module())
                 print(payload)
             if args.dump_schedule:
-                for schedule_module in wload.schedule_modules(parameters=params):
+                for schedule_module in wload.schedule_modules(
+                    parameters=params, device=args.target
+                ):
                     print(schedule_module)
         else:
-            pipeline = TransformDriver(wload.schedule_modules(parameters=params))
+            pipeline = TransformDriver(
+                wload.schedule_modules(parameters=params, device=args.target)
+            )
             payload = pipeline.apply(wload.payload_module())
             runner = Runner(
                 payload,
@@ -590,20 +605,21 @@ enabled via CLI arguments.
 
             ab_type = str(wload.ab_type)
             c_type = str(wload.c_type)
+            p = params[0]
             print(
-                f"sizes={list2str([params['m'], params['n'], params['k']])} "
-                f"ta={int(params['transpose_a'])} "
-                f"tb={int(params['transpose_b'])} "
+                f"sizes={list2str([p['m'], p['n'], p['k']])} "
+                f"ta={int(p['transpose_a'])} "
+                f"tb={int(p['transpose_b'])} "
                 f"dt={ab_type},{c_type} "
-                f"wg={list2str([params['wg_m'], params['wg_n']])} "
-                f"sg={list2str([params['sg_m'], params['sg_n']])} "
-                f"k={params['k_tile']} "
-                f"ld-a={list2str([params['load_a_m'], params['load_a_k']])} "
-                f"ld-b={list2str([params['load_b_k'], params['load_b_n']])} "
-                f"pf-a={list2str([params['prefetch_a_m'], params['prefetch_a_k']])} "
-                f"pf-b={list2str([params['prefetch_b_k'], params['prefetch_b_n']])} "
-                f"pf-a-nb={params['prefetch_a_nb']} "
-                f"pf-b-nb={params['prefetch_b_nb']} "
+                f"wg={list2str([p['wg_m'], p['wg_n']])} "
+                f"sg={list2str([p['sg_m'], p['sg_n']])} "
+                f"k={p['k_tile']} "
+                f"ld-a={list2str([p['load_a_m'], p['load_a_k']])} "
+                f"ld-b={list2str([p['load_b_k'], p['load_b_n']])} "
+                f"pf-a={list2str([p['prefetch_a_m'], p['prefetch_a_k']])} "
+                f"pf-b={list2str([p['prefetch_b_k'], p['prefetch_b_n']])} "
+                f"pf-a-nb={p['prefetch_a_nb']} "
+                f"pf-b-nb={p['prefetch_b_nb']} "
                 f"time(us): {elapsed:.2f} "
                 f"GFLOPS: {gflops:.2f}"
             )

--- a/examples/xegpu/mlp.py
+++ b/examples/xegpu/mlp.py
@@ -34,6 +34,7 @@ from lighthouse.execution import (
     GPUMemoryManager,
 )
 from lighthouse.utils.numpy import mlir_to_numpy_dtype
+from lighthouse.schedule.parameters import ScheduleParameters
 from lighthouse.schedule.xegpu import mlp_schedule, xegpu_to_binary
 from lighthouse.ingress.mlir_gen import (
     generate_gpu_mlp_payload,
@@ -244,7 +245,10 @@ class XeGPUMLP:
         return mod
 
     def schedule_modules(
-        self, stop_at_stage: str | None = None, parameters: dict | None = None
+        self,
+        stop_at_stage: str | None = None,
+        parameters: ScheduleParameters | None = None,
+        device: str | None = None,
     ) -> list[ir.Module]:
         assert parameters is not None, "Schedule parameters must be provided"
         schedules = []
@@ -253,6 +257,7 @@ class XeGPUMLP:
         schedules.append(
             mlp_schedule(
                 payload_func_name=self.payload_function_name,
+                device=device,
                 stop_at_stage=stop_at_stage,
                 params=parameters,
             )
@@ -425,6 +430,7 @@ if __name__ == "__main__":
         params = []
         for i, (M, N, K) in enumerate(matmuls):
             layer_params = {
+                "layer_kind": "matmul",
                 "m": M,
                 "n": N,
                 "k": K,
@@ -432,24 +438,28 @@ if __name__ == "__main__":
                 "transpose_b": tr_b,
             }
             params.append(layer_params)
-        if args.target:
-            for layer_params in params:
-                layer_params["device"] = args.target
+        params = ScheduleParameters(params)
 
         if args.dump_kernel or args.dump_schedule:
             pipeline = TransformDriver(
                 wload.schedule_modules(
-                    stop_at_stage=args.dump_kernel, parameters=params
+                    stop_at_stage=args.dump_kernel,
+                    parameters=params,
+                    device=args.target,
                 )
             )
             payload = pipeline.apply(wload.payload_module())
             if args.dump_kernel:
                 print(payload)
             if args.dump_schedule:
-                for schedule_module in wload.schedule_modules(parameters=params):
+                for schedule_module in wload.schedule_modules(
+                    parameters=params, device=args.target
+                ):
                     print(schedule_module)
         else:
-            pipeline = TransformDriver(wload.schedule_modules(parameters=params))
+            pipeline = TransformDriver(
+                wload.schedule_modules(parameters=params, device=args.target)
+            )
             payload = pipeline.apply(wload.payload_module())
             runner = Runner(
                 payload,

--- a/examples/xegpu/nanoGPT.py
+++ b/examples/xegpu/nanoGPT.py
@@ -189,7 +189,7 @@ def main():
     # mm/sm params drive the non-attention kernels (matmul, layernorm); fa_params
     # drives the fused attention kernel.
     param_selector = XeGPUParameterSelector()
-    mm_params = dict(param_selector.get_parameters((T, C, C)))
+    mm_params = dict(param_selector.get_parameters((T, C, C))[0])
     mm_params["gpu_specs"] = param_selector.gpu_specs
     ln_params = {
         "wg_rows": 64,

--- a/examples/xegpu/softmax.py
+++ b/examples/xegpu/softmax.py
@@ -18,6 +18,7 @@ from lighthouse.execution import GPUMemoryManager
 from lighthouse.utils.numpy import mlir_to_numpy_dtype
 from lighthouse.ingress.mlir_gen import get_mlir_elem_type
 from lighthouse.ingress.mlir_gen.gpu_softmax_payload import generate_gpu_softmax_payload
+from lighthouse.schedule.parameters import ScheduleParameters
 from lighthouse.schedule.xegpu import reduction_schedule, xegpu_to_binary
 
 
@@ -130,7 +131,9 @@ class XeGPUSoftmax:
         )
 
     def schedule_modules(
-        self, stop_at_stage: str | None = None, parameters: dict | None = None
+        self,
+        stop_at_stage: str | None = None,
+        parameters: ScheduleParameters | None = None,
     ) -> list[ir.Module]:
         """Generate transform schedule for softmax."""
         schedules = []
@@ -140,7 +143,7 @@ class XeGPUSoftmax:
             reduction_schedule(
                 payload_func_name=self.payload_function_name,
                 stop_at_stage=stop_at_stage,
-                parameters=parameters,
+                params=parameters,
             )
         )
 
@@ -243,13 +246,18 @@ def parse_cli():
 if __name__ == "__main__":
     args = parse_cli()
 
-    params = {
-        "sizes": args.sizes,
-        "wg_rows": args.wg_rows,
-        "sg_rows": args.sg_rows,
-        "subgroup_size": args.subgroup_size,
-        "reduction_step_size": args.reduction_step_size,
-    }
+    params = ScheduleParameters(
+        [
+            {
+                "layer_kind": "reduction",
+                "sizes": args.sizes,
+                "wg_rows": args.wg_rows,
+                "sg_rows": args.sg_rows,
+                "subgroup_size": args.subgroup_size,
+                "reduction_step_size": args.reduction_step_size,
+            }
+        ]
+    )
 
     M, N = args.sizes
     dtype = "f32"

--- a/examples/xegpu/torch_matmul.py
+++ b/examples/xegpu/torch_matmul.py
@@ -16,6 +16,7 @@ from mlir.dialects.transform import structured
 
 from lighthouse import dialects as lh_dialects
 from lighthouse import schedule as lh_schedule
+from lighthouse.schedule.parameters import ScheduleParams
 from lighthouse.pipeline.driver import TransformDriver
 from lighthouse.utils.mlir import get_mlir_library_path
 from lighthouse.execution.runner import Runner
@@ -48,7 +49,10 @@ def shared_libs() -> list[str]:
 
 
 def schedule_modules(
-    parameters: dict | None = None, benchmark: bool = False, entry_func: str = "main"
+    parameters: ScheduleParams | None = None,
+    device: str | None = None,
+    benchmark: bool = False,
+    entry_func: str = "main",
 ) -> list[ir.Module]:
     assert parameters is not None, "Schedule parameters must be provided"
     schedules = []
@@ -66,7 +70,8 @@ def schedule_modules(
     schedules.append(
         mlp_schedule(
             payload_func_name="main",
-            params=[parameters],
+            device=device,
+            params=parameters,
         )
     )
 
@@ -77,13 +82,17 @@ def schedule_modules(
 
 def lower_to_llvm(
     module: ir.Module,
-    parameters: dict | None = None,
+    parameters: ScheduleParams | None = None,
+    device: str | None = None,
     benchmark: bool = False,
     entry_func: str = "main",
 ) -> ir.Module:
     pipeline = TransformDriver(
         schedule_modules(
-            parameters=parameters, benchmark=benchmark, entry_func=entry_func
+            parameters=parameters,
+            device=device,
+            benchmark=benchmark,
+            entry_func=entry_func,
         )
     )
     payload = pipeline.apply(module)
@@ -207,40 +216,48 @@ enabled via CLI arguments.
     # Problem size
     m, n, k = args.sizes if args.sizes else (4096, 4096, 4096)
     # Set required parameters
-    params = {
-        "m": m,
-        "n": n,
-        "k": k,
-    }
-    if args.target:
-        params["device"] = args.target
+    params = ScheduleParams(
+        [
+            {
+                "layer_kind": "matmul",
+                "m": m,
+                "n": n,
+                "k": k,
+            }
+        ]
+    )
+    layer_params = params[0]
     if args.json:
         # Override parameters with values from JSON file if provided
         with open(args.json) as f:
             json_params = json.load(f)
-        params.update(json_params)
+        layer_params.update(json_params)
 
     # Override parameters with CLI args if provided
     if args.wg_tile:
-        params["wg_m"], params["wg_n"] = args.wg_tile
+        layer_params["wg_m"], layer_params["wg_n"] = args.wg_tile
     if args.sg_tile:
-        params["sg_m"], params["sg_n"] = args.sg_tile
+        layer_params["sg_m"], layer_params["sg_n"] = args.sg_tile
     if args.k_tile:
-        params["k_tile"] = args.k_tile
+        layer_params["k_tile"] = args.k_tile
     if args.load_tile_a:
-        params["load_a_m"], params["load_a_k"] = args.load_tile_a
+        layer_params["load_a_m"], layer_params["load_a_k"] = args.load_tile_a
     if args.load_tile_b:
-        params["load_b_k"], params["load_b_n"] = args.load_tile_b
+        layer_params["load_b_k"], layer_params["load_b_n"] = args.load_tile_b
     if args.prefetch_tile_a:
-        params["prefetch_a_m"], params["prefetch_a_k"] = args.prefetch_tile_a
+        layer_params["prefetch_a_m"], layer_params["prefetch_a_k"] = (
+            args.prefetch_tile_a
+        )
     if args.prefetch_tile_b:
-        params["prefetch_b_k"], params["prefetch_b_n"] = args.prefetch_tile_b
+        layer_params["prefetch_b_k"], layer_params["prefetch_b_n"] = (
+            args.prefetch_tile_b
+        )
     if args.prefetch_a_nb is not None:
-        params["prefetch_a_nb"] = args.prefetch_a_nb
+        layer_params["prefetch_a_nb"] = args.prefetch_a_nb
     if args.prefetch_b_nb is not None:
-        params["prefetch_b_nb"] = args.prefetch_b_nb
+        layer_params["prefetch_b_nb"] = args.prefetch_b_nb
 
-    for param_key, v in params.items():
+    for param_key, v in layer_params.items():
         if v is None:
             raise ValueError(
                 f"Parameter {param_key} is not set. Please provide it via CLI or JSON file."
@@ -258,7 +275,12 @@ enabled via CLI arguments.
         torch.xpu.synchronize()
 
         benchmark = args.nruns > 0
-        fn_compile = partial(lower_to_llvm, parameters=params, benchmark=benchmark)
+        fn_compile = partial(
+            lower_to_llvm,
+            parameters=params,
+            device=args.target,
+            benchmark=benchmark,
+        )
         backend = gpu_backend(
             fn_compile,
             device=xpu_device,
@@ -292,16 +314,17 @@ enabled via CLI arguments.
 
             ab_type = str(a.dtype)
             c_type = str(out.dtype)
+            p = params[0]
             print(
-                f"sizes={list2str([params['m'], params['n'], params['k']])} "
+                f"sizes={list2str([p['m'], p['n'], p['k']])} "
                 f"dt={ab_type},{c_type} "
-                f"wg-tile={list2str([params['wg_m'], params['wg_n']])} "
-                f"sg-tile={list2str([params['sg_m'], params['sg_n']])} "
-                f"k-tile={params['k_tile']} "
-                f"load-a-tile={list2str([params['load_a_m'], params['load_a_k']])} "
-                f"load-b-tile={list2str([params['load_b_k'], params['load_b_n']])} "
-                f"pf-a-tile={list2str([params['prefetch_a_m'], params['prefetch_a_k']])} "
-                f"pf-b-tile={list2str([params['prefetch_b_k'], params['prefetch_b_n']])} "
+                f"wg-tile={list2str([p['wg_m'], p['wg_n']])} "
+                f"sg-tile={list2str([p['sg_m'], p['sg_n']])} "
+                f"k-tile={p['k_tile']} "
+                f"load-a-tile={list2str([p['load_a_m'], p['load_a_k']])} "
+                f"load-b-tile={list2str([p['load_b_k'], p['load_b_n']])} "
+                f"pf-a-tile={list2str([p['prefetch_a_m'], p['prefetch_a_k']])} "
+                f"pf-b-tile={list2str([p['prefetch_b_k'], p['prefetch_b_n']])} "
                 f"time(us): {elapsed:.2f} "
                 f"GFLOPS: {gflops:.2f}"
             )

--- a/lighthouse/schedule/parameters.py
+++ b/lighthouse/schedule/parameters.py
@@ -1,0 +1,128 @@
+from collections.abc import Iterator
+import json
+import os
+
+
+class ScheduleParameters:
+    """
+    Schedule parameters abstraction.
+
+    ScheduleParameters is effectively a list of dictionaries, where each
+    dictionary contains the parameters for a specific stage of the lowering
+    schedule.
+
+    Each dictionary must contain a key "layer_kind" that defines the kind of
+    layer being transformed (e.g., "matmul"). The parameter values must be of
+    type int, float, str, bool, or a list of thereof. The semantics of the
+    parameters depend on the used lowering schedule.
+
+    ScheduleParameters can be stored to/loaded from disk using the `to_json`
+    and `from_json` methods.
+
+    ScheduleParameters object can be used as a list of dictionaries:
+
+    ```python
+    params = ScheduleParameters(
+        [
+            {"layer_kind": "matmul", "wg_tile": [256, 256]},
+        ]
+    )
+    for p in params:
+        print(p["layer_kind"], p["wg_tile"])
+    ```
+    """
+
+    def __init__(self, list_of_parameters: list[dict] | None):
+        """
+        Initialize the ScheduleParameters with an optional list of parameter dictionaries.
+        """
+        ScheduleParameters._verify_params_list(list_of_parameters)
+        self.list_of_parameters = list_of_parameters or []
+
+    def __iter__(self) -> Iterator[dict]:
+        return iter(self.list_of_parameters)
+
+    def __len__(self) -> int:
+        return len(self.list_of_parameters)
+
+    def __getitem__(self, index: int) -> dict:
+        return self.list_of_parameters[index]
+
+    def __setitem__(self, index: int, value: dict):
+        self._verify_params_dict(value)
+        self.list_of_parameters[index] = value
+
+    def __delitem__(self, index: int):
+        del self.list_of_parameters[index]
+
+    def append(self, value: dict):
+        self._verify_params_dict(value)
+        self.list_of_parameters.append(value)
+
+    def extend(self, values: list[dict]):
+        for value in values:
+            self._verify_params_dict(value)
+        self.list_of_parameters.extend(values)
+
+    def insert(self, index: int, value: dict):
+        self._verify_params_dict(value)
+        self.list_of_parameters.insert(index, value)
+
+    @staticmethod
+    def _verify_params_list(list_of_parameters: list[dict] | None):
+        if list_of_parameters is None:
+            return
+        if not isinstance(list_of_parameters, list):
+            raise ValueError(
+                f"list_of_parameters must be a list of dictionaries or None, got {type(list_of_parameters)}"
+            )
+        for item in list_of_parameters:
+            if not isinstance(item, dict):
+                raise ValueError(
+                    f"Each item in list_of_parameters must be a dictionary, got {type(item)}"
+                )
+        for params in list_of_parameters:
+            ScheduleParameters._verify_params_dict(params)
+
+    @staticmethod
+    def _verify_params_dict(params: dict):
+        if not isinstance(params, dict):
+            raise ValueError(
+                f"Each parameter entry must be a dictionary: found '{params}'."
+            )
+        if "layer_kind" not in params:
+            raise ValueError(
+                "Each parameter dictionary must contain a 'layer_kind' key."
+            )
+        if not isinstance(params["layer_kind"], str):
+            raise ValueError("'layer_kind' must be a string.")
+        for key, value in params.items():
+            if not isinstance(key, str):
+                raise ValueError(
+                    f"Parameter dictionary keys must be strings: found '{key}'."
+                )
+            if not isinstance(value, (int, float, str, bool, list, tuple)):
+                raise ValueError(
+                    f"Parameter dictionary values must be an int, float, str, bool, list, or tuple: found '{value}' for key '{key}'."
+                )
+
+    def to_json(self, filename, overwrite=False):
+        """
+        Serialize the schedule parameters to a JSON file.
+        """
+        if not overwrite and os.path.exists(filename):
+            raise FileExistsError(
+                f"File '{filename}' already exists. Use 'overwrite=True' to overwrite it."
+            )
+        with open(filename, "w") as f:
+            json.dump(self.list_of_parameters, f, indent=4)
+
+    @classmethod
+    def from_json(cls, filename: str):
+        """
+        Deserialize the schedule parameters from a JSON file.
+        """
+        with open(filename) as f:
+            list_of_parameters = json.load(f)
+        instance = cls(list_of_parameters)
+        return instance

--- a/lighthouse/schedule/xegpu/elemwise_schedule.py
+++ b/lighthouse/schedule/xegpu/elemwise_schedule.py
@@ -11,6 +11,7 @@ from lighthouse.pipeline.helper import (
 )
 
 from lighthouse.schedule import schedule_boilerplate
+from lighthouse.schedule.parameters import ScheduleParameters
 from .xegpu_specs import XeGPUSpecs
 from .xegpu_parameter_selector import XeGPUParameterSelector
 from .lowering_common import (
@@ -25,15 +26,13 @@ from .matmul_constraints import (
 
 
 def elemwise_schedule(
-    params: list[dict[str, int | None]],
+    params: ScheduleParameters,
     payload_func_name: str = "payload",
+    device: str | None = None,
     stop_at_stage: str = "",
 ) -> ir.Module:
     """Generate transform schedule module for elemwise payload."""
     assert params is not None and len(params) > 0, "params must be provided."
-    devices = {p.get("device") for p in params if "device" in p}
-    assert len(devices) <= 1, f"Multiple devices specified in params list: {devices}"
-    device = devices.pop() if devices else None
     param_selector = XeGPUParameterSelector(device=device)
     gpu_specs = param_selector.gpu_specs
 
@@ -67,7 +66,7 @@ def bundle_xegpu_elemwise_schedule(
     mod: ir.Value[transform.AnyOpType],
     payload_func_name: str,
     gpu_specs: XeGPUSpecs,
-    params: list[dict[str, int]],
+    params: ScheduleParameters,
     stop_at_stage: str = "",
 ) -> ir.Value[transform.AnyOpType]:
     """Schedule for lowering elemwise-like payload to xegpu wg level."""

--- a/lighthouse/schedule/xegpu/elemwise_schedule.py
+++ b/lighthouse/schedule/xegpu/elemwise_schedule.py
@@ -11,9 +11,6 @@ from lighthouse.pipeline.helper import (
 )
 
 from lighthouse.schedule import schedule_boilerplate
-from lighthouse.dialects import smt_ext
-from lighthouse.dialects.transform import smt_ext as td_smt_ext
-from lighthouse.dialects.transform.tune_ext import KnobValue
 from .xegpu_specs import XeGPUSpecs
 from .xegpu_parameter_selector import XeGPUParameterSelector
 from .lowering_common import (
@@ -70,7 +67,7 @@ def bundle_xegpu_elemwise_schedule(
     mod: ir.Value[transform.AnyOpType],
     payload_func_name: str,
     gpu_specs: XeGPUSpecs,
-    params: list[dict[str, int | KnobValue]],
+    params: list[dict[str, int]],
     stop_at_stage: str = "",
 ) -> ir.Value[transform.AnyOpType]:
     """Schedule for lowering elemwise-like payload to xegpu wg level."""
@@ -128,12 +125,12 @@ def xegpu_wg_annotation_for_elemwise_layer(
     gpu_func: ir.Value,
     gpu_specs: XeGPUSpecs,
     *,
-    wg_m: int | KnobValue,
-    wg_n: int | KnobValue,
-    sg_m: int | KnobValue,
-    sg_n: int | KnobValue,
-    load_m: int | KnobValue,
-    load_n: int | KnobValue,
+    wg_m: int,
+    wg_n: int,
+    sg_m: int,
+    sg_n: int,
+    load_m: int,
+    load_n: int,
     **_catch_all,
 ):
     """
@@ -142,18 +139,13 @@ def xegpu_wg_annotation_for_elemwise_layer(
     Should be applied after the payload has been converted to XeGPU using
     the convert-vector-to-xegpu pass.
     """
-
-    @td_smt_ext.constrain_params(wg_m, wg_n, sg_m, sg_n, load_m, load_n)
-    def calc_sg_layout(WG_M, WG_N, SG_M, SG_N, LD_M, LD_N):
-        smt_ext.assert_(WG_M % SG_M == 0)
-        smt_ext.assert_(WG_N % SG_N == 0)
-        smt_ext.assert_(SG_M % LD_M == 0)
-        smt_ext.assert_(SG_N % LD_N == 0)
-        smt_ext.assert_(LD_M <= LOAD_MAX_ROWS)
-        smt_ext.assert_(LD_N <= LOAD_MAX_COLS)
-        return WG_M // SG_M, WG_N // SG_N
-
-    sg_layout = calc_sg_layout.results
+    assert wg_m % sg_m == 0
+    assert wg_n % sg_n == 0
+    assert sg_m % load_m == 0
+    assert sg_n % load_n == 0
+    assert load_m <= LOAD_MAX_ROWS
+    assert load_n <= LOAD_MAX_COLS
+    sg_layout = [wg_m // sg_m, wg_n // sg_n]
 
     sg_tile = [sg_m, sg_n]
     load_tile = [load_m, load_n]

--- a/lighthouse/schedule/xegpu/lowering_common.py
+++ b/lighthouse/schedule/xegpu/lowering_common.py
@@ -9,9 +9,6 @@ from mlir.dialects.transform import memref
 import lighthouse.transform as lh_transform
 
 from lighthouse.dialects.transform import transform_ext
-from lighthouse.dialects import smt_ext
-from lighthouse.dialects.transform import smt_ext as td_smt_ext
-from lighthouse.dialects.transform.tune_ext import KnobValue
 
 from lighthouse.pipeline.helper import (
     PipelineInterrupt,
@@ -21,7 +18,7 @@ from lighthouse.pipeline.helper import (
     match_and_split,
 )
 from .xegpu_specs import XeGPUSpecs
-from .matmul_constraints import NB_WORKITEMS, MIN_NB_THREADS
+from .matmul_constraints import NB_WORKITEMS
 
 
 def get_named_func(
@@ -46,7 +43,7 @@ def vectorize_bufferize_and_outline_gpu_func(
     payload_func_name: str,
     *,
     gpu_specs: XeGPUSpecs,
-    params: list[dict[str, int | KnobValue]],
+    params: list[dict[str, int]],
     stop_at_stage: str = "",
 ) -> transform.AnyOpType:
     """Vectorizes and bufferizes the payload function and outlines it to gpu.func."""
@@ -154,7 +151,7 @@ def outline_gpu_function(
     payload_func_name: str,
     *,
     gpu_specs: XeGPUSpecs,
-    params: list[dict[str, int | KnobValue]],
+    params: list[dict[str, int]],
 ) -> transform.AnyOpType:
     """Set gpu.launch threads and outline the payload to gpu.func."""
     nlayers = len(params)
@@ -167,35 +164,10 @@ def outline_gpu_function(
         wg_m, wg_n = layer_params["wg_m"], layer_params["wg_n"]
         sg_m, sg_n = layer_params["sg_m"], layer_params["sg_n"]
 
-        @td_smt_ext.constrain_params(wg_m, wg_n, sg_m, sg_n)
-        def constrain_wg_sg_and_calc_nb_threads(
-            WG_M: int | smt_ext.SMTIntValue,
-            WG_N: int | smt_ext.SMTIntValue,
-            SG_M: int | smt_ext.SMTIntValue,
-            SG_N: int | smt_ext.SMTIntValue,
-        ):
-            # NB: normal asserts in case of concrete values, SMT assert ops for symbolic values.
-            smt_ext.assert_(WG_M % SG_M == 0)
-            smt_ext.assert_(WG_N % SG_N == 0)
-
-            # NB: normal ints in case of concrete values, SMT int values for symbolic values.
-            sg_m_threads = WG_M // SG_M
-            sg_n_threads = WG_N // SG_N
-            sg_threads = sg_m_threads * sg_n_threads
-            smt_ext.assert_(
-                sg_threads <= gpu_specs.max_nb_threads, "too many SG threads"
-            )
-            smt_ext.assert_(
-                sg_threads >= MIN_NB_THREADS,
-                f"too few SG threads: {sg_threads} {WG_M}/{SG_M}*{WG_N}/{SG_N}",
-            )
-
-            # number of threads collapsed to 1d layout
-            return sg_threads * NB_WORKITEMS
-
-        nb_threads: int | transform.AnyParamType = (
-            constrain_wg_sg_and_calc_nb_threads.results
-        )
+        sg_m_threads = wg_m // sg_m
+        sg_n_threads = wg_n // sg_n
+        sg_threads = sg_m_threads * sg_n_threads
+        nb_threads: int = sg_threads * NB_WORKITEMS
 
         xegpu.set_gpu_launch_threads(launch_op, threads=[nb_threads, 1, 1])
 

--- a/lighthouse/schedule/xegpu/matmul_costmodel.py
+++ b/lighthouse/schedule/xegpu/matmul_costmodel.py
@@ -111,6 +111,7 @@ def generate_configs(
     ) -> dict[str, int]:
         wg_tile, sg_tile, k_tile, ld_a, ld_b, pf_a, pf_b, tr_a, tr_b = config
         return {
+            "layer_kind": "matmul",
             "m": M,
             "n": N,
             "k": K,

--- a/lighthouse/schedule/xegpu/matmul_params.json
+++ b/lighthouse/schedule/xegpu/matmul_params.json
@@ -1,5 +1,6 @@
 [
     {
+        "layer_kind": "matmul",
         "m": 1024,
         "n": 1024,
         "k": 1024,
@@ -20,6 +21,7 @@
         "prefetch_b_nb": 1
     },
     {
+        "layer_kind": "matmul",
         "m": 1024,
         "n": 1024,
         "k": 8192,
@@ -40,6 +42,7 @@
         "prefetch_b_nb": 1
     },
     {
+        "layer_kind": "matmul",
         "m": 1024,
         "n": 8192,
         "k": 1024,
@@ -60,6 +63,7 @@
         "prefetch_b_nb": 1
     },
     {
+        "layer_kind": "matmul",
         "m": 128,
         "n": 16384,
         "k": 16384,
@@ -80,6 +84,7 @@
         "prefetch_b_nb": 1
     },
     {
+        "layer_kind": "matmul",
         "m": 128,
         "n": 16384,
         "k": 32768,
@@ -100,6 +105,7 @@
         "prefetch_b_nb": 1
     },
     {
+        "layer_kind": "matmul",
         "m": 128,
         "n": 32768,
         "k": 16384,
@@ -120,6 +126,7 @@
         "prefetch_b_nb": 1
     },
     {
+        "layer_kind": "matmul",
         "m": 128,
         "n": 32768,
         "k": 32768,
@@ -140,6 +147,7 @@
         "prefetch_b_nb": 1
     },
     {
+        "layer_kind": "matmul",
         "m": 128,
         "n": 8192,
         "k": 16384,
@@ -160,6 +168,7 @@
         "prefetch_b_nb": 1
     },
     {
+        "layer_kind": "matmul",
         "m": 2048,
         "n": 4096,
         "k": 8192,
@@ -180,6 +189,7 @@
         "prefetch_b_nb": 1
     },
     {
+        "layer_kind": "matmul",
         "m": 256,
         "n": 256,
         "k": 524288,
@@ -200,6 +210,7 @@
         "prefetch_b_nb": 1
     },
     {
+        "layer_kind": "matmul",
         "m": 32768,
         "n": 32768,
         "k": 32,
@@ -220,6 +231,7 @@
         "prefetch_b_nb": 1
     },
     {
+        "layer_kind": "matmul",
         "m": 32768,
         "n": 32768,
         "k": 64,
@@ -240,6 +252,7 @@
         "prefetch_b_nb": 2
     },
     {
+        "layer_kind": "matmul",
         "m": 4096,
         "n": 4096,
         "k": 4096,
@@ -260,6 +273,7 @@
         "prefetch_b_nb": 1
     },
     {
+        "layer_kind": "matmul",
         "m": 8192,
         "n": 8192,
         "k": 8192,

--- a/lighthouse/schedule/xegpu/mlp_schedule.py
+++ b/lighthouse/schedule/xegpu/mlp_schedule.py
@@ -13,6 +13,7 @@ from lighthouse.pipeline.helper import (
 )
 
 from lighthouse.schedule import schedule_boilerplate
+from lighthouse.schedule.parameters import ScheduleParameters
 from .xegpu_specs import XeGPUSpecs
 from .xegpu_parameter_selector import XeGPUParameterSelector
 from .lowering_common import (
@@ -28,29 +29,27 @@ from .matmul_constraints import (
 
 def matmul_schedule(
     payload_func_name: str = "payload",
+    device: str | None = None,
     stop_at_stage: str = "",
     **layer_params,
 ) -> ir.Module:
     """Generate transform schedule module for a single matmul layer."""
     return mlp_schedule(
-        params=[layer_params],
+        params=ScheduleParameters([{"layer_kind": "matmul", **layer_params}]),
         payload_func_name=payload_func_name,
+        device=device,
         stop_at_stage=stop_at_stage,
     )
 
 
 def mlp_schedule(
-    params: list[dict[str, int | None]],
+    params: ScheduleParameters,
     payload_func_name: str = "payload",
+    device: str | None = None,
     stop_at_stage: str = "",
 ) -> ir.Module:
     """Generate transform schedule module for MLP payload."""
-    assert params is not None and isinstance(params, list) and len(params) > 0, (
-        "params must be provided."
-    )
-    devices = {p.get("device") for p in params if "device" in p}
-    assert len(devices) <= 1, f"Multiple devices specified in params list: {devices}"
-    device = devices.pop() if devices else None
+    assert params is not None and len(params) > 0, "params must be provided."
     param_selector = XeGPUParameterSelector(device=device)
     gpu_specs = param_selector.gpu_specs
 
@@ -99,7 +98,7 @@ def mlp_schedule(
                     shape, transpose_a, transpose_b
                 )
                 # Overwrite original params to ensure consistent configuration
-                layer_params.update(generated_params)
+                layer_params.update(generated_params[0])
 
         try:
             bundle_xegpu_mlp_schedule(
@@ -121,7 +120,7 @@ def bundle_xegpu_mlp_schedule(
     mod: ir.Value[transform.AnyOpType],
     payload_func_name: str,
     gpu_specs: XeGPUSpecs,
-    params: list[dict[str, int]],
+    params: ScheduleParameters,
     stop_at_stage: str = "",
 ) -> ir.Value[transform.AnyOpType]:
     """Schedule for lowering MLP-like payload to xegpu wg level."""

--- a/lighthouse/schedule/xegpu/mlp_schedule.py
+++ b/lighthouse/schedule/xegpu/mlp_schedule.py
@@ -13,9 +13,6 @@ from lighthouse.pipeline.helper import (
 )
 
 from lighthouse.schedule import schedule_boilerplate
-from lighthouse.dialects import smt_ext
-from lighthouse.dialects.transform import smt_ext as td_smt_ext
-from lighthouse.dialects.transform.tune_ext import knob, KnobValue
 from .xegpu_specs import XeGPUSpecs
 from .xegpu_parameter_selector import XeGPUParameterSelector
 from .lowering_common import (
@@ -26,83 +23,7 @@ from .lowering_common import (
 from .matmul_constraints import (
     DPAS,
     PREFETCH_INST_DATA,
-    LOAD_MAX_ROWS,
-    LOAD_MAX_COLS,
-    PFETCH_MIN_ROWS,
-    PFETCH_MIN_COLS,
-    PFETCH_MAX_ROWS,
-    PFETCH_MAX_COLS,
-    MIN_NB_THREADS,
 )
-
-
-@KnobValue.ast_rewrite(in_exprs=True)
-def params_with_constraints_imposed(
-    params: dict[str, int | None], knob_name_prefix=""
-) -> dict[str, int | KnobValue]:
-    """Check the parameters for validity and replace `None`s with knobs with asserted ranges.
-
-    Inserts the `KnobOp`s for any knobs that are created at the active `InsertionPoint` and
-    maps the parameter name to the (`Knob`)`Value` returned by the `KnobOp`."""
-    m, n, k = params["m"], params["n"], params["k"]
-    assert isinstance(m, int) and isinstance(n, int) and isinstance(k, int)
-    assert m > 0 and n > 0 and k > 0
-    wg_m = params["wg_m"] or knob(knob_name_prefix + "wg_m")
-    wg_n = params["wg_n"] or knob(knob_name_prefix + "wg_n")
-    sg_m = params["sg_m"] or knob(knob_name_prefix + "sg_m")
-    sg_n = params["sg_n"] or knob(knob_name_prefix + "sg_n")
-    k_tile = params["k_tile"] or knob(knob_name_prefix + "k_tile")
-    load_a_m = params["load_a_m"] or knob(knob_name_prefix + "load_a_m")
-    load_a_k = params["load_a_k"] or knob(knob_name_prefix + "load_a_k")
-    load_b_k = params["load_b_k"] or knob(knob_name_prefix + "load_b_k")
-    load_b_n = params["load_b_n"] or knob(knob_name_prefix + "load_b_n")
-    prefetch_a_m = params["prefetch_a_m"] or knob(knob_name_prefix + "prefetch_a_m")
-    prefetch_a_k = params["prefetch_a_k"] or knob(knob_name_prefix + "prefetch_a_k")
-    prefetch_b_k = params["prefetch_b_k"] or knob(knob_name_prefix + "prefetch_b_k")
-    prefetch_b_n = params["prefetch_b_n"] or knob(knob_name_prefix + "prefetch_b_n")
-    prefetch_a_nb = params["prefetch_a_nb"] or knob(knob_name_prefix + "prefetch_a_nb")
-    prefetch_b_nb = params["prefetch_b_nb"] or knob(knob_name_prefix + "prefetch_b_nb")
-
-    # NB: Constraints on knobs will be added as attributes on the KnobOps, while
-    #     constraints on concrete values will be checked immediately.
-    assert min(max(m // 4, 16), 64) <= wg_m <= min(m, 256)
-    assert m % wg_m == 0 and wg_m % DPAS.M == 0
-    assert min(max(n // 4, 16), 64) <= wg_n <= min(n, 256)
-    assert n % wg_n == 0 and wg_n % DPAS.N == 0
-    assert 16 <= sg_m <= min(m, 128)
-    assert m % sg_m == 0 and sg_m % DPAS.M == 0
-    assert 16 <= sg_n <= min(n, 128)
-    assert n % sg_n == 0 and sg_n % DPAS.N == 0
-    assert 16 <= k_tile <= min(k, 256)
-    assert k % k_tile == 0 and k_tile % DPAS.K == 0
-    assert prefetch_a_nb > 0
-    assert prefetch_b_nb > 0
-
-    LOAD_TILE_SIZES = [8, 16, 32]
-    assert load_a_m in LOAD_TILE_SIZES and load_a_m % DPAS.M == 0
-    assert load_a_k in LOAD_TILE_SIZES and load_a_k % DPAS.K == 0
-    assert load_b_k in LOAD_TILE_SIZES and load_b_k % DPAS.K == 0
-    assert load_b_n in LOAD_TILE_SIZES and load_b_n % DPAS.N == 0
-    assert prefetch_a_m in LOAD_TILE_SIZES
-    assert prefetch_a_k in LOAD_TILE_SIZES
-    assert prefetch_b_k in LOAD_TILE_SIZES
-    assert prefetch_b_n in LOAD_TILE_SIZES
-
-    return {
-        "wg_m": wg_m,
-        "wg_n": wg_n,
-        "sg_m": sg_m,
-        "sg_n": sg_n,
-        "k_tile": k_tile,
-        "load_a_m": load_a_m,
-        "load_a_k": load_a_k,
-        "load_b_k": load_b_k,
-        "load_b_n": load_b_n,
-        "prefetch_a_m": prefetch_a_m,
-        "prefetch_a_k": prefetch_a_k,
-        "prefetch_b_k": prefetch_b_k,
-        "prefetch_b_n": prefetch_b_n,
-    }
 
 
 def matmul_schedule(
@@ -171,7 +92,6 @@ def mlp_schedule(
             ]
             if not all(p in layer_params for p in required_params):
                 # Some parameters are missing, use the parameter selector to fill
-                # NOTE None values are interpreted as knobs in the constraint function
                 shape = (m, n, k)
                 transpose_a = layer_params.get("transpose_a", False)
                 transpose_b = layer_params.get("transpose_b", False)
@@ -180,10 +100,6 @@ def mlp_schedule(
                 )
                 # Overwrite original params to ensure consistent configuration
                 layer_params.update(generated_params)
-
-            layer_params |= params_with_constraints_imposed(
-                layer_params, knob_name_prefix=f"layer_{i}_"
-            )
 
         try:
             bundle_xegpu_mlp_schedule(
@@ -205,7 +121,7 @@ def bundle_xegpu_mlp_schedule(
     mod: ir.Value[transform.AnyOpType],
     payload_func_name: str,
     gpu_specs: XeGPUSpecs,
-    params: list[dict[str, int | KnobValue]],
+    params: list[dict[str, int]],
     stop_at_stage: str = "",
 ) -> ir.Value[transform.AnyOpType]:
     """Schedule for lowering MLP-like payload to xegpu wg level."""
@@ -280,21 +196,21 @@ def xegpu_wg_annotation_for_mlp_layer(
     gpu_func: ir.Value,
     gpu_specs: XeGPUSpecs,
     *,
-    wg_m: int | KnobValue,
-    wg_n: int | KnobValue,
-    sg_m: int | KnobValue,
-    sg_n: int | KnobValue,
-    k_tile: int | KnobValue,
-    load_a_m: int | KnobValue,
-    load_a_k: int | KnobValue,
-    load_b_k: int | KnobValue,
-    load_b_n: int | KnobValue,
-    prefetch_a_m: int | KnobValue,
-    prefetch_a_k: int | KnobValue,
-    prefetch_b_k: int | KnobValue,
-    prefetch_b_n: int | KnobValue,
-    prefetch_a_nb: int | KnobValue,
-    prefetch_b_nb: int | KnobValue,
+    wg_m: int,
+    wg_n: int,
+    sg_m: int,
+    sg_n: int,
+    k_tile: int,
+    load_a_m: int,
+    load_a_k: int,
+    load_b_k: int,
+    load_b_n: int,
+    prefetch_a_m: int,
+    prefetch_a_k: int,
+    prefetch_b_k: int,
+    prefetch_b_n: int,
+    prefetch_a_nb: int,
+    prefetch_b_nb: int,
     transpose_a: bool,
     transpose_b: bool,
     **_catch_all,
@@ -309,109 +225,19 @@ def xegpu_wg_annotation_for_mlp_layer(
     anytype = transform.AnyOpType.get()
     anyvalue = transform.AnyValueType.get()
 
-    # Calculate with SMT ops in case of symbolic values, normal ints in case of concrete values.
-    @td_smt_ext.constrain_params(wg_m, wg_n, sg_m, sg_n)
-    def calc_sg_layout(WG_M, WG_N, SG_M, SG_N):
-        # NB: Constraint on overall num SG threads already dealt with elsewhere.
-        return WG_M // SG_M, WG_N // SG_N
-
-    sg_layout = calc_sg_layout.results
+    sg_layout = [wg_m // sg_m, wg_n // sg_n]
 
     load_tile_a = [load_a_m, load_a_k]
     load_tile_b = [load_b_k, load_b_n]
     prefetch_tile_a = [prefetch_a_m, prefetch_a_k]
     prefetch_tile_b = [prefetch_b_k, prefetch_b_n]
 
-    @td_smt_ext.constrain_params(
-        wg_m,
-        wg_n,
-        sg_m,
-        sg_n,
-        k_tile,
-        load_a_m,
-        load_a_k,
-        load_b_k,
-        load_b_n,
-        prefetch_a_m,
-        prefetch_a_k,
-        prefetch_b_k,
-        prefetch_b_n,
-        transpose_a,
-        transpose_b,
-    )
-    def constrain_and_calculate_load_and_prefetch_params(
-        WG_M,
-        WG_N,
-        SG_M,
-        SG_N,
-        K_TILE,
-        LDA_M,
-        LDA_K,
-        LDB_K,
-        LDB_N,
-        PFA_M,
-        PFA_K,
-        PFB_K,
-        PFB_N,
-        TR_A,
-        TR_B,
-    ):
-        # NB: normal asserts in case of concrete values, SMT assert ops for symbolic values
-        smt_ext.assert_(SG_M % LDA_M == 0)
-        smt_ext.assert_(K_TILE % LDA_K == 0)
-        smt_ext.assert_(K_TILE % LDB_K == 0)
-        smt_ext.assert_(SG_N % LDB_N == 0)
+    # prefetch tile shape depends on transpose flag
+    pf_shape_a = (k_tile, wg_m) if transpose_a else (wg_m, k_tile)
+    pf_shape_b = (wg_n, k_tile) if transpose_b else (k_tile, wg_n)
 
-        smt_ext.assert_(LDA_M <= LOAD_MAX_ROWS)
-        smt_ext.assert_(LDA_K <= LOAD_MAX_COLS)
-        smt_ext.assert_(LDB_K <= LOAD_MAX_ROWS)
-        smt_ext.assert_(LDB_N <= LOAD_MAX_COLS)
-
-        # prefetch tile shape depends on transpose flag
-        pf_shape_a = (K_TILE, WG_M) if TR_A else (WG_M, K_TILE)
-        pf_shape_b = (WG_N, K_TILE) if TR_B else (K_TILE, WG_N)
-
-        smt_ext.assert_(pf_shape_a[0] % PFA_M == 0)
-        smt_ext.assert_(pf_shape_a[1] % PFA_K == 0)
-        smt_ext.assert_(pf_shape_b[0] % PFB_K == 0)
-        smt_ext.assert_(pf_shape_b[1] % PFB_N == 0)
-
-        smt_ext.assert_(PFA_M <= PFETCH_MAX_ROWS)
-        smt_ext.assert_(PFA_K <= PFETCH_MAX_COLS)
-        smt_ext.assert_(PFA_M >= PFETCH_MIN_ROWS)
-        smt_ext.assert_(PFA_K >= PFETCH_MIN_COLS)
-
-        smt_ext.assert_(PFB_K <= PFETCH_MAX_ROWS)
-        smt_ext.assert_(PFB_N <= PFETCH_MAX_COLS)
-        smt_ext.assert_(PFB_K >= PFETCH_MIN_ROWS)
-        smt_ext.assert_(PFB_N >= PFETCH_MIN_COLS)
-
-        smt_ext.assert_(LDA_M % DPAS.M == 0)
-        smt_ext.assert_(LDA_K % DPAS.K == 0)
-        smt_ext.assert_(LDB_K % DPAS.K == 0)
-        smt_ext.assert_(LDB_N % DPAS.N == 0)
-
-        # prefetch A thread layout
-        prefetch_th_a_m = pf_shape_a[0] // PFA_M
-        prefetch_th_a_k = pf_shape_a[1] // PFA_K
-
-        prefetch_th_a = prefetch_th_a_m * prefetch_th_a_k
-        smt_ext.assert_(prefetch_th_a <= gpu_specs.max_nb_threads)
-        smt_ext.assert_(prefetch_th_a_m * prefetch_th_a_k >= MIN_NB_THREADS)
-
-        # prefetch B thread layout
-        prefetch_th_b_k = pf_shape_b[0] // PFB_K
-        prefetch_th_b_n = pf_shape_b[1] // PFB_N
-        prefetch_th_b = prefetch_th_b_k * prefetch_th_b_n
-        smt_ext.assert_(prefetch_th_b <= gpu_specs.max_nb_threads)
-        if isinstance(prefetch_th_b, smt_ext.SMTIntValue):
-            # NB: Constraint only enabled during tuning.
-            smt_ext.assert_(prefetch_th_b_k * prefetch_th_b_n >= MIN_NB_THREADS)
-
-        return prefetch_th_a_m, prefetch_th_a_k, prefetch_th_b_k, prefetch_th_b_n
-
-    prefetch_layout_a = constrain_and_calculate_load_and_prefetch_params.results[0:2]
-    prefetch_layout_b = constrain_and_calculate_load_and_prefetch_params.results[2:4]
+    prefetch_layout_a = [pf_shape_a[0] // prefetch_a_m, pf_shape_a[1] // prefetch_a_k]
+    prefetch_layout_b = [pf_shape_b[0] // prefetch_b_k, pf_shape_b[1] // prefetch_b_n]
 
     # matmul matrix shapes
     sg_tile_a = [sg_m, k_tile]

--- a/lighthouse/schedule/xegpu/reduction_schedule.py
+++ b/lighthouse/schedule/xegpu/reduction_schedule.py
@@ -250,7 +250,7 @@ def bundle_xegpu_reduction_schedule(
     gpu_func = match(gpu_mod, ops={"gpu.func"})
     store_nd_ops = match(gpu_func, ops={"xegpu.store_nd"})
     store_matrix_ops = match(gpu_func, ops={"xegpu.store_matrix"})
-    sg_layout = [layer_params["sg_rows"], 1]
+    sg_layout = [layer_params["wg_rows"] // layer_params["sg_rows"], 1]
     sg_data = [layer_params["sg_rows"], layer_params["reduction_step_size"]]
     with lh_transform.foreach(store_nd_ops) as store_op:
         xegpu.set_anchor_layout(store_op, sg_layout=sg_layout, sg_data=sg_data)

--- a/lighthouse/schedule/xegpu/reduction_schedule.py
+++ b/lighthouse/schedule/xegpu/reduction_schedule.py
@@ -19,12 +19,13 @@ from lighthouse.pipeline.helper import (
     PipelineInterrupt,
 )
 from lighthouse.schedule import schedule_boilerplate
+from lighthouse.schedule.parameters import ScheduleParameters
 from lighthouse.dialects.transform import transform_ext
 
 
 def reduction_schedule(
     stop_at_stage: str | None = None,
-    parameters: dict | None = None,
+    params: ScheduleParameters | None = None,
     payload_func_name: str = "payload",
 ) -> ir.Module:
     """
@@ -39,7 +40,8 @@ def reduction_schedule(
 
     Args:
         stop_at_stage: Optional stage name to stop early (for debugging)
-        parameters: Dictionary with scheduling parameters:
+        params: ScheduleParameters object containing one reduction layer
+            parameter dictionary with keys:
             - wg_rows: Number of rows per workgroup
             - sg_rows: Number of rows per subgroup
             - subgroup_size: Size of subgroup
@@ -49,7 +51,9 @@ def reduction_schedule(
     Returns:
         MLIR module containing the transform schedule
     """
-    assert parameters is not None, "Schedule parameters must be provided"
+    assert params is not None and len(params) > 0, (
+        "Schedule parameters must be provided"
+    )
 
     with schedule_boilerplate() as (schedule, named_seq):
         # match the payload module
@@ -66,7 +70,7 @@ def reduction_schedule(
             bundle_xegpu_reduction_schedule(
                 payload_mod,
                 payload_func_name=payload_func_name,
-                parameters=parameters,
+                params=params,
                 stop_at_stage=stop_at_stage,
             )
         except PipelineInterrupt:
@@ -80,15 +84,17 @@ def reduction_schedule(
 def bundle_xegpu_reduction_schedule(
     mod: ir.Value[transform.AnyOpType],
     payload_func_name: str,
-    parameters: dict,
+    params: ScheduleParameters,
     stop_at_stage: str = "",
 ) -> ir.Value[transform.AnyOpType]:
     """Schedule for lowering softmax payload to xegpu wg level."""
 
+    layer_params = params[0]
+
     if stop_at_stage == "initial":
         raise PipelineInterrupt()
 
-    reduction_step_size = parameters["reduction_step_size"]
+    reduction_step_size = layer_params["reduction_step_size"]
 
     anytype = transform.AnyOpType.get()
 
@@ -121,7 +127,7 @@ def bundle_xegpu_reduction_schedule(
     leaf_generic = transform_ext.extract_handle(generic_ops, -1)
     _, [wg_loop], _ = lh_transform.tile(
         leaf_generic,
-        tile_sizes=(parameters["wg_rows"],),
+        tile_sizes=(layer_params["wg_rows"],),
         fuse_producers=True,
         use_forall=True,
         apply_cleanup=False,
@@ -219,8 +225,8 @@ def bundle_xegpu_reduction_schedule(
     func = get_named_func(mod, payload_func_name)
     # set the number of threads for the gpu.launch operation
     launch_op = match_and_split(func, ops={"gpu.launch"})
-    num_subgroups = parameters["wg_rows"] // parameters["sg_rows"]
-    num_threads = num_subgroups * parameters["subgroup_size"]
+    num_subgroups = layer_params["wg_rows"] // layer_params["sg_rows"]
+    num_threads = num_subgroups * layer_params["subgroup_size"]
     xegpu.set_gpu_launch_threads(launch_op[0], threads=[num_threads, 1, 1])
 
     # outline gpu func
@@ -244,8 +250,8 @@ def bundle_xegpu_reduction_schedule(
     gpu_func = match(gpu_mod, ops={"gpu.func"})
     store_nd_ops = match(gpu_func, ops={"xegpu.store_nd"})
     store_matrix_ops = match(gpu_func, ops={"xegpu.store_matrix"})
-    sg_layout = [parameters["sg_rows"], 1]
-    sg_data = [parameters["sg_rows"], parameters["reduction_step_size"]]
+    sg_layout = [layer_params["sg_rows"], 1]
+    sg_data = [layer_params["sg_rows"], layer_params["reduction_step_size"]]
     with lh_transform.foreach(store_nd_ops) as store_op:
         xegpu.set_anchor_layout(store_op, sg_layout=sg_layout, sg_data=sg_data)
         transform.yield_()

--- a/lighthouse/schedule/xegpu/xegpu_parameter_selector.py
+++ b/lighthouse/schedule/xegpu/xegpu_parameter_selector.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from .matmul_costmodel import generate_configs
 from .xegpu_specs import XeGPUSpecs
+from ..parameters import ScheduleParameters
 
 DEFAULT_JSON_FILE = str(Path(__file__).parent / "matmul_params.json")
 
@@ -30,7 +31,7 @@ class XeGPUParameterSelector:
         self.gpu_specs = XeGPUSpecs.get(self.device)
         self.matmul_param_db = load_param_database(json_file)
 
-    def get_parameters(
+    def get_parameters_dict(
         self,
         shape: tuple[int, int, int],
         transpose_a: bool = False,
@@ -66,5 +67,19 @@ class XeGPUParameterSelector:
         params.setdefault("transpose_b", False)
         return params
 
-    def get_parameters_for_layers(self, param_list: list[dict]) -> list:
-        return [self.get_parameters(**params) for params in param_list]
+    def get_parameters(
+        self,
+        shape: tuple[int, int, int],
+        transpose_a: bool = False,
+        transpose_b: bool = False,
+        **kwargs,
+    ) -> ScheduleParameters:
+        params_dict = self.get_parameters_dict(
+            shape, transpose_a=transpose_a, transpose_b=transpose_b, **kwargs
+        )
+        return ScheduleParameters([params_dict])
+
+    def get_parameters_for_layers(self, param_list: list[dict]) -> ScheduleParameters:
+        return ScheduleParameters(
+            [self.get_parameters_dict(**params) for params in param_list]
+        )


### PR DESCRIPTION
- Adds `ScheduleParameters` object, see #253.
- The xegpu mlp, elemwise and reduction schedules take `ScheduleParameters` object.
- Tune dialect knobs are removed from xegpu schedules. All tile size values must have concrete int values now.
- Fixes a bug in the reduction schedule.

For xegpu KernelBench kernels, the `examples/xegpu/kernel_bench.py` routine now dumps the used kernel parameters as ScheduleParameters JSON file. In case of a single-matmul kernel, it runs the matmul autotuner to find good parameter values. For other cases (elementwise, reduction, MLPs) it uses heuristics or known hardcoded values. The dumped JSON file can be used directly with the appropriate lowering schedule (mlp, elemwise, or reduction).

```txt
 $ python examples/xegpu/kernel_bench.py -l 1 -b 16
 [...]
Executing benchmark: level1/16_Matmul_with_transposed_A.py
Payload function name: main
Inputs:
  0: shape=[8192, 2048], element_type=bf16
  1: shape=[8192, 4096], element_type=bf16
  2: shape=[2048, 4096], element_type=bf16
Tuning parameters and saving to kb_params_level1-16.json
 [...]
```