### PR TITLE
[xegpu] Simplify kernel bench script

### DIFF
--- a/examples/xegpu/kernel_bench.py
+++ b/examples/xegpu/kernel_bench.py
@@ -31,10 +31,6 @@ Run using bfloat16 datatype
 Increase verbosity
     python xegpu_kernel_bench.py -l 1 -b 1 -vv
 
-Run a single benchmark in debug mode (no timeout, exceptions raised
-immediately)
-    python xegpu_kernel_bench.py -l 1 -b 1 -vv --debug
-
 Dump the kernel at a specific stage of the pipeline, does not execute the
 benchmark
     python xegpu_kernel_bench.py -l 1 -b 1 --dump-kernel bufferized
@@ -73,7 +69,6 @@ from lighthouse.pipeline.helper import PipelineInterrupt
 from lighthouse.ingress.torch import gpu_backend, TargetDialect
 from lighthouse.ingress.torch.compile import TorchMemoryManager
 from tune_matmul_costmodel import optimize_payload
-from tune_utils import run_with_timeout
 from csv_logger import CSVLogger
 
 
@@ -246,15 +241,12 @@ def copy_module(module: ir.Module) -> ir.Module:
 
 
 def is_caused_by_pipeline_interrupt(exc: BaseException) -> bool:
-    """Return True if PipelineInterrupt appears anywhere in the exception chain."""
     pending = [exc]
     visited = set()
 
     while pending:
         current = pending.pop()
-        if current is None:
-            continue
-        if current in visited:
+        if current is None or current in visited:
             continue
         visited.add(current)
 
@@ -497,7 +489,6 @@ def lower_and_execute_benchmark(
     verify: bool = True,
     stop_at_stage: str | None = None,
     verbose: int = 0,
-    debug: bool = False,
     dump_parameters: bool = True,
 ) -> dict:
     """
@@ -514,7 +505,6 @@ def lower_and_execute_benchmark(
         verify: Whether to verify the result against PyTorch reference.
         stop_at_stage: Stage at which to stop the lowering pipeline.
         verbose: Verbosity level.
-        debug: Run without timeout and raise exceptions immediately.
         dump_parameters: Whether to save applied schedule parameters as JSON.
     Returns:
         A dictionary containing benchmark performance metrics.
@@ -582,8 +572,8 @@ def lower_and_execute_benchmark(
             gm, _ = dynamo.export(torch_model)(*torch_inputs)
             backend(gm, list(torch_inputs))
         except dynamo.exc.BackendCompilerFailed as e:
-            if debug and not is_caused_by_pipeline_interrupt(e):
-                raise e
+            if not is_caused_by_pipeline_interrupt(e):
+                raise
         return {}
 
     with warnings.catch_warnings():
@@ -689,18 +679,10 @@ def lower_and_execute_benchmark(
     return entry
 
 
-def run_experiment(use_timeout: bool = True, timeout: int = 1200, **kwargs) -> dict:
-    def ctx_wrapper(*args, **kwargs) -> dict:
-        with ir.Context() as ctx, ir.Location.unknown():
-            lh_dialects.register_and_load()
-            results = lower_and_execute_benchmark(*args, **kwargs, ctx=ctx)
-        return results
-
-    if use_timeout:
-        exec_func = partial(ctx_wrapper, **kwargs)
-        results = run_with_timeout(experiment_func=exec_func, timeout=timeout)
-    else:
-        results = ctx_wrapper(**kwargs)
+def run_experiment(**kwargs) -> dict:
+    with ir.Context() as ctx, ir.Location.unknown():
+        lh_dialects.register_and_load()
+        results = lower_and_execute_benchmark(**kwargs, ctx=ctx)
     return results
 
 
@@ -789,11 +771,6 @@ def parser_cli_args():
         help="Number of warmup runs (default: 500)",
     )
     parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="Run in single process and raise exceptions immediately.",
-    )
-    parser.add_argument(
         "--dump-parameters",
         action="store_true",
         help="Store used schedule parameters to disk in JSON format.",
@@ -856,8 +833,6 @@ if __name__ == "__main__":
                 nwarmup=args.nwarmup,
                 verbose=args.verbose,
                 stop_at_stage=stop_at_stage,
-                use_timeout=not args.debug,
-                debug=args.debug,
                 dump_parameters=args.dump_parameters,
             )
             if stop_at_stage:
@@ -874,10 +849,9 @@ if __name__ == "__main__":
             entry["executed"] = 1 if err_msg == "" else 0
             entry["error"] = err_msg
         except Exception as e:
-            if args.debug:
-                raise e
             print(f"Benchmark {short_path} failed with error: {e}", flush=True)
             entry["error"] = str(e)
+            raise e
 
         # Store intermediate results
         if csv_logger is not None:

--- a/examples/xegpu/kernel_bench.py
+++ b/examples/xegpu/kernel_bench.py
@@ -335,6 +335,7 @@ def infer_params_and_lower(
     payload_func_name: str = "main",
     stop_at_stage: str | None = None,
     params_cache_json: str | None = "kb_params.json",
+    dump_parameters: bool = True,
     enable_tuning: bool = True,
     verbose: int = 0,
 ) -> ir.Module:
@@ -356,6 +357,7 @@ def infer_params_and_lower(
         payload_func_name: Name of the payload function.
         stop_at_stage: Stage at which to stop the lowering pipeline.
         params_cache_json: Path to the JSON file for caching parameters.
+        dump_parameters: Whether to save the applied parameters as JSON.
         enable_tuning: Whether to enable runtime tuning.
         verbose: Verbosity level.
     Returns:
@@ -377,7 +379,6 @@ def infer_params_and_lower(
             print(f"Loading cached parameters from {params_cache_json}")
             schedule_params = ScheduleParameters.from_json(filename=params_cache_json)
         else:
-            print(f"Tuning parameters and saving to {params_cache_json}")
             # construct a buffer for kernel result
             res_type = kernel_metadata["inputs"][-1]  # result is last input
             shape = res_type.shape
@@ -395,11 +396,14 @@ def infer_params_and_lower(
                 func_metadata["write_bytes"],
             )
             schedule_params = ScheduleParameters([configs[0][1]])
-            schedule_params.to_json(filename=params_cache_json, overwrite=True)
+            if dump_parameters:
+                print(f"Saving tuned parameters to {params_cache_json}")
+                schedule_params.to_json(filename=params_cache_json, overwrite=True)
     else:
         print(f"Using default parameters for {schedule_kind} schedule")
-        print(f"Saving applied parameters to {params_cache_json}")
-        schedule_params.to_json(filename=params_cache_json, overwrite=True)
+        if dump_parameters:
+            print(f"Saving applied parameters to {params_cache_json}")
+            schedule_params.to_json(filename=params_cache_json, overwrite=True)
 
     if verbose > 2:
         print("Payload module before lowering:")
@@ -494,6 +498,7 @@ def lower_and_execute_benchmark(
     stop_at_stage: str | None = None,
     verbose: int = 0,
     debug: bool = False,
+    dump_parameters: bool = True,
 ) -> dict:
     """
     High-level function to lower and execute a KernelBench benchmark.
