### PR TITLE
Include json files in package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ build-backend = "setuptools.build_meta"
 include = ["lighthouse*"]
 
 [tool.setuptools.package-data]
-"lighthouse" = ["**/*.yaml"]
+"lighthouse" = ["**/*.yaml", "**/*.json"]
 
 [tool.setuptools.dynamic]
 version = {attr = "lighthouse.__version__"}


### PR DESCRIPTION
Ships all `*.json` files under the `lighthouse` directory in the python package.

Needed for distributing `lighthouse/schedule/xegpu/matmul_params.json` at the moment.