### PR TITLE
[transform] Target-aware register reduction dim tiling strategy

### DIFF
--- a/lighthouse/dialects/transform/transform_ext/utils/tiling/registry.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/tiling/registry.py
@@ -1,12 +1,14 @@
 from .strategy_base import TilingStrategy
 from .strategy_cache import CacheTilingStrategy
 from .strategy_register_parallel import RegisterParallelTilingStrategy
+from .strategy_register_reduction import RegisterReductionTilingStrategy
 
 
 # Maps each canonical strategy name to its implementation class.
 _STRATEGY_REGISTRY: dict[str, type[TilingStrategy]] = {
     "cache": CacheTilingStrategy,
     "register_parallel": RegisterParallelTilingStrategy,
+    "register_reduction": RegisterReductionTilingStrategy,
 }
 
 

--- a/lighthouse/dialects/transform/transform_ext/utils/tiling/strategy_register_reduction.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/tiling/strategy_register_reduction.py
@@ -1,0 +1,41 @@
+from mlir import ir
+
+from lighthouse.utils.mlir import opview
+
+from .strategy_base import StrategyContext, TilingStrategy
+from .common import (
+    assign_reduction_tiles,
+    parallel_and_reduction_dims,
+)
+from .target_caps import (
+    generic_reduction_tiles,
+    is_amx_bf16_contraction,
+    is_f32_contraction,
+)
+
+
+class RegisterReductionTilingStrategy(TilingStrategy):
+    """Register-level tiling of reduction dimensions; target-derived defaults."""
+
+    def compute(
+        self, op: ir.Operation | ir.OpView, ctx: StrategyContext
+    ) -> list[int] | None:
+        out_map = self.output_map(op)
+        if out_map is None:
+            return None
+
+        sizes = [0] * out_map.n_dims
+        _, reduction_dims = parallel_and_reduction_dims(out_map)
+        if not reduction_dims:
+            return None
+
+        ov = opview(op)
+        if is_amx_bf16_contraction(ov, ctx.target):
+            red_tiles = [32]
+        elif is_f32_contraction(ov):
+            red_tiles = [2]
+        else:
+            red_tiles = generic_reduction_tiles()
+
+        assign_reduction_tiles(reduction_dims, red_tiles, sizes)
+        return sizes

--- a/lighthouse/dialects/transform/transform_ext/utils/tiling/target_caps.py
+++ b/lighthouse/dialects/transform/transform_ext/utils/tiling/target_caps.py
@@ -72,3 +72,8 @@ def generic_parallel_tiles(
     out_elem = ir.ShapedType(linalg_outputs(op)[0].type).element_type
     inner = _vector_lane_count(target, out_elem)
     return [inner] if len(parallel_dims) == 1 else [1, inner]
+
+
+def generic_reduction_tiles() -> list[int]:
+    """Default reduction tile for ops without a microkernel profile."""
+    return [1]

--- a/test/transform/test_assign_tile_sizes.py
+++ b/test/transform/test_assign_tile_sizes.py
@@ -71,6 +71,11 @@ def run(
 # CHECK-SAME: transform_ext.tile_sizes = array<i64: 8, 32, 0>
 run("strategy_attr_register_parallel", PAYLOAD, "linalg.matmul", "register_parallel")
 
+# CHECK-LABEL: Test: strategy_attr_register_reduction
+# CHECK: linalg.matmul
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 0, 0, 2>
+run("strategy_attr_register_reduction", PAYLOAD, "linalg.matmul", "register_reduction")
+
 # CHECK-LABEL: Test: strategy_attr_cache
 # CHECK: linalg.matmul
 # CHECK-SAME: transform_ext.tile_sizes = array<i64: 32, 32, 0>

--- a/test/transform/test_tile_and_fuse_register_tiling.py
+++ b/test/transform/test_tile_and_fuse_register_tiling.py
@@ -39,8 +39,20 @@ def assign_register_parallel():
     )
 
 
+def assign_register_reduction():
+    return tf.assign_and_propagate_tile_sizes(
+        tile_size=32,
+        strategy="register_reduction",
+        propagate=False,
+    )
+
+
 def tile_and_fuse_keep():
     return tf.tile_and_fuse_annotated(clear_annotations=False)
+
+
+def tile_reduction_batch_only():
+    return tf.tile_annotated(target_op="linalg.batch_matmul", clear_annotations=False)
 
 
 MLP = """
@@ -110,6 +122,20 @@ module {
 """
 
 
+BMM = """
+module {
+  func.func @main(%a: tensor<8x64x96xf32>, %b: tensor<8x96x128xf32>) -> tensor<8x64x128xf32> {
+    %cst = arith.constant 0.0 : f32
+    %0 = tensor.empty() : tensor<8x64x128xf32>
+    %1 = linalg.fill ins(%cst: f32) outs(%0: tensor<8x64x128xf32>) -> tensor<8x64x128xf32>
+    %2 = linalg.batch_matmul ins(%a, %b : tensor<8x64x96xf32>, tensor<8x96x128xf32>)
+        outs(%1 : tensor<8x64x128xf32>) -> tensor<8x64x128xf32>
+    return %2 : tensor<8x64x128xf32>
+  }
+}
+"""
+
+
 # CHECK-LABEL: Test: register_parallel_tile_and_fuse
 # CHECK: linalg.matmul {transform_ext.tile_sizes = array<i64: 8, 32, 0>}
 # CHECK: linalg.generic
@@ -144,4 +170,17 @@ run_with_target_override(
     MLP,
     features=["amx_tile"],
     schedules=(assign_register_parallel, tile_and_fuse_keep),
+)
+
+
+# Reduction tiling annotates only the K dim, so tiling yields a sequential scf.for
+# over K with the GEMM intact inside; the parallel dims stay untiled.
+# CHECK-LABEL: Test: register_reduction_tile_only
+# CHECK: scf.for
+# CHECK: linalg.batch_matmul {transform_ext.tile_sizes = array<i64: 0, 0, 0, 2>}
+run(
+    "register_reduction_tile_only",
+    BMM,
+    assign_register_reduction,
+    tile_reduction_batch_only,
 )

--- a/test/transform/test_tile_size_ops.py
+++ b/test/transform/test_tile_size_ops.py
@@ -208,3 +208,17 @@ run(
         strategy="register_parallel",
     ),
 )
