### PR TITLE
[transform] Tiling strategy framework

### DIFF
--- a/lighthouse/dialects/transform/transform_ext/ops/assign_tile_sizes.py
+++ b/lighthouse/dialects/transform/transform_ext/ops/assign_tile_sizes.py
@@ -3,6 +3,7 @@ from mlir.dialects import ext, transform
 from mlir.dialects.transform import DiagnosedSilenceableFailure
 
 from lighthouse.dialects.transform.transform_ext import TransformExtensionDialect
+from lighthouse.execution.target import TargetInfo
 from lighthouse.dialects.transform.transform_ext.utils import tile_size_analysis as tsa
 
 
@@ -22,12 +23,16 @@ class AssignTileSizesOp(TransformExtensionDialect.Operation, name="assign_tile_s
         target: Handle to anchor op(s).
         tile_size: Optional size for tiled dimensions (default: 32).
             Acts as a user hint, e.g. tile by 64 instead of the default 32.
+        strategy: Tiling strategy.
     Return:
         Pass-through handle to the (now annotated) target ops.
     """
 
     target: ext.Operand[transform.AnyOpType]
     tile_size: ext.Operand[transform.AnyParamType] | None = None
+    strategy: ir.StringAttr = ext.attribute(
+        default_factory=lambda: ir.StringAttr.get("cache")
+    )
     annotated: ext.Result[transform.AnyOpType[()]] = ext.infer_result()
 
     @classmethod
@@ -51,6 +56,9 @@ class AssignTileSizesOp(TransformExtensionDialect.Operation, name="assign_tile_s
                 if len(tile_attr) == 1 and isinstance(tile_attr[0], ir.IntegerAttr):
                     tile_size = tile_attr[0].value
 
+            strategy = op.strategy.value
+            target = TargetInfo.host()
+
             annotated = []
             for target_op in target_ops:
                 # Respect existing annotations so earlier (e.g. GEMM-derived)
@@ -58,7 +66,12 @@ class AssignTileSizesOp(TransformExtensionDialect.Operation, name="assign_tile_s
                 if tsa.get_tile_sizes_attr(target_op) is not None:
                     annotated.append(target_op)
                     continue
-                sizes = tsa.compute_tile_sizes(target_op, tile_size=tile_size)
+                sizes = tsa.compute_tile_sizes(
+                    target_op,
+                    tile_size=tile_size,
+                    strategy=strategy,
+                    target=target,
+                )
                 if sizes is None:
                     continue
                 tsa.set_tile_sizes_attr(target_op, sizes)
@@ -82,6 +95,7 @@ class AssignTileSizesOp(TransformExtensionDialect.Operation, name="assign_tile_s
 def assign_tile_sizes(
     target: ir.Value[transform.AnyOpType],
     tile_size: int | ir.Value | None = None,
+    strategy: str = "cache",
 ) -> ir.Value:
     """
     snake_case wrapper to create an AssignTileSizesOp.
@@ -89,6 +103,7 @@ def assign_tile_sizes(
     Args:
         target: Handle to anchor op(s).
         tile_size: Optional size for tiled dimensions (default: 32).
+        strategy: Tiling strategy.
     Returns:
         Pass-through handle to the (now annotated) target ops.
     """
@@ -99,4 +114,5 @@ def assign_tile_sizes(
     return AssignTileSizesOp(
         target=target,
         tile_size=tile_size,
+        strategy=ir.StringAttr.get(strategy),
     ).annotated

--- a/lighthouse/dialects/transform/transform_ext/utils/tile_size_analysis.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/tile_size_analysis.py
@@ -1,9 +1,14 @@
 from collections.abc import Sequence
 
 from mlir import ir
-from mlir.dialects import linalg
 
-from lighthouse.utils.mlir import opview, indexing_maps, dim_position, linalg_outputs
+from lighthouse.execution.target import TargetInfo
+from lighthouse.utils.mlir import opview
+
+from .tiling import (
+    StrategyContext,
+    get_tiling_strategy,
+)
 
 # Attribute used to annotate payload ops with their target tile sizes
 # (one entry per iteration dimension, in loop order).
@@ -12,100 +17,27 @@ TILE_SIZES_ATTR_NAME = "transform_ext.tile_sizes"
 # Default size used for tiled dimensions when no hint is provided.
 DEFAULT_TILE_SIZE = 32
 
-# Number of innermost parallel dimensions tiled with the full tile size.
-# Other parallel dimensions are tiled with unit size to keep them sequential.
-DEFAULT_PARALLEL_TILE_DIMS = 2
-
-
-def _output_tensor_dim_of_iter_dim(out_map: ir.AffineMap) -> dict[int, int]:
-    """Map each iteration dim to the output tensor dim it indexes (if any)."""
-    mapping: dict[int, int] = {}
-    for tensor_dim, expr in enumerate(out_map.results):
-        pos = dim_position(expr)
-        if pos is not None:
-            mapping[pos] = tensor_dim
-    return mapping
-
-
-def _disable_small_tiles(
-    op: ir.OpView,
-    out_map: ir.AffineMap,
-    sizes: list[int],
-    tile_size: int = DEFAULT_TILE_SIZE,
-) -> None:
-    """Disable tiling for parallel dims whose static extent is below tile_size.
-
-    Tiling a dimension that is smaller than the tile size only adds loop
-    overhead, so such dimensions are left untiled (size 0).
-    """
-    out_type = ir.ShapedType(linalg_outputs(op)[0].type)
-    iter_to_tensor = _output_tensor_dim_of_iter_dim(out_map)
-    for iter_dim, tensor_dim in iter_to_tensor.items():
-        if sizes[iter_dim] <= 1:
-            # Unit / untiled dimensions are always fine.
-            continue
-        dim = out_type.shape[tensor_dim]
-        if ir.ShapedType.is_static_size(dim) and dim < tile_size:
-            sizes[iter_dim] = 0
-
 
 def compute_tile_sizes(
     op: ir.Operation | ir.OpView,
     tile_size: int = DEFAULT_TILE_SIZE,
-    parallel_tile_dims: int = DEFAULT_PARALLEL_TILE_DIMS,
+    strategy: str = "cache",
+    target: TargetInfo | None = None,
 ) -> list[int] | None:
-    """Compute target tile sizes for an op over its iteration space.
+    """Compute per-dimension tile sizes for an operation's iteration space.
 
-    For structured ops, the innermost `parallel_tile_dims` parallel (output) dims
-    are tiled with `tile_size`, any remaining parallel dims (batch / outer M/N)
-    with a unit size, and reduction dims are left untiled. Statically small
-    parallel dims are also left untiled.
+    Args:
+        op: Payload operation to analyze.
+        tile_size: Tiling size hint.
+        strategy: Tiling strategy.
+        target: Target-hardware description.
 
-    pack / unpack ops are tiled to a single inner tile per iteration: a pack tiles
-    every source dim by 1; an unpack tiles its packed output dims (`inner_dims_pos`)
-    by the inner tile size and the rest by 1.
-
-    Returns one size per iteration dim (loop order), or None if unsupported.
+    Returns:
+        A list of tile sizes (one per iteration dimension), or `None` when the
+        operation is unsupported by the selected strategy.
     """
-    ov = opview(op)
-
-    # pack / unpack have no affine indexing maps; their tiling follows the pack
-    # structure (they are tiled standalone, not fused into a group).
-    if isinstance(ov, linalg.PackOp):
-        return [1] * ir.ShapedType(ov.source.type).rank
-    if isinstance(ov, linalg.UnPackOp):
-        sizes = [1] * ir.ShapedType(ov.result.type).rank
-        inner_dims = ir.DenseI64ArrayAttr(ov.inner_dims_pos)
-        inner_tiles = ir.DenseI64ArrayAttr(ov.static_inner_tiles)
-        for dim, tile in zip(inner_dims, inner_tiles):
-            sizes[dim] = tile
-        return sizes
-
-    maps = indexing_maps(ov)
-    if maps is None:
-        return None
-    # Only single-output ops are supported for now.
-    if len(linalg_outputs(ov)) != 1:
-        return None
-
-    # The output operand's map is the last one (inputs first, then outputs).
-    out_map = maps[-1]
-    sizes = [0] * out_map.n_dims
-
-    # Tile the innermost parallel dims with the full tile size and
-    # any outer parallel dims (batch, outer M/N) with a unit size.
-    parallel_dims = [
-        pos for pos in (dim_position(e) for e in out_map.results) if pos is not None
-    ]
-    if not parallel_dims:
-        return None
-    for d in parallel_dims[:-parallel_tile_dims]:
-        sizes[d] = 1
-    for d in parallel_dims[-parallel_tile_dims:]:
-        sizes[d] = tile_size
-
-    _disable_small_tiles(ov, out_map, sizes, tile_size)
-    return sizes
+    ctx = StrategyContext(tile_size=tile_size, target=target)
+    return get_tiling_strategy(strategy).compute(op, ctx)
 
 
 def get_tile_sizes_attr(op: ir.Operation | ir.OpView) -> list[int] | None:
@@ -127,3 +59,13 @@ def clear_tile_sizes_attr(op: ir.Operation | ir.OpView) -> None:
     attrs = opview(op).operation.attributes
     if TILE_SIZES_ATTR_NAME in attrs:
         del attrs[TILE_SIZES_ATTR_NAME]
+
+
+__all__ = [
+    "DEFAULT_TILE_SIZE",
+    "TILE_SIZES_ATTR_NAME",
+    "clear_tile_sizes_attr",
+    "compute_tile_sizes",
+    "get_tile_sizes_attr",
+    "set_tile_sizes_attr",
+]

--- a/lighthouse/dialects/transform/transform_ext/utils/tiling/__init__.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/tiling/__init__.py
@@ -1,0 +1,14 @@
+from .strategy_base import (
+    StrategyContext,
+    TilingStrategy,
+)
+from .common import parallel_and_reduction_dims
+from .registry import get_tiling_strategy, normalize_strategy_name
+
+__all__ = [
+    "StrategyContext",
+    "TilingStrategy",
+    "get_tiling_strategy",
+    "normalize_strategy_name",
+    "parallel_and_reduction_dims",
+]

--- a/lighthouse/dialects/transform/transform_ext/utils/tiling/common.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/tiling/common.py
@@ -1,0 +1,42 @@
+from mlir import ir
+
+from lighthouse.utils.mlir import dim_position, linalg_outputs
+
+
+def parallel_and_reduction_dims(out_map: ir.AffineMap) -> tuple[list[int], list[int]]:
+    """Split iteration dims into (parallel, reduction) via the output indexing map.
+
+    Dims indexed by the output map are parallel; all others are reduction.
+    """
+    parallel_dims = [
+        pos for pos in (dim_position(e) for e in out_map.results) if pos is not None
+    ]
+    reduction_dims = [d for d in range(out_map.n_dims) if d not in parallel_dims]
+    return parallel_dims, reduction_dims
+
+
+def output_tensor_dim_of_iter_dim(out_map: ir.AffineMap) -> dict[int, int]:
+    """Map each iteration dim to the output tensor dim it indexes (if any)."""
+    mapping: dict[int, int] = {}
+    for tensor_dim, expr in enumerate(out_map.results):
+        pos = dim_position(expr)
+        if pos is not None:
+            mapping[pos] = tensor_dim
+    return mapping
+
+
+def disable_small_tiles(
+    op: ir.OpView,
+    out_map: ir.AffineMap,
+    sizes: list[int],
+    tile_size: int,
+) -> None:
+    """Disable tiling for parallel dims whose static extent is below tile_size."""
+    out_type = ir.ShapedType(linalg_outputs(op)[0].type)
+    iter_to_tensor = output_tensor_dim_of_iter_dim(out_map)
+    for iter_dim, tensor_dim in iter_to_tensor.items():
+        if sizes[iter_dim] <= 1:
+            continue
+        dim = out_type.shape[tensor_dim]
+        if ir.ShapedType.is_static_size(dim) and dim < tile_size:
+            sizes[iter_dim] = 0

--- a/lighthouse/dialects/transform/transform_ext/utils/tiling/registry.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/tiling/registry.py
@@ -1,0 +1,24 @@
+from .strategy_base import TilingStrategy
+from .strategy_cache import CacheTilingStrategy
+
+
+# Maps each canonical strategy name to its implementation class.
+_STRATEGY_REGISTRY: dict[str, type[TilingStrategy]] = {
+    "cache": CacheTilingStrategy,
+}
+
+
+def normalize_strategy_name(name: str | None) -> str:
+    """Canonicalize a strategy name to its registry key."""
+    return (name or "cache").strip().lower().replace("-", "_")
+
+
+def get_tiling_strategy(name: str) -> TilingStrategy:
+    """Instantiate the tiling strategy registered under `name`.
+
+    Raises ValueError if `name` (after normalization) is not a known strategy.
+    """
+    key = normalize_strategy_name(name)
+    if key not in _STRATEGY_REGISTRY:
+        raise ValueError(f"Unknown tiling strategy: {name}")
+    return _STRATEGY_REGISTRY[key]()

--- a/lighthouse/dialects/transform/transform_ext/utils/tiling/strategy_base.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/tiling/strategy_base.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from mlir import ir
+
+from lighthouse.execution.target import TargetInfo
+from lighthouse.utils.mlir import indexing_maps, linalg_outputs, opview
+
+
+@dataclass
+class StrategyContext:
+    tile_size: int = 32  # Hint for tile size selection.
+    target: TargetInfo | None = None
+
+
+class TilingStrategy(ABC):
+    """Base interface for tile-size selection strategies."""
+
+    @abstractmethod
+    def compute(
+        self, op: ir.Operation | ir.OpView, ctx: StrategyContext
+    ) -> list[int] | None:
+        """Return one tile size per loop dimension, or None if unsupported."""
+
+    @staticmethod
+    def output_map(op: ir.Operation | ir.OpView) -> ir.AffineMap | None:
+        """Output indexing map of a single-output linalg op, else None."""
+        ov = opview(op)
+        maps = indexing_maps(ov)
+        if maps is None or len(linalg_outputs(ov)) != 1:
+            return None
+        return maps[-1]

--- a/lighthouse/dialects/transform/transform_ext/utils/tiling/strategy_cache.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/tiling/strategy_cache.py
@@ -1,0 +1,50 @@
+from mlir import ir
+from mlir.dialects import linalg
+
+from lighthouse.utils.mlir import opview
+
+from .strategy_base import StrategyContext, TilingStrategy
+from .common import disable_small_tiles, parallel_and_reduction_dims
+
+
+class CacheTilingStrategy(TilingStrategy):
+    """Cache-level tiling.
+
+    Intended as a first-level tiling.
+    Improves memory access patterns and helps expose parallelism.
+    """
+
+    _PARALLEL_TILE_DIMS = 2
+
+    def compute(
+        self, op: ir.Operation | ir.OpView, ctx: StrategyContext
+    ) -> list[int] | None:
+        ov = opview(op)
+
+        # pack / unpack have no affine indexing maps; their tiling follows
+        # the pack structure.
+        if isinstance(ov, linalg.PackOp):
+            return [1] * ir.ShapedType(ov.source.type).rank
+        if isinstance(ov, linalg.UnPackOp):
+            sizes = [1] * ir.ShapedType(ov.result.type).rank
+            inner_dims = ir.DenseI64ArrayAttr(ov.inner_dims_pos)
+            inner_tiles = ir.DenseI64ArrayAttr(ov.static_inner_tiles)
+            for dim, tile in zip(inner_dims, inner_tiles):
+                sizes[dim] = tile
+            return sizes
+
+        out_map = self.output_map(ov)
+        if out_map is None:
+            return None
+
+        sizes = [0] * out_map.n_dims
+        parallel_dims, _ = parallel_and_reduction_dims(out_map)
+        if not parallel_dims:
+            return None
+
+        for d in parallel_dims[: -self._PARALLEL_TILE_DIMS]:
+            sizes[d] = 1
+        for d in parallel_dims[-self._PARALLEL_TILE_DIMS :]:
+            sizes[d] = ctx.tile_size
+        disable_small_tiles(ov, out_map, sizes, ctx.tile_size)
+        return sizes

--- a/lighthouse/pipeline/descriptors/x86_64/pack-and-tile.yaml
+++ b/lighthouse/pipeline/descriptors/x86_64/pack-and-tile.yaml
@@ -7,8 +7,8 @@ Pipeline:
   - schedule: "x86/pack_lowering.py[gen=lower_packs_unpacks]{tile_size=$tile_size}"
   - pass: "linalg-morph-ops{named-to-category generic-to-category}"
 
-  - schedule: "tile_and_fuse.py[gen=assign_and_propagate_tile_sizes]{tile_size=$tile_size}"
-  - schedule: "tile_and_fuse.py[gen=assign_elementwise_tile_sizes]{tile_size=$tile_size}"
+  - schedule: "tile_and_fuse.py[gen=assign_and_propagate_tile_sizes]{tile_size=$tile_size strategy=cache}"
+  - schedule: "tile_and_fuse.py[gen=assign_elementwise_tile_sizes]{tile_size=$tile_size strategy=cache}"
   - schedule: "tile_and_fuse.py[gen=tile_and_fuse_annotated]"
 
   - schedule: "linalg.py[gen=linalg_contract_fold_unit_dims]"

--- a/lighthouse/schedule/tile_and_fuse.py
+++ b/lighthouse/schedule/tile_and_fuse.py
@@ -1,10 +1,12 @@
 from mlir import ir
 from mlir.dialects import transform
 from mlir.dialects.transform import structured
+from mlir.dialects.transform import loop
 
 from lighthouse.dialects.transform import transform_ext
 from lighthouse.schedule.builders import schedule_boilerplate
 import lighthouse.transform as lh_transform
+
 
 # Named GEMM ops treated as default anchors.
 # Their tiles take precedence and drive the tiling of surrounding ops.
@@ -24,6 +26,8 @@ _GEMM_ANCHOR_OPS = [
 def assign_and_propagate_tile_sizes(
     anchor_op: str | list[str] | None = None,
     tile_size: int = 32,
+    strategy: str = "cache",
+    propagate: bool = True,
 ) -> ir.Module:
     """
     Assign tile sizes to anchor ops and propagate them to their neighbors.
@@ -35,7 +39,9 @@ def assign_and_propagate_tile_sizes(
 
     Args:
         anchor_op: Op(s) to anchor tiling on. Defaults to the GEMM op family.
-        tile_size: Size used for tiled dimensions. User hint, default 32.
+        tile_size: Tiling size hint.
+        strategy: Tiling strategy.
+        propagate: Whether to propagate the tile sizes to neighboring ops.
     Returns:
         Schedule
     """
@@ -44,13 +50,22 @@ def assign_and_propagate_tile_sizes(
 
     with schedule_boilerplate() as (sched, named_seq):
         anchors = lh_transform.match_op(named_seq.bodyTarget, anchor_op)
-        annotated = transform_ext.assign_tile_sizes(anchors, tile_size=tile_size)
-        transform_ext.propagate_tile_sizes(annotated)
+        annotated = transform_ext.assign_tile_sizes(
+            anchors,
+            tile_size=tile_size,
+            strategy=strategy,
+        )
+        if propagate:
+            transform_ext.propagate_tile_sizes(annotated)
         transform.yield_()
     return sched
 
 
-def assign_elementwise_tile_sizes(tile_size: int = 32) -> ir.Module:
+def assign_elementwise_tile_sizes(
+    tile_size: int = 32,
+    strategy: str = "cache",
+    propagate: bool = True,
+) -> ir.Module:
     """
     Anchor tiling on elementwise ops only.
 
@@ -58,7 +73,9 @@ def assign_elementwise_tile_sizes(tile_size: int = 32) -> ir.Module:
     propagation. Already-annotated ops are kept.
 
     Args:
-        tile_size: Size used for tiled dimensions. User hint, default 32.
+        tile_size: Tiling size hint.
+        strategy: Tiling strategy.
+        propagate: Whether to propagate the tile sizes to neighboring ops.
     Returns:
         Schedule
     """
@@ -67,8 +84,92 @@ def assign_elementwise_tile_sizes(tile_size: int = 32) -> ir.Module:
             named_seq.bodyTarget, structured.MatchInterfaceEnum.LinalgOp
         )
         elementwise = transform_ext.filter_elementwise(candidates)
-        annotated = transform_ext.assign_tile_sizes(elementwise, tile_size=tile_size)
-        transform_ext.propagate_tile_sizes(annotated)
+        annotated = transform_ext.assign_tile_sizes(
+            elementwise,
+            tile_size=tile_size,
+            strategy=strategy,
+        )
+        if propagate:
+            transform_ext.propagate_tile_sizes(annotated)
+        transform.yield_()
+    return sched
+
+
+def _execute_annotated(
+    target_op: str | list[str] | None,
+    use_forall: bool,
+    clear_annotations: bool,
+    action: str,
+) -> ir.Module:
+    """Execute annotated tiling actions for matched ops.
+
+    This internal helper applies one of two actions over candidate ops:
+    - ``"fuse"``: select fusion roots, tile them using annotated tile sizes,
+      and greedily fuse producers.
+    - ``"tile"``: tile candidates using annotated tile sizes only.
+
+    Args:
+        target_op: Candidate op(s) to consider. Defaults to all linalg ops.
+        use_forall: Use ``scf.forall`` for tiling when supported by the action.
+        clear_annotations: Clear tile/fuse annotations on produced loop handles.
+        action: Action to perform.
+    Returns:
+        Schedule
+    """
+
+    def _merge_loop_handles(loop_handles):
+        """Normalize loop handles to a single handle when possible."""
+        try:
+            loops = list(loop_handles)
+        except TypeError:
+            return loop_handles
+        if len(loops) == 1:
+            return loops[0]
+        return transform.merge_handles(loops)
+
+    if target_op is None:
+        target_op = structured.MatchInterfaceEnum.LinalgOp
+
+    with schedule_boilerplate() as (sched, named_seq):
+        candidates = lh_transform.match_op(named_seq.bodyTarget, target_op)
+        if action == "fuse":
+            targets = transform_ext.get_fusion_roots(candidates)
+        else:
+            targets = candidates
+        with lh_transform.foreach(targets) as op:
+            tiles = transform_ext.get_tile_sizes(op)
+
+            if action == "fuse":
+                fused = structured.FuseOp(
+                    op,
+                    tile_sizes=tiles,
+                    apply_cleanup=True,
+                    use_forall=use_forall,
+                )
+                if clear_annotations:
+                    loops = _merge_loop_handles(fused.loops)
+                    transform_ext.clear_tile_and_fuse_annotations(loops)
+
+            elif action == "tile":
+                if use_forall:
+                    _, loops = structured.TileUsingForallOp(
+                        op,
+                        tile_sizes=tiles,
+                    ).results
+                else:
+                    _, loops = structured.TileUsingForOp(
+                        op,
+                        sizes=tiles,
+                    ).results
+                if clear_annotations:
+                    loops = _merge_loop_handles(loops)
+                    transform_ext.clear_tile_and_fuse_annotations(loops)
+
+            else:
+                raise ValueError(f"Unsupported action: {action}")
+
+            transform.yield_()
+        lh_transform.cleanup(named_seq.bodyTarget)
         transform.yield_()
     return sched
 
@@ -92,26 +193,61 @@ def tile_and_fuse_annotated(
     Returns:
         Schedule
     """
+    return _execute_annotated(
+        target_op=target_op,
+        use_forall=use_forall,
+        clear_annotations=clear_annotations,
+        action="fuse",
+    )
+
+
+def tile_annotated(
+    target_op: str | list[str] | None = None,
+    use_forall: bool = False,
+    clear_annotations: bool = True,
+) -> ir.Module:
+    """
+    Tile annotated ops with its tile sizes.
+
+    Args:
+        target_op: Candidate op(s) to consider. Defaults to all linalg ops.
+        use_forall: Generate `scf.forall` loops (parallel) when tiling.
+        clear_annotations: Clear the annotations from the tiled ops.
+    Returns:
+        Schedule
+    """
+    return _execute_annotated(
+        target_op=target_op,
+        use_forall=use_forall,
+        clear_annotations=clear_annotations,
+        action="tile",
+    )
+
+
+def tile_and_unroll_annotated(
+    target_op: str | list[str] | None = None,
+    clear_annotations: bool = True,
+) -> ir.Module:
+    """Tile annotated ops and fully unroll the loops created by tiling."""
     if target_op is None:
         target_op = structured.MatchInterfaceEnum.LinalgOp
 
     with schedule_boilerplate() as (sched, named_seq):
         candidates = lh_transform.match_op(named_seq.bodyTarget, target_op)
-        roots = transform_ext.get_fusion_roots(candidates)
-        with lh_transform.foreach(roots) as op:
+        with lh_transform.foreach(candidates) as op:
             tiles = transform_ext.get_tile_sizes(op)
-            fused = structured.FuseOp(
+            _, loops = structured.TileUsingForOp(
                 op,
-                tile_sizes=tiles,
-                apply_cleanup=True,
-                use_forall=use_forall,
-            )
-            # Fusion has consumed the annotations of this group. Clear them from
-            # the ops now inside the generated loop(s).
+                sizes=tiles,
+            ).results
             if clear_annotations:
-                loops = transform.merge_handles(list(fused.loops))
+                # Clear annotations before unrolling: full unroll may consume
+                # loop handles and make post-unroll cleanup invalid.
                 transform_ext.clear_tile_and_fuse_annotations(loops)
+            inner_to_outer = transform_ext.reverse_handles(loops)
+            with lh_transform.foreach(inner_to_outer) as handle:
+                loop.loop_unroll_full(handle)
+                transform.yield_()
             transform.yield_()
-        lh_transform.cleanup(named_seq.bodyTarget)
         transform.yield_()
     return sched

--- a/test/transform/test_assign_tile_sizes.py
+++ b/test/transform/test_assign_tile_sizes.py
@@ -1,0 +1,83 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from mlir import ir
+from mlir.dialects import transform
+
+import lighthouse.dialects as lh_dialects
+from lighthouse import transform as lh_transform
+from lighthouse.dialects.transform.transform_ext import assign_tile_sizes
+from lighthouse.dialects.transform.transform_ext.ops.assign_tile_sizes import (
+    AssignTileSizesOp,
+)
+from lighthouse.schedule.builders import schedule_boilerplate
+
+PAYLOAD = """
+module {
+  func.func @main(%a: tensor<128x64xf32>, %b: tensor<64x128xf32>) -> tensor<128x128xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e = tensor.empty() : tensor<128x128xf32>
+    %f = linalg.fill ins(%cst : f32) outs(%e : tensor<128x128xf32>) -> tensor<128x128xf32>
+    %mm = linalg.matmul ins(%a, %b : tensor<128x64xf32>, tensor<64x128xf32>)
+        outs(%f : tensor<128x128xf32>) -> tensor<128x128xf32>
+    return %mm : tensor<128x128xf32>
+  }
+}
+"""
+
+PAYLOAD_ELTWISE = """
+module {
+    func.func @main(%a: tensor<64x64xf32>, %b: tensor<64x64xf32>) -> tensor<64x64xf32> {
+        %sum = linalg.add ins(%a, %b : tensor<64x64xf32>, tensor<64x64xf32>)
+                outs(%a : tensor<64x64xf32>) -> tensor<64x64xf32>
+        return %sum : tensor<64x64xf32>
+    }
+}
+"""
+
+
+def run(
+    name: str,
+    payload_text: str,
+    target_op: str,
+    strategy: str,
+    tile_size: int | None = None,
+):
+    print(f"Test: {name}", flush=True)
+    with ir.Context(), ir.Location.unknown():
+        lh_dialects.register_and_load()
+        payload = ir.Module.parse(payload_text)
+        with schedule_boilerplate() as (sched, named_seq):
+            ops = lh_transform.match_op(named_seq.bodyTarget, target_op)
+            annotated_handle = assign_tile_sizes(
+                ops,
+                tile_size=tile_size,
+                strategy=strategy,
+            )
+            # Verify the strategy attribute is wired on the op's IR.
+            assign_op = annotated_handle.owner.opview
+            assert isinstance(assign_op, AssignTileSizesOp), (
+                f"Expected AssignTileSizesOp, got {type(assign_op)}"
+            )
+            assert assign_op.strategy.value == strategy, (
+                f"Expected strategy={strategy!r}, got {assign_op.strategy.value!r}"
+            )
+            transform.yield_()
+        sched.body.operations[0].apply(payload.operation)
+        print(payload)
+
+
+# CHECK-LABEL: Test: strategy_attr_cache
+# CHECK: linalg.matmul
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 32, 0>
+run("strategy_attr_cache", PAYLOAD, "linalg.matmul", "cache")
+
+# CHECK-LABEL: Test: eltwise_non_default_tile_size
+# CHECK: linalg.add
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 16, 16>
+run(
+    "eltwise_non_default_tile_size",
+    PAYLOAD_ELTWISE,
+    "linalg.add",
+    "cache",
+    tile_size=16,
+)

--- a/test/transform/test_tile_and_fuse.py
+++ b/test/transform/test_tile_and_fuse.py
@@ -2,7 +2,7 @@
 
 """Tests for the generic tile-and-fuse transform ops and schedules.
 
-Exercises the three-step strategy on linalg payloads:
+Exercises the three-step approach on linalg payloads:
     1. assign tile sizes to anchor ops (GEMMs / elementwise)
     2. propagate them to neighboring ops
     3. tile and fuse using the annotations
@@ -30,15 +30,15 @@ def run(name: str, payload_str: str, *schedules):
 
 
 def assign_gemm():
-    return tf.assign_and_propagate_tile_sizes(tile_size=32)
+    return tf.assign_and_propagate_tile_sizes(tile_size=32, strategy="cache")
 
 
 def assign_elementwise():
-    return tf.assign_elementwise_tile_sizes(tile_size=32)
+    return tf.assign_elementwise_tile_sizes(tile_size=32, strategy="cache")
 
 
 def assign_elementwise64():
-    return tf.assign_elementwise_tile_sizes(tile_size=64)
+    return tf.assign_elementwise_tile_sizes(tile_size=64, strategy="cache")
 
 
 def tile_and_fuse():

--- a/test/transform/test_tile_size_ops.py
+++ b/test/transform/test_tile_size_ops.py
@@ -9,6 +9,7 @@ from lighthouse import transform as lh_transform
 from lighthouse.dialects.transform.transform_ext import assign_tile_sizes
 from lighthouse.dialects.transform.transform_ext import get_leading_unit_tile_sizes
 from lighthouse.dialects.transform.transform_ext import get_tile_sizes
+
 from lighthouse.schedule.builders import schedule_boilerplate
 
 
@@ -99,10 +100,16 @@ module {
 """
 
 
-def build_assign_schedule(op_name: str):
+def build_assign_schedule(
+    op_name: str,
+    strategy: str = "cache",
+):
     with schedule_boilerplate() as (sched, named_seq):
         ops = lh_transform.match_op(named_seq.bodyTarget, op_name)
-        assign_tile_sizes(ops)
+        assign_tile_sizes(
+            ops,
+            strategy=strategy,
+        )
         transform.yield_()
     return sched
 

--- a/test/transform/test_tiling_strategy_cache.py
+++ b/test/transform/test_tiling_strategy_cache.py
@@ -1,0 +1,50 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from mlir import ir
+from mlir.dialects import transform
+
+import lighthouse.dialects as lh_dialects
+from lighthouse import transform as lh_transform
+from lighthouse.dialects.transform.transform_ext import assign_tile_sizes
+from lighthouse.schedule.builders import schedule_boilerplate
+
+
+def run(name: str, payload_str: str, build_schedule):
+    print(f"Test: {name}", flush=True)
+    with ir.Context(), ir.Location.unknown():
+        lh_dialects.register_and_load()
+        payload = ir.Module.parse(payload_str)
+        sched = build_schedule()
+        sched.body.operations[0].apply(payload.operation)
+        print(payload)
+
+
+PAYLOAD = """
+#id = affine_map<(d0, d1) -> (d0, d1)>
+module {
+  func.func @main(%a: tensor<16x64xf32>) -> tensor<16x64xf32> {
+    %e = tensor.empty() : tensor<16x64xf32>
+    %g = linalg.generic {indexing_maps = [#id, #id], iterator_types = ["parallel", "parallel"]}
+        ins(%a : tensor<16x64xf32>)
+        outs(%e : tensor<16x64xf32>) {
+    ^bb0(%i: f32, %o: f32):
+      linalg.yield %i : f32
+    } -> tensor<16x64xf32>
+    return %g : tensor<16x64xf32>
+  }
+}
+"""
+
+
+def build_schedule():
+    with schedule_boilerplate() as (sched, named_seq):
+        ops = lh_transform.match_op(named_seq.bodyTarget, "linalg.generic")
+        assign_tile_sizes(ops, strategy="cache")
+        transform.yield_()
+    return sched
+
+
+# CHECK-LABEL: Test: cache_strategy
+# CHECK: linalg.generic
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 0, 32>
+run("cache_strategy", PAYLOAD, build_schedule)


### PR DESCRIPTION
Adds a pluggable tile-size selection framework.
As an initial integration, the current default tile sizes are ported over to a cache strategy implementation.

The tiling strategies act as plugins to steer tile size selection step of Tile'n'Fuse framework while fully reusing the common infrastructure powering further propagation and tiling/fusion.

By separating the tile size selection logic, Tile'n'Fuse tools become more flexible and can more easily adapt to payload IR.

Assisted-by: Claude