@@ -510,6 +515,7 @@ def lower_and_execute_benchmark(
         stop_at_stage: Stage at which to stop the lowering pipeline.
         verbose: Verbosity level.
         debug: Run without timeout and raise exceptions immediately.
+        dump_parameters: Whether to save applied schedule parameters as JSON.
     Returns:
         A dictionary containing benchmark performance metrics.
     """
@@ -556,6 +562,7 @@ def lower_and_execute_benchmark(
         payload_func_name="main",
         stop_at_stage=stop_at_stage,
         params_cache_json=f"kb_params_level{level}-{id}.json",
+        dump_parameters=dump_parameters,
         enable_tuning=execute,
         verbose=2,
     )
@@ -773,7 +780,7 @@ def parser_cli_args():
         "--nruns",
         type=int,
         default=500,
-        help="Number of runs for benchmarking (default: 1000)",
+        help="Number of runs for benchmarking (default: 500)",
     )
     parser.add_argument(
         "--nwarmup",
@@ -785,6 +792,16 @@ def parser_cli_args():
         "--debug",
         action="store_true",
         help="Run in single process and raise exceptions immediately.",
+    )
+    parser.add_argument(
+        "--dump-parameters",
+        action="store_true",
+        help="Store used schedule parameters to disk in JSON format.",
+    )
+    parser.add_argument(
+        "--dump-csv",
+        action="store_true",
+        help="Dump the benchmarking results to a CSV file.",
     )
     parser.add_argument(
         "--verbose",
@@ -805,7 +822,7 @@ if __name__ == "__main__":
     kb_pattern = f"level{kb_level}/*.py"
     bench_list = get_benchmarks(kb_pattern, include=benchmarks)
 
-    if not stop_at_stage:
+    if args.dump_csv and not stop_at_stage:
         csv_file = "out_kernelbench.csv"
         csv_logger = CSVLogger(csv_file, echo_stdout=False, verbose=True)
     else:
@@ -841,6 +858,7 @@ if __name__ == "__main__":
                 stop_at_stage=stop_at_stage,
                 use_timeout=not args.debug,
                 debug=args.debug,
+                dump_parameters=args.dump_parameters,
             )
             if stop_at_stage:
                 continue

--- a/examples/xegpu/torch_matmul.py
+++ b/examples/xegpu/torch_matmul.py
@@ -16,7 +16,7 @@ from mlir.dialects.transform import structured
 
 from lighthouse import dialects as lh_dialects
 from lighthouse import schedule as lh_schedule
-from lighthouse.schedule.parameters import ScheduleParams
+from lighthouse.schedule.parameters import ScheduleParameters
 from lighthouse.pipeline.driver import TransformDriver
 from lighthouse.utils.mlir import get_mlir_library_path
 from lighthouse.execution.runner import Runner
@@ -49,7 +49,7 @@ def shared_libs() -> list[str]:
 
 
 def schedule_modules(
-    parameters: ScheduleParams | None = None,
+    parameters: ScheduleParameters | None = None,
     device: str | None = None,
     benchmark: bool = False,
     entry_func: str = "main",
@@ -82,7 +82,7 @@ def schedule_modules(
 
 def lower_to_llvm(
     module: ir.Module,
-    parameters: ScheduleParams | None = None,
+    parameters: ScheduleParameters | None = None,
     device: str | None = None,
     benchmark: bool = False,
     entry_func: str = "main",
@@ -216,7 +216,7 @@ enabled via CLI arguments.
     # Problem size
     m, n, k = args.sizes if args.sizes else (4096, 4096, 4096)
     # Set required parameters
-    params = ScheduleParams(
+    params = ScheduleParameters(
         [
             {
                 "layer_kind": "matmul",


### PR DESCRIPTION
- Adds `--dump-parameters` and `--dump-csv` options to `kernel_bench.py`. By default nothing is store to disk, useful for CI.
- Removes kernel execution in a child python process from `kernel_bench.py`. The script cannot recover from a compiler/runtime failure.
- Fixes `torch_matmul.py` example