+
+
+# Register-reduction strategy: only the reduction K dim is tiled.
+# CHECK-LABEL: Test: register_reduction_strategy
+# CHECK: linalg.batch_matmul
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 0, 0, 0, 2>
+run(
+    "register_reduction_strategy",
+    BATCH_MATMUL_PAYLOAD,
+    lambda: build_assign_schedule(
+        "linalg.batch_matmul",
+        strategy="register_reduction",
+    ),
+)

--- a/test/transform/test_tiling_strategy_register_reduction.py
+++ b/test/transform/test_tiling_strategy_register_reduction.py
@@ -1,0 +1,131 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from mlir import ir
+from mlir.dialects import transform
+
+import lighthouse.dialects as lh_dialects
+from lighthouse import transform as lh_transform
+from lighthouse.dialects.transform.transform_ext import assign_tile_sizes
+from lighthouse.schedule.builders import schedule_boilerplate
+
+
+def run(name: str, payload_str: str, build_schedule):
+    print(f"Test: {name}", flush=True)
+    with ir.Context(), ir.Location.unknown():
+        lh_dialects.register_and_load()
+        payload = ir.Module.parse(payload_str)
+        sched = build_schedule()
+        sched.body.operations[0].apply(payload.operation)
+        print(payload)
+
+
+PAYLOAD = """
+module {
+  func.func @main(%a: tensor<4x64x64xf32>, %b: tensor<4x64x64xf32>) -> tensor<4x64x64xf32> {
+    %cst = arith.constant 0.0 : f32
+    %e = tensor.empty() : tensor<4x64x64xf32>
+    %f = linalg.fill ins(%cst : f32) outs(%e : tensor<4x64x64xf32>) -> tensor<4x64x64xf32>
+    %mm = linalg.batch_matmul ins(%a, %b : tensor<4x64x64xf32>, tensor<4x64x64xf32>)
+        outs(%f : tensor<4x64x64xf32>) -> tensor<4x64x64xf32>
+    return %mm : tensor<4x64x64xf32>
+  }
+}
+"""
+
+
+# A contraction with two reduction dims (k0, k1): only the innermost one gets the
+# strategy tile, the outer reduction dim is unit-tiled.
+MULTI_REDUCTION = """
+#mA = affine_map<(m, n, k0, k1) -> (m, k0, k1)>
+#mB = affine_map<(m, n, k0, k1) -> (k0, k1, n)>
+#mC = affine_map<(m, n, k0, k1) -> (m, n)>
+module {
+  func.func @main(%a: tensor<64x32x16xf32>, %b: tensor<32x16x128xf32>,
+        %o: tensor<64x128xf32>) -> tensor<64x128xf32> {
+    %c = linalg.contract indexing_maps = [#mA, #mB, #mC]
+        ins(%a, %b : tensor<64x32x16xf32>, tensor<32x16x128xf32>)
+        outs(%o : tensor<64x128xf32>) -> tensor<64x128xf32>
+    return %c : tensor<64x128xf32>
+  }
+}
+"""
+
+
+# A non-contraction reduction: falls back to the generic reduction tile.
+GENERIC_REDUCE = """
+#id = affine_map<(d0, d1) -> (d0, d1)>
+#out = affine_map<(d0, d1) -> (d0)>
+module {
+  func.func @main(%a: tensor<64x256xf32>, %o: tensor<64xf32>) -> tensor<64xf32> {
+    %r = linalg.generic {indexing_maps = [#id, #out],
+        iterator_types = ["parallel", "reduction"]}
+        ins(%a : tensor<64x256xf32>) outs(%o : tensor<64xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %s = arith.addf %in, %out : f32
+      linalg.yield %s : f32
+    } -> tensor<64xf32>
+    return %r : tensor<64xf32>
+  }
+}
+"""
+
+
+# A fully parallel op: the strategy has nothing to tile.
+ELTWISE = """
+module {
+  func.func @main(%a: tensor<64x64xf32>, %b: tensor<64x64xf32>) -> tensor<64x64xf32> {
+    %s = linalg.add ins(%a, %b : tensor<64x64xf32>, tensor<64x64xf32>)
+        outs(%a : tensor<64x64xf32>) -> tensor<64x64xf32>
+    return %s : tensor<64x64xf32>
+  }
+}
+"""
+
+
+def build_schedule(op_name: str = "linalg.batch_matmul"):
+    with schedule_boilerplate() as (sched, named_seq):
+        ops = lh_transform.match_op(named_seq.bodyTarget, op_name)
+        assign_tile_sizes(
+            ops,
+            strategy="register_reduction",
+        )
+        transform.yield_()
+    return sched
+
+
+# Parallel dims (batch, M, N) stay untiled; only the K dim gets the f32 tile.
+# CHECK-LABEL: Test: register_reduction_strategy
+# CHECK: linalg.batch_matmul
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 0, 0, 0, 2>
+run("register_reduction_strategy", PAYLOAD, build_schedule)
+
+
+# CHECK-LABEL: Test: register_reduction_multiple_reduction_dims
+# CHECK: linalg.contract
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 0, 0, 1, 2>
+run(
+    "register_reduction_multiple_reduction_dims",
+    MULTI_REDUCTION,
+    lambda: build_schedule("linalg.contract"),
+)
+
+
+# CHECK-LABEL: Test: register_reduction_generic_reduce
+# CHECK: linalg.generic
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 0, 1>
+run(
+    "register_reduction_generic_reduce",
+    GENERIC_REDUCE,
+    lambda: build_schedule("linalg.generic"),
+)
+
+
+# No reduction dim: the op must be left unannotated.
+# CHECK-LABEL: Test: register_reduction_no_reduction_dims
+# CHECK: linalg.add
+# CHECK-NOT: transform_ext.tile_sizes
+run(
+    "register_reduction_no_reduction_dims",
+    ELTWISE,
+    lambda: build_schedule("linalg.add"),
+)

--- a/test/transform/test_tiling_strategy_target_aware.py
+++ b/test/transform/test_tiling_strategy_target_aware.py
@@ -72,6 +72,17 @@ def build_register_parallel():
     return sched
 
 
+def build_register_reduction():
+    with schedule_boilerplate() as (sched, named_seq):
+        ops = lh_transform.match_op(named_seq.bodyTarget, "linalg.matmul")
+        assign_tile_sizes(
+            ops,
+            strategy="register_reduction",
+        )
+        transform.yield_()
+    return sched
+
+
 # CHECK-LABEL: Test: f32_register_parallel_default
 # CHECK: linalg.matmul
 # CHECK-SAME: transform_ext.tile_sizes = array<i64: 8, 32, 0>
@@ -157,4 +168,46 @@ with TargetInfo.override(features=[]):
         "eltwise_register_parallel_no_features",
         ELTWISE,
         lambda: build_register_parallel_eltwise(),
+    )
+
+
+# CHECK-LABEL: Test: f32_register_reduction_default
+# CHECK: linalg.matmul
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 0, 0, 2>
+run("f32_register_reduction_default", F32_MATMUL, lambda: build_register_reduction())
+
+
+# CHECK-LABEL: Test: bf16_amx_register_reduction_default
+# CHECK: linalg.matmul
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 0, 0, 32>
+with TargetInfo.override(features=["amx_tile"]):
+    run(
+        "bf16_amx_register_reduction_default",
+        BF16_MATMUL,
+        lambda: build_register_reduction(),
+    )
+
+
+# Without AMX, bf16 matmul is not an all-f32 contraction either, so it falls back
+# to the generic reduction tile.
+# CHECK-LABEL: Test: bf16_no_amx_register_reduction_generic_fallback
+# CHECK: linalg.matmul
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 0, 0, 1>
+with TargetInfo.override(features=[]):
+    run(
+        "bf16_no_amx_register_reduction_generic_fallback",
+        BF16_MATMUL,
+        lambda: build_register_reduction(),
+    )
+
+
+# An AMX-capable target must not change f32 GEMM reduction tiling.
+# CHECK-LABEL: Test: f32_register_reduction_under_amx_target
+# CHECK: linalg.matmul
+# CHECK-SAME: transform_ext.tile_sizes = array<i64: 0, 0, 2>
+with TargetInfo.override(features=["amx_tile"]):
+    run(
+        "f32_register_reduction_under_amx_target",
+        F32_MATMUL,
+        lambda: build_register_reduction(),
     )


### PR DESCRIPTION
Adds register-level reduction strategy that derives tile sizes based on operations and target.

A separate register-level strategy that focuses on reduction dims. As previously, the current implementation mimics existings pipeline descriptors and is another step toward reshaping operations into register-friendly sizes.

Assisted-by: Claude